### PR TITLE
fix: 모바일 환경에서 가족 선택 페이지로 잘못 리다이렉트되는 문제 수정

### DIFF
--- a/src/app/(authenticated)/page.tsx
+++ b/src/app/(authenticated)/page.tsx
@@ -12,8 +12,12 @@
  */
 
 import { getUserProfileAction } from "@/app/actions/user/get-user-profile-action";
-import { setSelectedFamilyUuid } from "@/lib/server/cookies";
+import {
+  setSelectedFamilyUuid,
+  getSelectedFamilyUuid,
+} from "@/lib/server/cookies";
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 
 // 쿠키를 사용하므로 동적 렌더링 필요
 export const dynamic = "force-dynamic";
@@ -22,9 +26,31 @@ export default async function HomePage() {
   // 1. 사용자 프로필 조회 (기본 가족 확인)
   const profileResult = await getUserProfileAction();
 
+  // 디버깅: 프로필 조회 결과 확인
+  if (!profileResult.success) {
+    console.error("프로필 조회 실패:", profileResult);
+  }
+
   if (profileResult.success && profileResult.data.defaultFamilyUuid) {
     // 🎯 기본 가족 있음 → 쿠키 설정하고 대시보드로
-    await setSelectedFamilyUuid(profileResult.data.defaultFamilyUuid);
+    const defaultFamilyUuid = profileResult.data.defaultFamilyUuid;
+
+    // 쿠키 설정
+    await setSelectedFamilyUuid(defaultFamilyUuid);
+
+    // 쿠키 설정 확인 (모바일 환경에서 쿠키 설정이 실패할 수 있음)
+    const savedFamilyUuid = await getSelectedFamilyUuid();
+    if (savedFamilyUuid !== defaultFamilyUuid) {
+      // 쿠키 설정 실패 시 다시 시도
+      console.warn(
+        `쿠키 설정 실패. 예상: ${defaultFamilyUuid}, 실제: ${savedFamilyUuid}`
+      );
+      await setSelectedFamilyUuid(defaultFamilyUuid);
+    }
+
+    // 쿠키 설정 후 캐시 재검증 (리다이렉트 전에 완료 보장)
+    revalidatePath("/", "layout");
+
     redirect("/dashboard");
   }
 


### PR DESCRIPTION
## 문제
모바일 환경에서 가족이 있는데도 항상 가족 선택 페이지로 리다이렉트되는 문제가 발생했습니다.

## 원인
- 쿠키 설정이 완료되기 전에 redirect가 실행되어 쿠키가 제대로 설정되지 않음
- 모바일 환경에서 쿠키 설정이 실패할 수 있는 경우 대비 부족

## 해결 방법
- 쿠키 설정 후 `revalidatePath` 추가하여 리다이렉트 전 완료 보장
- 쿠키 설정 확인 로직 추가 (모바일 환경 대비)
- 프로필 조회 실패 시 디버깅 로그 추가

## 변경 사항
- `src/app/(authenticated)/page.tsx`: 쿠키 설정 후 재검증 및 확인 로직 추가