### PR TITLE
fix: 읽지 않은 알림 수 응답 타입 수정

### DIFF
--- a/src/app/actions/notification/get-unread-count-action.ts
+++ b/src/app/actions/notification/get-unread-count-action.ts
@@ -5,6 +5,7 @@ import { requireAuth } from "@/lib/server/auth-helpers";
 import type { ApiResponse } from "@/lib/server/api/types";
 import type { ActionResult } from "@/lib/errors";
 import { ErrorCode } from "@/lib/errors/error-code";
+import type { UnreadCountResponse } from "@/types/actions/notification";
 
 /**
  * 가족의 읽지 않은 알림 수를 조회합니다.
@@ -17,16 +18,18 @@ export async function getUnreadCountAction(
     await requireAuth();
 
     // 백엔드 API 호출
-    const response = await serverApiClient<ApiResponse<number>>(
+    // 백엔드는 { unreadCount: number } 형태로 반환
+    const response = await serverApiClient<ApiResponse<UnreadCountResponse>>(
       `/families/${familyUuid}/notifications/unread-count`,
       {
         method: "GET",
       }
     );
 
+    // response.data는 { unreadCount: number } 형태
     return {
       success: true,
-      data: response.data ?? 0,
+      data: response.data?.unreadCount ?? 0,
     };
   } catch (error) {
     console.error("[getUnreadCountAction] Error:", error);


### PR DESCRIPTION
## 문제

백엔드 API가 `{ unreadCount: number }` 형태로 반환하는데, 프론트엔드 코드에서는 `number`로 직접 처리하고 있었습니다.

터미널 출력:
```
response {
  success: true,
  data: { unreadCount: 1 },
  timestamp: '2025-11-13T21:40:32.429524'
}
```

## 원인

- `ApiResponse<number>`로 타입을 지정했지만, 실제 응답은 `ApiResponse<{ unreadCount: number }>` 형태
- `response.data`로 직접 접근하려 했지만, 실제로는 `response.data.unreadCount`로 접근해야 함

## 해결 방법

- `UnreadCountResponse` 타입 import 추가
- `ApiResponse<number>` → `ApiResponse<UnreadCountResponse>`로 타입 변경
- `response.data ?? 0` → `response.data?.unreadCount ?? 0`로 수정

## 변경사항

- `src/app/actions/notification/get-unread-count-action.ts`: 응답 타입 및 데이터 접근 방식 수정

## 테스트

- [x] 타입 체크 통과
- [x] 응답 구조 확인