### PR TITLE
feat(auth) session 콜백에서 profile 호출하지 않도록 변경

### DIFF
--- a/src/__tests__/components/settings/SettingsPageClient.test.tsx
+++ b/src/__tests__/components/settings/SettingsPageClient.test.tsx
@@ -19,6 +19,12 @@ jest.mock("@/app/actions/user/set-default-family-action", () => ({
 jest.mock("@/app/actions/family/update-family-action", () => ({
   updateFamilyAction: jest.fn(),
 }));
+// useSessionRefresh 훅 모킹
+jest.mock("@/lib/client/use-session-refresh", () => ({
+  useSessionRefresh: () => ({
+    refreshSession: jest.fn().mockResolvedValue(undefined),
+  }),
+}));
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(() => ({
@@ -33,12 +39,12 @@ jest.mock("sonner", () => ({
   },
 }));
 
-import { render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { SettingsPageClient } from "@/app/(authenticated)/settings/_components/SettingsPageClient";
-import { setDefaultFamilyAction } from "@/app/actions/user/set-default-family-action";
 import { updateFamilyAction } from "@/app/actions/family/update-family-action";
+import { setDefaultFamilyAction } from "@/app/actions/user/set-default-family-action";
 import type { Family } from "@/types/family";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const mockSetDefaultFamilyAction =
   setDefaultFamilyAction as jest.MockedFunction<typeof setDefaultFamilyAction>;

--- a/src/app/(authenticated)/families/create/page.tsx
+++ b/src/app/(authenticated)/families/create/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createFamilyAction } from "@/app/actions/family/create-family-action";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -10,7 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { createFamilyAction } from "@/app/actions/family/create-family-action";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -20,6 +21,7 @@ export default function CreateFamilyPage() {
   const [familyType, setFamilyType] = useState<"personal" | "family">("family");
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -39,6 +41,8 @@ export default function CreateFamilyPage() {
       });
 
       if (result.success) {
+        // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
+        await refreshSession();
         toast.success("가족이 성공적으로 생성되었습니다!");
         // 백엔드에서 첫 가족 생성 시 자동으로 defaultFamilyUuid 설정됨
         // 대시보드로 바로 이동 (홈에서 리다이렉트 처리)

--- a/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
+++ b/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { setDefaultFamilyAction } from "@/app/actions/user/set-default-family-action";
 import { updateFamilyAction } from "@/app/actions/family/update-family-action";
+import { setDefaultFamilyAction } from "@/app/actions/user/set-default-family-action";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
-import { Check, Users, DollarSign, Edit2, Save, X } from "lucide-react";
+import { Check, DollarSign, Edit2, Save, Users, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -23,6 +24,7 @@ export function SettingsPageClient({
   defaultFamilyUuid,
 }: SettingsPageClientProps) {
   const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
   const [selectedFamily, setSelectedFamily] = useState<string>("");
   const [currentDefaultFamily, setCurrentDefaultFamily] = useState<string>(
     defaultFamilyUuid || ""
@@ -43,6 +45,8 @@ export function SettingsPageClient({
 
       if (result.success) {
         setCurrentDefaultFamily(selectedFamily);
+        // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
+        await refreshSession();
         toast.success("기본 가족이 설정되었습니다");
         router.refresh();
       } else {

--- a/src/app/actions/family/create-family-action.ts
+++ b/src/app/actions/family/create-family-action.ts
@@ -1,5 +1,8 @@
 /**
  * 가족 생성 Server Action
+ *
+ * ⚠️ 주의: 이 액션 호출 후 클라이언트에서 세션 갱신이 필요합니다.
+ * useSessionRefresh 훅의 refreshSession()을 호출하세요.
  */
 
 "use server";
@@ -12,9 +15,8 @@ import {
 } from "@/lib/errors";
 import { serverApiClient } from "@/lib/server/api/client";
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { setDefaultFamilyAction } from "../user/set-default-family-action";
 import type { CreateFamilyData, CreateFamilyResult } from "@/types/family";
-import { revalidatePath } from "next/cache";
+import { setDefaultFamilyAction } from "../user/set-default-family-action";
 
 export async function createFamilyAction(
   data: CreateFamilyData
@@ -42,11 +44,6 @@ export async function createFamilyAction(
     // 백엔드에서 첫 가족 생성 시 자동으로 defaultFamilyUuid 설정됨
     // 프론트엔드에서도 명시적으로 설정 (중복 호출이지만 안전장치)
     await setDefaultFamilyAction(result.data.uuid);
-
-    // 세션 업데이트를 위해 관련 경로 revalidate
-    // session callback에서 프로필을 다시 조회하도록 함
-    revalidatePath("/");
-    revalidatePath("/dashboard");
 
     return successResult(result.data);
   } catch (error) {

--- a/src/app/actions/family/select-family-action.ts
+++ b/src/app/actions/family/select-family-action.ts
@@ -1,6 +1,9 @@
 /**
  * 선택된 가족 설정 Server Action
- * 프로필의 defaultFamilyUuid를 업데이트하고 페이지를 새로고침
+ * 프로필의 defaultFamilyUuid를 업데이트
+ *
+ * ⚠️ 주의: 이 액션 호출 후 클라이언트에서 세션 갱신이 필요합니다.
+ * useSessionRefresh 훅의 refreshSession()을 호출하세요.
  */
 
 "use server";
@@ -12,9 +15,8 @@ import {
   type ActionResult,
 } from "@/lib/errors";
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { getFamiliesAction } from "./get-families-action";
 import { setDefaultFamilyAction } from "../user/set-default-family-action";
-import { revalidatePath } from "next/cache";
+import { getFamiliesAction } from "./get-families-action";
 
 export async function selectFamilyAction(
   familyUuid: string
@@ -48,9 +50,6 @@ export async function selectFamilyAction(
     if (!result.success) {
       throw ActionError.internalError("기본 가족 설정에 실패했습니다");
     }
-
-    // 모든 페이지 재검증
-    revalidatePath("/", "layout");
 
     return successResult(undefined);
   } catch (error) {

--- a/src/app/actions/user/set-default-family-action.ts
+++ b/src/app/actions/user/set-default-family-action.ts
@@ -5,13 +5,28 @@ import {
   successResult,
   type ActionResult,
 } from "@/lib/errors";
+import { auth } from "@/lib/server";
 import { serverApiClient } from "@/lib/server/api/client";
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { revalidatePath } from "next/cache";
 
 /**
  * 기본 가족 설정 Server Action
  * UserProfile의 defaultFamilyUuid를 업데이트
+ *
+ * ⚠️ 주의: 이 액션 호출 후 클라이언트에서 세션 갱신이 필요합니다.
+ * useSessionRefresh 훅의 refreshSession()을 호출하세요.
+ *
+ * @example
+ * ```tsx
+ * const { refreshSession } = useSessionRefresh();
+ *
+ * const handleSetDefaultFamily = async (familyUuid: string) => {
+ *   const result = await setDefaultFamilyAction(familyUuid);
+ *   if (result.success) {
+ *     await refreshSession(); // 세션 갱신
+ *   }
+ * };
+ * ```
  */
 export async function setDefaultFamilyAction(
   familyUuid: string
@@ -25,9 +40,6 @@ export async function setDefaultFamilyAction(
       method: "PUT",
       body: JSON.stringify({ defaultFamilyUuid: familyUuid }),
     });
-
-    // 3. Next.js 캐시 무효화 - 모든 페이지 재검증 (세션도 재조회됨)
-    revalidatePath("/", "layout");
 
     return successResult(undefined);
   } catch (error) {

--- a/src/components/families/FamilySelector.tsx
+++ b/src/components/families/FamilySelector.tsx
@@ -7,6 +7,7 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { ChevronRight, Plus, User, Users } from "lucide-react";
 import Image from "next/image";
@@ -25,6 +26,7 @@ export function FamilySelector({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const autoSelectedRef = useRef(false);
+  const { refreshSession } = useSessionRefresh();
 
   useEffect(() => {
     initializeSelector();
@@ -86,7 +88,11 @@ export function FamilySelector({
 
   const handleFamilySelect = async (family: Family) => {
     // 선택한 가족을 기본 가족으로 저장
-    await setDefaultFamilyAction(family.uuid);
+    const result = await setDefaultFamilyAction(family.uuid);
+    if (result.success) {
+      // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
+      await refreshSession();
+    }
     onFamilySelect(family);
   };
 

--- a/src/components/families/FamilySelectorDropdown.tsx
+++ b/src/components/families/FamilySelectorDropdown.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { Users } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -17,6 +18,7 @@ import { useEffect, useState } from "react";
 
 export function FamilySelectorDropdown() {
   const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
   const [families, setFamilies] = useState<Family[]>([]);
   const [selectedFamily, setSelectedFamily] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -47,7 +49,10 @@ export function FamilySelectorDropdown() {
           setSelectedFamily(firstFamilyUuid);
 
           // 쿠키에도 저장 (특히 가족이 1개일 때 중요)
-          await selectFamilyAction(firstFamilyUuid);
+          const result = await selectFamilyAction(firstFamilyUuid);
+          if (result.success) {
+            await refreshSession();
+          }
         }
       }
     } catch (err) {
@@ -69,6 +74,8 @@ export function FamilySelectorDropdown() {
     const result = await selectFamilyAction(familyUuid);
 
     if (result.success) {
+      // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
+      await refreshSession();
       // 페이지 새로고침하여 선택된 가족의 데이터 표시
       router.refresh();
     } else {

--- a/src/components/families/FamilySelectorPage.tsx
+++ b/src/components/families/FamilySelectorPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { setDefaultFamilyAction } from "@/app/actions/user/set-default-family-action";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { useRouter } from "next/navigation";
 import { FamilySelector } from "./FamilySelector";
@@ -15,12 +16,15 @@ interface FamilySelectorPageProps {
  */
 export function FamilySelectorPage({ families }: FamilySelectorPageProps) {
   const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
 
   const handleFamilySelect = async (family: Family) => {
     // 선택한 가족을 기본 가족으로 설정
     const result = await setDefaultFamilyAction(family.uuid);
 
     if (result.success) {
+      // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
+      await refreshSession();
       // 기본 가족 설정 완료 → 대시보드로 이동
       router.push("/dashboard");
     }

--- a/src/lib/client/use-session-refresh.ts
+++ b/src/lib/client/use-session-refresh.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useCallback } from "react";
+
+/**
+ * 세션 갱신 훅
+ *
+ * 프로필 변경 후 세션을 갱신해야 할 때 사용합니다.
+ * NextAuth의 update()를 호출하면 jwt callback(trigger="update")이 실행되어
+ * 백엔드에서 최신 프로필을 다시 조회합니다.
+ *
+ * @example
+ * ```tsx
+ * const { refreshSession } = useSessionRefresh();
+ *
+ * const handleUpdateProfile = async () => {
+ *   await updateProfileAction(...);
+ *   await refreshSession(); // 세션 갱신
+ * };
+ * ```
+ */
+export function useSessionRefresh() {
+  const { update } = useSession();
+
+  const refreshSession = useCallback(async () => {
+    // update()를 호출하면 jwt callback(trigger="update")이 실행됨
+    await update();
+  }, [update]);
+
+  return { refreshSession };
+}

--- a/src/lib/server/auth/profile-fetcher.ts
+++ b/src/lib/server/auth/profile-fetcher.ts
@@ -1,0 +1,17 @@
+import { UserProfile } from "@/types";
+import { serverApiGet } from "../api";
+
+/**
+ * 사용자 프로필을 백엔드에서 조회합니다.
+ * jwt callback에서 사용되며, 실패 시 null을 반환합니다.
+ *
+ * @returns UserProfile | null
+ */
+export async function fetchUserProfile(): Promise<UserProfile | null> {
+  try {
+    return await serverApiGet<UserProfile>("/users/me/profile");
+  } catch (error) {
+    console.error("[fetchUserProfile] 프로필 조회 실패:", error);
+    return null;
+  }
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -31,5 +31,7 @@ declare module "next-auth/jwt" {
     backendRefreshToken: string;
     backendTokenExpiredAt: string;
     backendTokenIssuedAt: string;
+    /** 사용자 프로필 정보 (jwt callback에서 캐싱) */
+    profile: UserProfile | null;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,15 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
-    "types": [
-      "node",
-      "jest",
-      "@testing-library/jest-dom"
-    ]
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": [
     "next-env.d.ts",
@@ -40,7 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## session 콜백에서 profile 호출하지 않도록 변경

- 매 `auth()` 호출마다 `session()` 콜백이 호출 됨
- 따라서 `jwt()` 생성 시, 첫 profile 호출 후, update 메소드가 트리거 되면, 프로필 정보를 갱신할 수 있도록 개선