### PR TITLE
fix: 프로덕션 console.log/error 제거

### DIFF
--- a/src/app/actions/dashboard/get-monthly-daily-stats-action.ts
+++ b/src/app/actions/dashboard/get-monthly-daily-stats-action.ts
@@ -40,9 +40,6 @@ export async function getMonthlyDailyStatsAction(year: number, month: number) {
     const endDate = `${year}-${String(month).padStart(2, "0")}-${lastDay}`;
 
     // 병렬로 데이터 조회 (최대 1000개로 가정)
-    console.log(
-      `[Calendar] Fetching stats for family ${familyUuid} from ${startDate} to ${endDate}`,
-    );
     const [expensesResult, incomesResult] = await Promise.all([
       serverApiGet<{ items: ExpenseResponse[] }>(
         `/families/${familyUuid}/expenses?size=1000&startDate=${startDate}&endDate=${endDate}`,
@@ -57,8 +54,6 @@ export async function getMonthlyDailyStatsAction(year: number, month: number) {
         return { items: [] as IncomeResponse[] };
       }),
     ]);
-    console.log(`[Calendar] Expenses count: ${expensesResult?.items?.length}`);
-    console.log(`[Calendar] Incomes count: ${incomesResult?.items?.length}`);
 
     // 일별 집계
     const dailyMap = new Map<string, { income: number; expense: number }>();

--- a/src/components/incomes/dialogs/AddIncomeDialog.tsx
+++ b/src/components/incomes/dialogs/AddIncomeDialog.tsx
@@ -62,11 +62,9 @@ export function AddIncomeDialog({ open, onOpenChange }: AddIncomeDialogProps) {
           setFamilyUuid(result.data[0].familyUuid);
         }
       } else {
-        console.error("Failed to load categories:", result.error);
         toast.error(result.error.message);
       }
-    } catch (error) {
-      console.error("Failed to load categories:", error);
+    } catch {
       toast.error("카테고리를 불러오는데 실패했습니다");
     } finally {
       setIsLoadingCategories(false);


### PR DESCRIPTION
## Summary

- `get-monthly-daily-stats-action`: 디버그용 `console.log` 3개 제거 (closes #115)
- `AddIncomeDialog`: 중복 `console.error` 제거 — `toast`로 사용자 피드백이 이미 처리됨 (closes #122)

## Test plan

- [ ] 분석 페이지에서 월 이동 시 정상 동작 확인
- [ ] 수입 추가 다이얼로그에서 카테고리 로드 실패 시 toast 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)