### PR TITLE
feat(layout): 라우트별 loading.tsx 및 전역 error.tsx 추가

### DIFF
--- a/src/app/(authenticated)/categories/loading.tsx
+++ b/src/app/(authenticated)/categories/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoadingSpinner } from "@/components/common/PageLoadingSpinner";
+
+export default function CategoriesLoading() {
+  return <PageLoadingSpinner />;
+}

--- a/src/app/(authenticated)/error.tsx
+++ b/src/app/(authenticated)/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { PageError } from "@/components/common/PageError";
+
+/**
+ * 인증 라우트 전역 에러 바운더리
+ * 하위 라우트에서 error.tsx가 없으면 이 파일이 대신 처리
+ */
+export default function AuthenticatedError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <PageError reset={reset} />;
+}

--- a/src/app/(authenticated)/settings/loading.tsx
+++ b/src/app/(authenticated)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoadingSpinner } from "@/components/common/PageLoadingSpinner";
+
+export default function SettingsLoading() {
+  return <PageLoadingSpinner />;
+}

--- a/src/app/(authenticated)/transactions/loading.tsx
+++ b/src/app/(authenticated)/transactions/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoadingSpinner } from "@/components/common/PageLoadingSpinner";
+
+export default function TransactionsLoading() {
+  return <PageLoadingSpinner />;
+}

--- a/src/components/common/PageError.tsx
+++ b/src/components/common/PageError.tsx
@@ -1,0 +1,33 @@
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface PageErrorProps {
+  reset: () => void;
+}
+
+/**
+ * 페이지 에러 UI
+ * error.tsx 파일에서 사용 (레이아웃 내부에서 표시)
+ */
+export function PageError({ reset }: PageErrorProps) {
+  return (
+    <div className="flex items-center justify-center min-h-[60vh] py-12">
+      <div className="flex flex-col items-center space-y-4 animate-in fade-in duration-300 text-center px-4">
+        <div className="w-16 h-16 md:w-20 md:h-20 rounded-2xl md:rounded-3xl bg-red-50 flex items-center justify-center">
+          <AlertCircle className="w-8 h-8 md:w-10 md:h-10 text-red-400" />
+        </div>
+        <div className="flex flex-col items-center space-y-1">
+          <p className="text-base md:text-lg text-gray-900 font-semibold">
+            문제가 발생했습니다
+          </p>
+          <p className="text-xs md:text-sm text-gray-500">
+            잠시 후 다시 시도해주세요
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={reset}>
+          다시 시도
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `PageError` 공통 컴포넌트 추가 — AlertCircle 아이콘 + "다시 시도" 버튼 (closes #117)
- `(authenticated)/error.tsx`: 인증 라우트 전역 에러 바운더리 (하위 라우트 별도 error.tsx 없으면 여기서 처리)
- `transactions/`, `categories/`, `settings/`에 `loading.tsx` 추가 — `PageLoadingSpinner` 재사용

## Test plan

- [ ] `/transactions` 페이지 이동 시 로딩 스피너 표시 확인
- [ ] `/categories`, `/settings` 동일 확인
- [ ] 에러 발생 시 "문제가 발생했습니다" 화면 + "다시 시도" 버튼 표시 확인
- [ ] "다시 시도" 클릭 시 `reset()` 호출되어 재렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)