### PR TITLE
fix(ci): claude-code-review가 CLAUDE.md/README.md를 코멘트에 포함하는 문제 수정

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,11 +14,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
       - name: Dismiss old Claude bot comments
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,4 +107,4 @@ jobs:
             - **Be specific** — reference exact file names and line numbers when citing issues
             - **If there are zero issues**, write a short positive review with the 🟢 section only
 
-          claude_args: '--allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
+          claude_args: '--allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` 스텝 제거: 레포를 체크아웃하지 않으면 Claude가 로컬 파일에 접근 불가
- `--disallowedTools "Read,Write,Edit,Glob,Grep,LS"` 추가: 파일시스템 도구 명시적 차단

## 근본 원인

`--allowedTools`는 Bash 서브커맨드만 제한하고, Claude Code의 네이티브 도구(Read/Glob/Grep)는 제한하지 않음. 레포가 체크아웃된 상태에서 Claude가 CLAUDE.md, README.md 등을 자동으로 읽어 리뷰 코멘트에 포함시키는 문제 발생.

## Test plan

- [ ] 새 PR 오픈 시 Actions 탭에서 `claude-review` 워크플로우 실행 확인
- [ ] 코멘트에 CLAUDE.md / README.md 내용이 포함되지 않음 확인
- [ ] 코멘트에 테스트 메시지가 포함되지 않음 확인
- [ ] PR diff 기반 실제 코드 리뷰 코멘트 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)