### PR TITLE
fix(ci): claude-code-action에 필요한 actions/checkout 복원

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,6 +14,11 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Dismiss old Claude bot comments
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- PR #131에서 `actions/checkout@v4`를 제거했으나, `claude-code-action@v1`은 내부적으로 `git fetch origin main --depth=1`을 실행하여 `.claude` 등 설정 파일을 복원하는 보안 메커니즘이 있음
- checkout 없이 실행하면 `fatal: not a git repository` 에러로 CI 실패
- checkout 스텝을 복원하고, `--disallowedTools "Read,Write,Edit,Glob,Grep,LS"`는 유지하여 Claude의 로컬 파일 직접 읽기 차단 효과는 보존

## Root Cause

`claude-code-action@v1` 내부 동작:
1. Claude Code CLI 설치
2. **`git fetch origin main --depth=1`** 실행 → git 저장소 필요
3. `.claude`, `.mcp.json` 등을 main 브랜치에서 복원 (PR head 신뢰 불가)

## Test plan

- [ ] PR #126에서 `claude-review` job이 정상 실행되는지 확인
- [ ] CLAUDE.md / README.md가 코멘트에 포함되지 않는지 확인 (`--disallowedTools` 효과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)