### PR TITLE
fix(security): getMonthlyDailyStatsAction 인증 가드 누락 수정

### DIFF
--- a/src/app/actions/dashboard/get-monthly-daily-stats-action.ts
+++ b/src/app/actions/dashboard/get-monthly-daily-stats-action.ts
@@ -2,7 +2,10 @@
 
 import { endOfMonth, format, parseISO } from "date-fns";
 import { serverApiGet } from "@/lib/server/api";
-import { getSelectedFamilyUuid } from "@/lib/server/auth/auth-helpers";
+import {
+  requireAuth,
+  getSelectedFamilyUuid,
+} from "@/lib/server/auth/auth-helpers";
 
 interface ExpenseResponse {
   uuid: string;
@@ -29,6 +32,8 @@ export interface DailyTransactionSummary {
  * (API가 없으므로 목록 조회 후 집계)
  */
 export async function getMonthlyDailyStatsAction(year: number, month: number) {
+  await requireAuth();
+
   const familyUuid = await getSelectedFamilyUuid();
   if (!familyUuid) {
     return { success: false, error: "가족이 선택되지 않았습니다.", data: [] };


### PR DESCRIPTION
## Summary
- `getMonthlyDailyStatsAction`에 `requireAuth()` 호출 추가
- 비인증 사용자가 월별 일일 통계 데이터를 조회할 수 없도록 차단
- `get-dashboard-stats-action.ts`와 동일한 인증 패턴으로 일관성 확보

## Test plan
- [ ] 비인증 상태에서 Server Action 직접 호출 시 인증 오류 반환 확인
- [ ] 인증 상태에서 정상 동작 확인

Closes #138

🤖 Generated with [Claude Code](https://claude.ai/claude-code)