### PR TITLE
ci(claude): Dependabot PR에서 Claude Code Review 잡 스킵

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     # 같은 PR에 대해 동시에 실행 중인 이전 리뷰 run을 취소하여 중복 코멘트 방지
     concurrency:


### PR DESCRIPTION
## Summary

- Dependabot PR에서 `CLAUDE_CODE_OAUTH_TOKEN`이 null로 전달되어 Claude Code Review 워크플로우가 실패하는 문제 수정
- `if: github.actor != 'dependabot[bot]'` 조건 추가로 Dependabot PR에서 잡 자체를 스킵

## 원인

GitHub 보안 정책상 `pull_request` 이벤트에서 Dependabot PR은 시크릿에 접근할 수 없음.
`pull_request_target`으로 변경하는 방법도 있으나, 의존성 업데이트 PR은 코드 리뷰 대상이 아니므로 스킵이 더 적절한 선택.

## Test plan

- [ ] 일반 PR에서 Claude Code Review가 정상 동작하는지 확인
- [ ] Dependabot PR에서 Claude Code Review 잡이 스킵(skipped)되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)