### PR TITLE
fix(api): 알림 읽음 처리 및 카테고리 수정/삭제 엔드포인트 경로 마이그레이션

### DIFF
--- a/src/app/actions/category/delete-category-action.ts
+++ b/src/app/actions/category/delete-category-action.ts
@@ -35,7 +35,7 @@ export async function deleteCategoryAction(
 
     const familyUuid = await getSelectedFamilyUuid();
     if (!familyUuid) {
-      throw ActionError.invalidInput("familyUuid", familyUuid, "가족 UUID가 없습니다");
+      throw ActionError.familyNotSelected();
     }
 
     await serverApiDelete(`/families/${familyUuid}/categories/${categoryUuid}`);

--- a/src/app/actions/category/update-category-action.ts
+++ b/src/app/actions/category/update-category-action.ts
@@ -74,7 +74,7 @@ export async function updateCategoryAction(
 
     const familyUuid = await getSelectedFamilyUuid();
     if (!familyUuid) {
-      throw ActionError.invalidInput("familyUuid", familyUuid, "가족 UUID가 없습니다");
+      throw ActionError.familyNotSelected();
     }
 
     const category = await serverApiPut<CategoryResponse>(

--- a/src/app/actions/notification/mark-notification-read-action.ts
+++ b/src/app/actions/notification/mark-notification-read-action.ts
@@ -7,8 +7,11 @@ import {
 } from "@/lib/server/auth/auth-helpers";
 import { revalidatePath } from "next/cache";
 import type { Notification } from "@/types/actions/notification";
-import type { ActionResult } from "@/lib/errors";
+import { ActionError, type ActionResult } from "@/lib/errors";
 import { ErrorCode } from "@/lib/errors/error-code";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * 알림을 읽음 처리합니다.
@@ -21,16 +24,25 @@ export async function markNotificationReadAction(
     // 인증 확인
     await requireAuth();
 
+    // notificationUuid 형식 검증
+    if (!UUID_REGEX.test(notificationUuid)) {
+      return ActionError.invalidInput(
+        "notificationUuid",
+        notificationUuid,
+        "올바른 UUID 형식이 아닙니다"
+      ).toFailureResult();
+    }
+
     // familyUuid 소유권 검증
     const sessionFamilyUuid = await getSelectedFamilyUuid();
-    if (!sessionFamilyUuid || familyUuid !== sessionFamilyUuid) {
-      return {
-        success: false,
-        error: {
-          code: ErrorCode.NOTIFICATION_READ_FAILED,
-          message: "권한이 없습니다.",
-        },
-      };
+    if (!sessionFamilyUuid) {
+      return ActionError.familyNotSelected().toFailureResult();
+    }
+    if (familyUuid !== sessionFamilyUuid) {
+      return new ActionError(
+        ErrorCode.NOT_FAMILY_MEMBER,
+        "해당 가족의 구성원이 아닙니다"
+      ).toFailureResult();
     }
 
     // 백엔드 API 호출


### PR DESCRIPTION
## Summary

- 백엔드 API 경로 변경(이슈 #149)에 따른 프론트엔드 마이그레이션
- `familyUuid`가 URL에 포함된 새 엔드포인트로 3개 Server Action 업데이트
- 함수 시그니처 변경 없음 → 호출 사이트 수정 불필요

## 변경 내용

| 파일 | 기존 경로 | 새 경로 |
|------|----------|--------|
| `mark-notification-read-action.ts` | `PATCH /notifications/{uuid}/read` | `PATCH /families/{familyUuid}/notifications/{uuid}/read` |
| `update-category-action.ts` | `PUT /categories/{uuid}` | `PUT /families/{familyUuid}/categories/{uuid}` |
| `delete-category-action.ts` | `DELETE /categories/{uuid}` | `DELETE /families/{familyUuid}/categories/{uuid}` |

카테고리 액션은 `getSelectedFamilyUuid()`로 `familyUuid`를 내부에서 조회 (기존 `create-category-action`과 동일한 패턴).

관련 백엔드 PR: jon889/fos-accountbook-backend#76

## Test plan

- [ ] `pnpm lint` — 에러 0개 확인
- [ ] `pnpm test` — 169개 테스트 전부 통과 확인
- [ ] 알림 읽음 처리 동작 확인
- [ ] 카테고리 수정/삭제 동작 확인

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)