### PR TITLE
fix(recurring-expense): category null 방어 처리 — SSR 크래시 수정

### DIFF
--- a/src/components/recurring-expense/RecurringExpenseItem.tsx
+++ b/src/components/recurring-expense/RecurringExpenseItem.tsx
@@ -33,8 +33,15 @@ export function RecurringExpenseItem({
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const { name, amount, dayOfMonth, generatedThisMonth, category } =
-    recurringExpense;
+  const { name, amount, dayOfMonth, generatedThisMonth } = recurringExpense;
+  const category = recurringExpense.category ?? {
+    uuid: "",
+    familyUuid: "",
+    name: "미분류",
+    icon: "📁",
+    createdAt: "",
+    updatedAt: "",
+  };
 
   const handleDelete = async () => {
     setIsDeleting(true);

--- a/src/types/recurring-expense.ts
+++ b/src/types/recurring-expense.ts
@@ -4,7 +4,7 @@ export interface RecurringExpense {
   uuid: string;
   familyUuid: string;
   categoryUuid: string;
-  category: CategoryResponse;
+  category: CategoryResponse | null;
   name: string;
   amount: number;
   dayOfMonth: number;


### PR DESCRIPTION
## Summary
- 프로덕션에서 고정지출 페이지 접근 시 SSR 크래시 발생
- `RecurringExpense.category`가 백엔드에서 `null`로 응답될 때 `Cannot read properties of undefined (reading 'icon')` 에러
- `category` 타입을 `CategoryResponse | null`로 변경, fallback 객체("미분류")로 방어 처리

## 근본 원인
백엔드에서 반복 지출의 category가 null로 응답하는 케이스 존재 → 별도 백엔드 이슈로 조사 요청 예정

## Test plan
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test` 200개 전체 통과
- [ ] 프로덕션 배포 후 고정지출 페이지 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)