### PR TITLE
chore(gitignore): ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ next-env.d.ts
 # claude, oh-my-claudecode
 .claude/settings.local.json
 .omc
+
+.claude/worktrees/


### PR DESCRIPTION
## Summary

`.claude/worktrees/` 경로를 gitignore에 추가하여 다가올 병렬 작업(git worktree 기반 인사이트 이식)의 임시 파일이 커밋되지 않도록 함.

## Change

- `.gitignore`: `.claude/worktrees/` 1줄 추가

## Test plan

- [x] 로컬에서 `git worktree add .claude/worktrees/test` 실행 후 `git status`에 노출되지 않음 확인 (로컬 검증)
- [ ] 머지 후 Stage 1 S1(fos-accountbook 인사이트 이식 worktree) 진행 가능 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)