### PR TITLE
chore(ci): claude-code-review fos-blog 노하우 + Checks 탭 노출

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,14 +26,46 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
+      checks: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      # /review 트리거 댓글에 👀 이모지로 즉시 작업 시작 시그널
+      - name: /review 댓글에 시작 reaction 추가
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST \
+            --field content=eyes || true
+
+      # issue_comment 트리거된 workflow run 은 GitHub Actions 의 알려진 제약으로
+      # PR Checks 탭에 자동 등록 안 됨. PR head SHA 에 Check Run 을 수동 생성하여
+      # /review 진행 상태가 PR 페이지에서 가시화되도록 한다.
+      - name: PR head SHA 조회 + Check Run 시작 (Checks 탭 노출)
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HEAD_SHA=$(gh pr view ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --json headRefOid --jq .headRefOid)
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+
+          CHECK_RUN_ID=$(gh api "repos/${{ github.repository }}/check-runs" \
+            --method POST \
+            --field name="Claude Code Review" \
+            --field head_sha="$HEAD_SHA" \
+            --field status="in_progress" \
+            --field details_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --jq .id)
+          echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> "$GITHUB_ENV"
+          echo "Check Run 시작: id=$CHECK_RUN_ID head_sha=$HEAD_SHA"
 
       - name: Minimize old Claude bot comments
         env:
@@ -73,9 +105,13 @@ jobs:
             done
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        # v1 floating tag 가 install.sh 에서 silently 교체된 binary tarball 로 깨진 후
+        # (issue anthropics/claude-code-action#1290, 2026-05-06 회귀) v1.0.111 로 pin.
+        # upstream 픽스 후 다시 v1 으로 풀 것.
+        uses: anthropics/claude-code-action@v1.0.111
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
           prompt: |
             You are a code review orchestrator for the fos-accountbook project (Next.js 16 family budget app).
             Your job is to coordinate 4 parallel specialist reviewers, then post a single GitHub review.
@@ -251,6 +287,11 @@ jobs:
             REVIEW_EOF
             ```
 
+            JSON `body` / inline `body` 필드 안의 `\n` 은 JSON parser 가 해석하므로 정상.
+            **단** 별도 `gh pr comment --body "..."` 형태로 추가 댓글을 게시할 일이 생기면 반드시
+            `--body-file - <<'EOF' ... EOF` HEREDOC 패턴 사용 — 큰따옴표 안의 `\n` 은 shell 이
+            literal 두 글자 그대로 GitHub API 에 전달해 댓글 포매팅이 깨진다 (fos-blog 관측 사고).
+
             ## Review Body Format (Korean)
 
             ```
@@ -278,6 +319,21 @@ jobs:
 
             ## Critical Rules
 
+            - **PR 브랜치에 어떠한 파일도 git add / commit / push 금지** — review 작업은 read-only +
+              GitHub API 호출만. 임시 파일 (예: `.claude-pr/summary.md`) 도 만들지 말 것.
+              디스크에 파일을 만든 후 읽는 패턴 금지 (action wrapper 의 `git add -A` 가 그 파일을
+              PR 브랜치 commit 으로 흘려보냄 — fos-blog PR #83 실제 사고). API body 는 항상
+              stdin (`--input -` HEREDOC) 으로만 전달.
+            - **테스트 / 더미 / placeholder 댓글 게시 절대 금지** — 실제 production 리뷰임.
+              사용자 토큰 낭비 + review-fix 흐름 오염. 게시 직전 다음 sanity check 통과해야 한다:
+              - body 가 `🔴`/`🟡` severity 마커 + `**문제**:` + `**수정**:` 패턴을 모두 포함하는가?
+              - body 에 `test body`, `test 1`, `sample`, `placeholder`, `example`, `<여기에>`,
+                `{ISSUE}`, `{FIX}` 같은 dummy / template 잔재가 없는가?
+              - body 가 12자 미만이거나 의미 있는 한국어 문장 0개면 reject
+              위 셋 중 하나라도 실패하는 entry 는 즉시 제거 후 게시. inline `comments` 배열이
+              비면 `comments` 키 자체를 생략하고 review body 에 "발견사항 없음 — 인라인 코멘트
+              skip" 한 줄로 갈음 (fos-blog PR #114 실제 사고 — Claude action 이 자연어 가이드를
+              무시하고 "test body" 같은 placeholder 게시).
             - **Post exactly ONE review** — do not call the reviews API more than once
             - **Do NOT post a separate general comment** — the review body IS the summary
             - **Only include sections that have content** — omit empty 🔴 or 🟡 sections
@@ -290,3 +346,40 @@ jobs:
             - If `gh api` returns 422, log the error and do NOT retry
 
           claude_args: '--model claude-sonnet-4-6 --allowedTools "Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'
+
+      # 작업 결과를 /review 댓글에 ✅/❌ reaction 으로 표시 (success/failure 분기, always 실행)
+      - name: /review 댓글에 종료 reaction 추가
+        if: github.event_name == 'issue_comment' && always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ job.status }}
+        run: |
+          # job.status: success | failure | cancelled
+          if [ "$OUTCOME" = "success" ]; then
+            CONTENT="+1"
+          else
+            CONTENT="-1"
+          fi
+          gh api "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            --method POST \
+            --field content="$CONTENT" || true
+
+      # Check Run 완료 처리 — job.status 를 conclusion 으로 매핑 (PR Checks 탭에서 즉시 결과 가시화)
+      - name: Check Run 완료 처리 (success/failure/cancelled)
+        if: github.event_name == 'issue_comment' && always() && env.CHECK_RUN_ID != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTCOME: ${{ job.status }}
+        run: |
+          case "$OUTCOME" in
+            success)   CONCLUSION="success" ;;
+            failure)   CONCLUSION="failure" ;;
+            cancelled) CONCLUSION="cancelled" ;;
+            *)         CONCLUSION="failure" ;;
+          esac
+
+          gh api "repos/${{ github.repository }}/check-runs/${{ env.CHECK_RUN_ID }}" \
+            --method PATCH \
+            --field status="completed" \
+            --field conclusion="$CONCLUSION" || true
+          echo "Check Run 완료: conclusion=$CONCLUSION"


### PR DESCRIPTION
## Summary

fos-blog 의 누적된 claude-code-review 운영 노하우를 fos-accountbook 에 통합 + `/review` 댓글 트리거 시 PR Checks 탭 노출 추가.

## 배경

fos-accountbook 의 review workflow 는 기본 골격만 있고 fos-blog 가 6개월간 축적한 사고 대응/UX 개선이 미반영. 또한 `issue_comment` 로 트리거된 workflow run 은 GitHub Actions 의 알려진 제약으로 PR Checks 탭에 자동 등록 안 됨 — `/review` 진행 상태가 PR 페이지에서 안 보이는 문제.

## 변경

### UX 개선
- **시작 reaction (👀)** — `/review` 댓글에 즉시 eyes reaction → 사용자에게 작업 시작 시그널
- **종료 reaction (✅/❌)** — `job.status` 따라 +1/-1 reaction 자동 분기
- **Check Run 노출** — PR head SHA 에 Check Run 수동 생성 (`status=in_progress`) → 종료 시 conclusion (`success`/`failure`/`cancelled`) PATCH. PR Checks 탭에서 진행 상태 + 결과 가시화

### 운영 안정성
- **action 버전 pin** — `@v1` → `@v1.0.111` (issue [anthropics/claude-code-action#1290](https://github.com/anthropics/claude-code-action/issues/1290) v1 floating tag 회귀 회피)
- **봇 PR 리뷰 허용** — `allowed_bots: "*"` 로 dependabot PR 도 자동 리뷰 대상
- **PR 브랜치 commit 가드** — prompt 에 명시 (action wrapper `git add -A` 가 임시 파일을 PR 브랜치 commit 으로 흘려보낸 fos-blog PR #83 사고)
- **dummy/placeholder 댓글 sanity check** — 12자 미만, `🔴`/`🟡` 마커 부재, `test`/`sample`/`placeholder` 패턴 reject (fos-blog PR #114 — Claude action 이 `test body` 같은 placeholder 게시한 사고)
- **HEREDOC `\n` literal 가드** — 추가 댓글 게시 시 `--body "...\n..."` 회피 명시

### Permissions 갱신
- `issues: read` → `write` (reaction 게시)
- `checks: write` 신규 (Check Run create/patch)

## fos-blog vs fos-accountbook 의 의도된 차이 (가져오지 않음)

- 이전 댓글 처리: fos-blog 는 DELETE, fos-accountbook 은 graphql `minimizeComment(OUTDATED)` — 이력 보존 측면에서 fos-accountbook 방식 유지
- review 게시 구조: fos-blog 는 인라인 review + 별도 일반 요약 댓글 분리, fos-accountbook 은 단일 review API 에 `body` + `comments` 통합 (event=APPROVE/REQUEST_CHANGES) — 단일 호출이 더 깔끔하므로 유지
- post-cleanup step (게시된 dummy 댓글 자동 DELETE): 단일 review API 구조에서는 인라인 dummy 가 review-fix 흐름으로 흘러갈 가능성 낮아 prompt sanity check 만 추가

## Test plan

- [ ] 이 PR 자체에 자동 리뷰 발동 (pull_request opened 트리거) — review 정상 게시 확인
- [ ] PR 댓글에 `/review` 입력 → 댓글에 👀 즉시 추가 → PR Checks 탭에 "Claude Code Review" 진행 표시
- [ ] 리뷰 종료 후 댓글에 ✅ 추가 + Checks 탭에 success conclusion
- [ ] 차후 dependabot PR 에 자동 리뷰 발동 확인 (allowed_bots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)