### PR TITLE
chore(skills): /planning + /build-with-teams + /review-fix 흐름 개선

### DIFF
--- a/.claude/skills/build-with-teams/SKILL.md
+++ b/.claude/skills/build-with-teams/SKILL.md
@@ -7,72 +7,48 @@ description: Claude Agent Teams 기반 구현 자동화. 계획(team-lead) → �
 
 task phase를 Claude Agent Teams 파이프라인으로 실행하는 시스템. 4-5명의 에이전트가 가시적으로 협업.
 
-## 사전 검증 (실행 전 필수 — 3중 체크)
+## 사전 검증 (실행 전 필수)
 
-plan 인자를 받으면 **가장 먼저** 아래 3가지 모두 확인. 하나라도 걸리면 사용자에게 알리고 **실행 차단** (사용자 확인 없이 강행 금지):
+plan 인자를 받으면 **가장 먼저** 아래 단계를 순서대로 수행. 신 워크플로 (`/planning` 이 plan 브랜치 push 만 하고 PR 은 `/build-with-teams` 가 생성) 기반이라 검증 단순화.
 
-### 1. main의 `index.json` status
+### 1. 원격 plan 브랜치 존재 — `/planning` 완료 여부
 
 ```bash
 # cwd: <repo root>
-test -f tasks/{plan}/index.json || echo "TASK_MISSING"
-jq -r .status tasks/{plan}/index.json 2>/dev/null
-```
-
-- `TASK_MISSING` → task 파일 부재. `/planning` 으로 먼저 설계할지 사용자에게 확인 (실사례: plan012 가 phase 메모에만 언급됐을 뿐 task 디렉터리는 없는 상태에서 호출됨)
-- `completed` → 추가 검증 (아래 "completed 마킹 ↔ 머지 커밋 정합" 참조)
-- `pending` / `in_progress` → 다음 검증으로
-
-### 2. 원격 `feat/{plan}` 브랜치 존재
-
-```bash
-git ls-remote --heads origin "feat/{plan}" | grep -q . && echo FOUND || echo NONE
-```
-
-`FOUND` → 차단. 이미 작업 중이거나 PR 미머지 상태일 가능성. 사용자 확인 후 (a) 그 브랜치를 fetch 해서 이어서 작업할지 (b) 새로 시작할지 결정.
-
-### 3. 해당 plan 제목을 포함한 오픈 PR
-
-```bash
-gh pr list --state open --search "{plan}" --json number,title,headRefName
-```
-
-결과 있음 → 차단. 작업 완료 후 머지 대기 중일 가능성.
-
-> 세 검증 모두 통과해야 신규 실행. **PR 머지 전 단계에서 main 의 `index.json` 은 여전히 `pending` 이므로 1번만 보면 재실행 사고를 놓친다. 2·3번이 커버.**
-
-### task 단독 PR 이 이미 열려있는 경우 — 옵션 A (이어서 작업) 권장 흐름 (필수)
-
-위 2번 (FOUND) + 3번 (OPEN PR) 이 동시에 걸리고, 해당 PR 이 task 파일만 (코드 변경 0개) 머지 대기 중이라면 **옵션 A (이어서 작업)** 로 전환한다. 이는 차단이 아니라 **그 PR 을 그대로 결과물 통합 PR 로 사용**하는 흐름이다 (plan024/025 의 사후 정리 사고를 처음부터 회피).
-
-**판정 기준** — `gh pr view <N> --json files,additions,deletions` 결과:
-- `files` 가 `tasks/{plan}/...` 만 포함 + 코드 (`src/...`) 변경 0
-- `state` = OPEN
-→ 옵션 A 자동 권장 (사용자 confirm)
-
-**옵션 A 흐름**:
-1. **새 브랜치 만들지 말 것** — 기존 브랜치 그대로 사용
-2. worktree 체크아웃: `git worktree add .claude/worktrees/{plan} feat/{plan}` (`-b` 없음 → 기존 브랜치 사용)
-3. phase 실행 → 결과물 commit → **같은 브랜치**에 push (PR 에 commits 추가됨)
-4. PR 제목 `chore(task)` → `feat(...)` / `fix(...)` 로 갱신: `gh pr edit <N> --title "..."` + body 도 결과물 반영 후 갱신
-5. 마지막 phase 의 `status="completed"` 마킹은 같은 브랜치 안에서
-
-**옵션 A 회피해야 하는 상황**:
-- task PR 이 이미 코드 변경을 포함 (다른 사람이 부분 구현 push 중) → 사용자 confirm 후 변경 분류
-- task PR 의 base 가 main 이 아닌 경우 (드물게 stacked PR) → 별도 처리
-
-**옵션 B (별도 `-impl` 브랜치)** 는 plan024/025 처럼 task PR 과 결과물 PR 이 분리되어 사후 정리 비용이 발생하므로, task PR 이 이미 머지된 후에만 사용 (즉 옵션 A 가 불가한 상황). 사고 패턴이라 디폴트 금지.
-
-### `completed` 마킹 ↔ 머지 커밋 정합 검증 (역방향)
-
-status 가 `completed` 인데 실제 머지 커밋이 origin/main 에 없으면 마킹 사고. 차단 전 한 번 더 확인:
-
-```bash
 git fetch origin
-git log origin/main --oneline --grep "{plan}" | head -3   # 비어있으면 마킹 사고 의심
+git ls-remote --heads origin "plan/{N}-*" | head -3
 ```
 
-부재면 사용자에게 알리고 status 를 pending 으로 되돌릴지 결정 (실사례: plan006 이 status="completed" 였지만 머지 안 된 상태에서 plan007 진행 시도, 사전 게이트 PHASE_BLOCKED).
+- 결과 없음 → `/planning {N}` 호출 안 했거나 push 누락. 사용자에게 안내:
+  > `plan{N}` 브랜치가 원격에 없습니다. `/planning {N}` 를 먼저 호출해서 task + 브랜치를 만들어 주세요.
+- 결과 있음 → 정확한 브랜치 이름 (`plan/{N}-{slug}`) 확인 후 다음 단계
+
+### 2. plan 브랜치에 task 파일 존재 확인
+
+```bash
+git ls-tree origin/plan/{N}-{slug} -- tasks/plan{N}-{slug}/index.json
+```
+
+부재면 비정상 (planning 이 task 안 만든 상태). 사용자 확인 후 `/planning {N}` 재호출 안내.
+
+### 3. 해당 plan 의 오픈 PR 점검
+
+```bash
+gh pr list --head "plan/{N}-{slug}" --state open --json number,title,headRefName,additions,deletions
+```
+
+- 결과 없음 → 신규 실행 OK (가장 흔한 케이스)
+- 결과 있음 → 이전 build-with-teams 실행이 PR 까지 만든 상태. 사용자 결정 (`AskUserQuestion`):
+  - (a) 같은 브랜치에 추가 phase commit 후 PR 갱신 (이어서 작업)
+  - (b) 별개 plan 으로 결정 (새 plan 번호 부여)
+
+### 4. 이미 머지된 plan 재호출 차단 (역방향)
+
+```bash
+git log origin/main --oneline --grep "plan{N}" | head -3
+```
+
+merge commit 발견 시 이미 완료된 plan. 사용자에게 알리고 (a) 새 plan 번호 부여 또는 (b) 후속 작업 전용 follow-up 브랜치 결정 의뢰. 실사례: fos-blog plan006 이 status="completed" 였지만 머지 안 된 상태에서 plan007 진행 시도 → 신 워크플로에서는 PR 생성 자체가 build-with-teams 책임이라 이런 사고 자체 회피.
 
 ## 핵심 원칙
 
@@ -286,25 +262,31 @@ TeamCreate → team name: plan{N}
 
 critic + docs-verifier 를 `run_in_background: true` 로 스폰. 대기 상태로 준비. (단, fos-blog 에서는 docs-verifier / code-reviewer 가 self-shutdown 패턴이 있으므로 위 "팀원 self-shutdown 패턴 대응" 참조 — 검사 시점에 새로 스폰하는 게 안전)
 
-### 2. 문서 파악 + 논의
+### 2. plan 브랜치 fetch + worktree 체크아웃
 
-team-lead 가 `docs/` 하위 문서 + `CLAUDE.md` 를 읽고 사용자와 논의.
+`/planning` 이 만든 브랜치 (`plan/{N}-{slug}`) 를 fetch + worktree 로 체크아웃. **새 브랜치 만들지 말 것** — 기존 브랜치에 phase commits 를 추가한다.
 
-### 3. docs 최신화 + 커밋
+```bash
+# cwd: <repo root>
+git fetch origin plan/{N}-{slug}
+git worktree add .claude/worktrees/plan{N} plan/{N}-{slug}   # -b 없음 (기존 브랜치 사용)
+cd .claude/worktrees/plan{N}
+pnpm install   # 의존성 설치
+```
 
-논의 결과를 task 생성 전에 docs 에 반영. docs 변경사항 단독 커밋.
+worktree 안에는 task 파일이 이미 있음 (`/planning` 이 commit + push 했으므로). docs 도 갱신된 상태.
 
-### 4. task 파일 생성
+### 3. task 파일 검토 + 필요 시 보강
 
-`tasks/{task-name}/` 디렉터리에 `index.json` + `phase-{N}.md` 생성. phase 프롬프트 규칙:
+`tasks/plan{N}-{slug}/index.json` + `phase-*.md` 를 읽고 critic 평가 전에 빠진 부분이 없는지 점검. `/planning` 단계에서 누락된 사항이 발견되면 **같은 브랜치에 보강 commit 추가** (별도 PR 만들지 않음).
+
+phase 프롬프트 규칙 (planning 에서 이미 적용됐어야 하는 사항 — 검증):
 
 - 원자적 단일 책임, 작업 항목 5개 이하
 - 자기완결적 (이전 대화 없이 독립 실행 가능)
 - 성공 기준에 모든 작업 검증 포함 (grep/test/diff/build — "눈으로 확인" 금지)
 - 모든 Bash 블록 앞에 `# cwd: ...` 주석
-- **마지막 phase 작업 목록에 `index.json` 의 `status="completed"` + 모든 phase `status="completed"` 업데이트를 포함** (task 파일 설계 단계에서 명시) — main 별도 커밋 회피
-
-task 파일 생성 후 커밋. **단 이 commit 을 별도 PR 로 push/머지 금지** — task 파일과 phase 결과물은 **반드시 같은 PR 에 묶는다**. 별도 PR 로 task 만 머지하면 (a) status="pending" 인 채로 main 에 task 가 들어가 추후 재실행 사고 + (b) 실제 결과물이 다른 PR 에서 머지되는 경우 task spec 과 코드 간 정합 검증이 누락된다 (실사례: fos-blog plan024 — task 가 PR #110 단독 머지, 결과물은 PR #81 에서 이미 머지된 상태로 사후 정리 필요). worktree 안에서 task 파일 commit → phase 실행/검증 → 같은 브랜치 push → 한 번에 PR 생성.
+- **마지막 phase 작업 목록에 `index.json` 의 `status="completed"` + 모든 phase `status="completed"` 업데이트 포함** — 별도 commit 회피
 
 **task 재분할 시 index.json 동시 갱신 강제 (필수 — webtoon-maker-v1 plan250 관측)**: critic REVISE 후 phase 파일을 재작성/추가/제거할 때 `index.json` 의 `total_phases` + `phases` 배열 + description 본문을 **반드시 같은 commit 으로 갱신**한다. phase 파일만 추가하고 index.json 미수정한 채 commit 하면 파이프라인이 신 phase 를 인식 못해 executor 가 구 phase 만 실행 → plan 핵심 누락 사고. team-lead 는 commit 직전 sanity check:
 
@@ -411,11 +393,15 @@ executor 완료 후 team-lead → docs-verifier 에게 검증 요청. self-shutd
      - **B**: 별도 hotfix PR 분리 → 머지 후 plan PR rebase (책임 분리, 시간 소요)
      - **C**: 그대로 PR 생성 + description 에 의존 명시 (사용자가 hotfix PR 머지 후 rebase)
    - 결정 후 진행. 결정 이력은 PR description 의 "Build" 섹션에 명시
-4. **`tasks/{task-name}/index.json` status="completed" 마킹은 PR 브랜치 안에서**:
-   - 이상적: 마지막 phase 작업 항목에 포함 (단계 4 의 phase 설계 단계에서 명시) → 별도 commit 불필요
-   - 차선: PR 브랜치 안에서 별도 `chore(tasks): mark {plan} completed` commit
-   - **main 직접 커밋/푸시 금지** — 이중 진실원 + push 충돌 위험. 재실행 사고 방지는 위 "사전 검증 3중 체크" 가 담당
-5. push + `gh pr create` (main 대상). CI 실패가 plan 외부에 있으면 description 에 의존 PR 번호 + 머지 순서 명시
+4. **`tasks/{task-name}/index.json` status="completed" 마킹은 plan 브랜치 안에서**:
+   - 이상적: 마지막 phase 작업 항목에 포함 (단계 3 의 phase 설계 단계에서 명시) → 별도 commit 불필요
+   - 차선: plan 브랜치 안에서 별도 `chore(tasks): mark {plan} completed` commit
+   - **main 직접 커밋/푸시 금지** — 이중 진실원 + push 충돌 위험
+5. **push + PR 생성/갱신**:
+   - 사전 검증 3 (오픈 PR 점검) 결과에 따라 분기:
+     - **신규 실행 (오픈 PR 없음)** → `git push` 후 `gh pr create --base main --head plan/{N}-{slug}` 신규 생성. 제목 형식: `feat(scope): {plan 핵심}` 또는 `fix(scope): ...`. body 에 task spec 요약 + 결과물 commits + Test plan 포함
+     - **이어서 실행 (오픈 PR 있음, 사용자 옵션 (a) 선택)** → 같은 브랜치 push (commits 추가됨) + `gh pr edit <N> --title "..." --body "..."` 로 제목/body 갱신. PR 번호는 사전 검증 3 에서 확인한 값
+   - CI 실패가 plan 외부에 있으면 description 에 의존 PR 번호 + 머지 순서 명시
 6. **즉시 팀 shutdown** (SendMessage `shutdown_request`) + worktree 정리 + team-lead 누적 노하우 보고
 7. 사용자가 GitHub 에서 PR 머지 → completed 상태 자동 main 반영. main 후속 작업 0개
 
@@ -482,18 +468,19 @@ fi
 
 실사례: `.claire-worktrees/plan011-...` 가 ESLint 에러 유발 — 다음 plan 시작 시점에 자동 정리되도록 게이트화.
 
-### worktree 생성
+### worktree 생성 (plan 브랜치 기반)
 
 ```bash
 # cwd: <repo root>
 mkdir -p .claude/worktrees
-git worktree add .claude/worktrees/{plan이름} -b feat/{plan이름} origin/main
-cd .claude/worktrees/{plan이름}
+git fetch origin plan/{N}-{slug}
+git worktree add .claude/worktrees/plan{N} plan/{N}-{slug}   # -b 없음 — /planning 이 만든 기존 브랜치 사용
+cd .claude/worktrees/plan{N}
 pnpm install                # 의존성 설치
 pnpm db:generate            # Drizzle schema 변경이 있으면 타입 재생성 (선택)
 ```
 
-**worktree 정리**: 메인 워킹 디렉토리로 돌아가서 `git worktree remove .claude/worktrees/{plan이름}` + 로컬 브랜치 정리 `git branch -D feat/{plan이름}` (PR 머지 후엔 안전).
+**worktree 정리**: 메인 워킹 디렉토리로 돌아가서 `git worktree remove .claude/worktrees/plan{N}`. 로컬 브랜치 (`plan/{N}-{slug}`) 는 PR 머지 후 cleanup 시 삭제 (즉시 삭제 금지 — 사용자가 follow-up commit 추가할 수 있음).
 
 이렇게 하면 여러 plan 을 **동시 병렬 실행**해도 서로 간섭하지 않는다.
 
@@ -516,21 +503,22 @@ executor 가 phase 실패 보고 시:
 
 ## 실행 흐름 요약
 
+전제: `/planning {N}` 이 task 파일 생성 + `plan/{N}-{slug}` 브랜치 push 완료 (PR 미생성 상태). build-with-teams 가 같은 브랜치에서 phase 실행 + PR 생성.
+
 ```
-[사전 검증 3중 체크 — main index.json status + 원격 feat 브랜치 + 오픈 PR]
+[사전 검증 — plan 브랜치 존재 + task 파일 존재 + 오픈 PR 점검 + 머지 이력]
     → [실행 모드 선택 게이트 — AskUserQuestion: A 정식 / B 사후검수 / C 직접]
     → [메인 워킹 트리 사전 점검 (앞섬/뒤짐/dirty 안내)]
     → [오타 worktree pre-flight 정리]
-    → [worktree 생성 (origin/main 기반)]
-    → [docs 최신화 + 커밋]
-    → [task 파일 생성 + 커밋]  ← 마지막 phase 에 index.json completed 업데이트 포함
+    → [worktree 생성 — plan/{N}-{slug} 기반 (기존 브랜치 사용)]
+    → [task 파일 검토 + 보강 commit 필요 시 추가]
     → [critic 평가] ←─ REVISE 면 계획 수정 후 재평가 (한도 3회)
     → [executor 실행 — cwd 격리 + scope 확장 보고 가드] ←─ 실패 시 원인 분석 후 재실행
     → [code-reviewer 검사] ←─ FIX_NEEDED 면 executor 재투입 (한도 2회)
     → [docs-verifier 검증 (문서 부패 포함)] ←─ VIOLATION/UPDATE_NEEDED 면 재투입 (한도 2회)
     → [통합 검증 (CI) — 실패 시 plan 범위 내/외 분기 절차]
-    → [team-lead 최종 push (PR 브랜치 안에서 index.json completed 마킹 포함)]
-    → [PR 생성 (main 대상)]
+    → [team-lead 최종 push (plan 브랜치 안에서 index.json completed 마킹 포함)]
+    → [PR 생성 또는 갱신 (오픈 PR 없으면 신규, 있으면 gh pr edit 으로 갱신)]
     → [팀 즉시 shutdown + worktree 정리 (post-flight 오타 정리 1회 더) + 누적 노하우 보고]
     → (사용자 PR 머지 → completed 자동 main 반영, 후속 작업 0개)
 ```

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -159,20 +159,28 @@ task 파일을 **사용자에게 제출하기 전**에 반드시 [`common-pitfal
 1. **docs 반영 완료 확인** — `docs/adr.md` / `docs/flow.md` / `docs/data-schema.md` / `docs/code-architecture.md` / `docs/pages/{page}.md` / `CLAUDE.md` 중 해당하는 문서에 이번 결정이 모두 기록됐는지 점검
 2. **task 파일 생성** — `tasks/plan{N}-{kebab-slug}/` 디렉터리 + `index.json` + phase 파일들 작성. 상세 규칙은 [`task-create.md`](./task-create.md) 참조 (index.json 스키마 / model 라우팅 / phase 작성 체크리스트 / 마지막 2 phase 표준). CLAUDE.md "Task 작업 규칙" 도 준수 — 원자적 단일 책임, phase 당 작업 5개 이하, 자기완결 프롬프트, **마지막 phase 에 index.json status="completed" 마킹 명시**
 3. **`common-pitfalls.md` 의 P1~P9 + 패턴 소진 체크리스트 사전 소진** — task 제출 전 self-check
-4. **branch 확인** — `git branch --show-current` 가 `main` 이어야 함. PR 브랜치에서 작업 중이면 stash 후 main 으로 switch
-5. **git commit** — docs 변경 + task 파일을 **한 커밋** 으로 묶어 생성
-6. **git push origin main** — 원격에 즉시 반영 (force push 금지)
-7. 사용자 보고 + 실행 안내:
+4. **plan 브랜치 생성** — `git switch -c plan/{N}-{kebab-slug} origin/main`. 매 plan 마다 origin/main 기준 신규 브랜치 (이전 plan 브랜치 위에 쌓지 않는다)
+5. **git commit** — docs 변경 + task 파일을 **한 커밋** 으로 묶어 생성. commit 메시지: `docs(plan{N}): {plan 한 줄 요약}`
+6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정). **PR 생성하지 않는다** — task 만으로는 머지할 가치가 없으므로 PR 단독 머지 사고 (status="pending" 인 채 main 진입) 를 처음부터 회피
+7. **main 으로 복귀** — `git switch main`. 이후 사용자가 `/build-with-teams` 호출 시 같은 브랜치에서 작업 이어가도록
+8. 사용자 보고 + 실행 안내:
 
-> plan{N} task 파일 생성 + commit + push 완료. `/build-with-teams plan{N}` 로 구현을 시작하세요.
+> plan{N} task 파일 생성 + push 완료 (브랜치: `plan/{N}-{kebab-slug}`).
+> `/build-with-teams plan{N}` 로 구현을 시작하면 같은 브랜치에서 phase 실행 후 PR 이 생성됩니다.
 
-**실제 구현 (phase 실행) 은 사용자가 명시적으로 `/build-with-teams` 를 호출할 때 시작.** planning 스킬은 task 생성 + push 까지만 책임진다.
+**실제 구현 (phase 실행) + PR 생성은 사용자가 명시적으로 `/build-with-teams` 를 호출할 때 시작.** planning 스킬은 task 생성 + 브랜치 push 까지만 책임진다 (PR 생성 책임 없음).
+
+### 왜 PR 을 생성하지 않는가
+
+- task 파일 단독 PR 은 **결과물 없는 spec 만 main 으로 머지**되는 사고 패턴 — `status="pending"` 인 채 main 에 진입하면 다른 세션에서 재실행 시 사전 검증이 통과해 중복 작업 발생 (실사례: fos-blog plan024/025 사후 정리 비용)
+- task 와 결과물을 같은 PR 에 묶으면 spec ↔ 코드 정합성을 reviewer 가 한 번에 검증 가능 — 분리된 두 PR 보다 정합 보장에 유리
+- 사용자가 며칠 후 `/build-with-teams` 로 재개해도 PR 미생성 → 머지 위험 0. 브랜치만 보존되므로 안전
 
 ### 예외
 
-- **docs 변경 없음 + task 없음** (논의만 한 케이스): commit / push 생략, "task 생성할 규모 아니므로 기록 없이 종료" 고지
-- **force push 필요**: 금지 — 기존 커밋 수정 대신 새 커밋 생성
-- **원격 branch protection 으로 main 직접 push 차단**: PR 경로로 우회 (브랜치 만들고 PR 생성)
+- **docs 변경 없음 + task 없음** (논의만 한 케이스): branch 생성 / commit / push 생략, "task 생성할 규모 아니므로 기록 없이 종료" 고지
+- **force push 필요**: 금지 — 기존 커밋 수정 대신 새 커밋 생성. 단 사용자가 명시적으로 `/planning` 재호출로 task 수정을 요청한 경우에 한해 같은 브랜치에 추가 commit + push (force 아님)
+- **plan 브랜치가 이미 원격에 존재**: 다른 세션에서 만든 동일 plan. 사용자에게 알리고 (a) 그 브랜치 fetch 후 추가 commit (b) 새 plan 번호로 신규 결정 의뢰 (`AskUserQuestion`)
 
 ---
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -53,7 +53,86 @@ gh pr view <N> --comments
 
 ---
 
-## 2단계: 리뷰 분류 및 우선순위 결정
+## 2단계: PR Conflict 사전 점검 및 해결
+
+리뷰 fix 를 push 하기 전에 PR 이 main 과 conflict 상태인지 확인. CONFLICTING 인 채로 fix commit 을 push 하면 PR 이 여전히 머지 불가 → fix 효과가 무력화.
+
+### 2-1. mergeable 상태 확인
+
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus
+```
+
+판정:
+- `mergeable: MERGEABLE` + `mergeStateStatus: CLEAN/UNSTABLE/HAS_HOOKS/BLOCKED` → conflict 없음. 3단계로
+- `mergeable: CONFLICTING` 또는 `mergeStateStatus: DIRTY` → conflict 해결 필요. 2-2 로
+- `mergeable: UNKNOWN` → 잠시 대기 후 재확인 (GitHub 가 머지 분석 중)
+
+> `BLOCKED` 는 보호 규칙 (리뷰 필수 등) 의미 — conflict 와 별개로 fix 진행 가능.
+
+### 2-2. worktree 만들어 rebase 시도
+
+```bash
+# cwd: <repo root>
+git fetch origin
+mkdir -p .claude/worktrees
+git worktree add .claude/worktrees/{branch}-rebase {pr-head-branch}
+cd .claude/worktrees/{branch}-rebase
+git rebase origin/main 2>&1 | tail -10
+```
+
+conflict 가 발생한 파일을 `git status` 로 식별.
+
+### 2-3. Conflict 분류 + 자동/수동 처리
+
+| Conflict 유형 | 처리 방식 |
+|---|---|
+| `pnpm-lock.yaml` / `package-lock.json` / `yarn.lock` | 항상 main 채택 (`git checkout --ours <file>`) + 패키지 매니저 install 로 재생성 (`pnpm install`). lockfile 수동 머지 금지 — 무결성 깨짐 |
+| `package.json` | 수동 머지: 신규 의존성은 보존, 버전은 main 우선. conflict marker 직접 편집 |
+| 코드 파일 (.ts/.tsx/.js/.css 등) | **사용자 결정 분기** (`AskUserQuestion`) — 의미적 충돌이라 자동 처리 금지 |
+| docs (.md) | 양쪽 보존 권장 — 두 변경이 의도된 다른 정보일 가능성 높음. 사용자 confirm 후 머지 |
+
+**lockfile 처리 표준 절차**:
+
+```bash
+# rebase 중에는 --ours = upstream(main), --theirs = our commit. main 채택은 --ours.
+git checkout --ours pnpm-lock.yaml
+# package.json 수동 fix 후
+pnpm install  # lock 재생성
+git add package.json pnpm-lock.yaml
+```
+
+**코드 파일 conflict 결정 의뢰 (필수)**:
+
+`AskUserQuestion` 으로 옵션 제시:
+- (a) main 채택 (`--ours`)
+- (b) PR 채택 (`--theirs`)
+- (c) 양쪽 변경 병합 (수동 — 어떻게 병합할지 추가 질문)
+- (d) 사용자가 직접 해결할 테니 worktree 만 남겨둠 (skill 종료, 사용자가 수동 처리 후 force-push)
+
+### 2-4. 검증 + force-with-lease push
+
+conflict 해결 후 빌드/테스트 검증 → 통과 시 force-with-lease push (rebase 한 commit hash 가 변경되므로 force 필요. `--force-with-lease` 는 원격이 예상한 상태일 때만 push — 다른 사람의 push 덮어씌움 방지):
+
+```bash
+pnpm lint && pnpm build && pnpm test:ci
+git rebase --continue   # 모든 conflict 해결 시
+git push --force-with-lease
+```
+
+### 2-5. 정리 + 재확인
+
+```bash
+cd <repo root>
+git worktree remove .claude/worktrees/{branch}-rebase
+gh pr view <N> --json mergeable,mergeStateStatus   # MERGEABLE 재확인
+```
+
+이 단계가 끝나면 3단계로. 단 사용자가 (d) 옵션 선택 시 fix 진행 차단 + 사용자가 수동 처리 후 재호출하도록 안내.
+
+---
+
+## 3단계: 리뷰 분류 및 우선순위 결정
 
 리뷰 댓글에서 항목을 파싱한다. 이 프로젝트에서는 claude bot이 아래 형식으로 댓글을 남긴다:
 
@@ -102,7 +181,7 @@ claude bot 외에도 GitHub formal review, 인라인 코드 댓글(`gh api .../p
 
 ---
 
-## 3단계: 코드 수정
+## 4단계: 코드 수정
 
 🔴 항목부터 처리하고, 완료 후 🟡 항목을 처리한다.
 
@@ -121,7 +200,7 @@ claude bot 외에도 GitHub formal review, 인라인 코드 댓글(`gh api .../p
 
 ---
 
-## 4단계: 검증
+## 5단계: 검증
 
 코드 수정 전에 테스트 파일 목록을 미리 저장해 둔다:
 
@@ -150,7 +229,7 @@ pnpm lint && pnpm tsc --noEmit && pnpm test --passWithNoTests
 
 ---
 
-## 5단계: Commit & Push
+## 6단계: Commit & Push
 
 commit 메시지는 이 프로젝트의 컨벤션을 따른다 (commit-convention 스킬 참조):
 
@@ -193,7 +272,7 @@ COMMIT_HASH=$(git rev-parse --short HEAD)
 
 ---
 
-## 6단계: 인라인 코멘트에 해결 내용 reply
+## 7단계: 인라인 코멘트에 해결 내용 reply
 
 코드 수정이 완료되고 push된 후, 처리한 인라인 리뷰 댓글 각각에 reply를 달아 해결됐음을 알린다.
 
@@ -245,7 +324,7 @@ ${ISSUE_URL}"
 
 ---
 
-## 7단계: 결과 보고
+## 8단계: 결과 보고
 
 완료 후 요약:
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -303,6 +303,36 @@ reply 본문 작성 원칙:
 - 리뷰가 지적한 문제와 적용한 해결책을 간결하게 기술한다
 - 건너뛴 항목(이미 반영됐거나 해당 없음)은 reply하지 않는다
 
+### ⚠️ 트리거 키워드 회피 (필수 — 사고 방지)
+
+PR/이슈 댓글 게시 시 본문에 **claude-code-review workflow 의 트리거 키워드를 절대 포함 금지**. workflow 의 if 조건이 `contains(comment.body, '/review')` 같은 substring 매칭이라 reply 본문에 그 단어가 자연스럽게 들어가도 **워크플로 재호출 사고** 발생 (사용자 토큰 낭비 + 무한 루프 위험).
+
+**금지 패턴** (claude bot trigger 키워드):
+- `/review` (정확히 이 문자열 포함 시 발동)
+- 그 외 워크플로 if 조건에서 사용하는 모든 키워드 (워크플로별로 점검)
+
+**대체 표현**:
+| 금지 | 대체 |
+|---|---|
+| `## /review 반영 완료` | `## 코드 리뷰 반영 완료` 또는 `## ✅ 반영 완료` |
+| `/review 의 머스트 픽스 처리` | `리뷰 의 머스트 픽스 처리` 또는 `머스트 픽스 처리` |
+| `/review-fix 결과` | `review-fix 결과` 또는 `리뷰 처리 결과` |
+
+**사전 검증 (게시 직전)**:
+
+```bash
+# 게시 직전 body 에서 트리거 키워드 grep
+BODY="<게시할 본문>"
+if printf '%s' "$BODY" | grep -qE '/review\b'; then
+  echo "🚫 차단: body 에 /review 트리거 키워드 포함 — 대체 표현으로 수정 후 재게시"
+  exit 1
+fi
+```
+
+이 검증을 모든 `gh pr comment` / `gh api .../comments/*/replies` 호출 직전에 수행. 사고 발생 시 사용자에게 즉시 보고하고 댓글 삭제 (`gh api repos/{repo}/issues/comments/{id} -X DELETE`) 후 재게시.
+
+**실사례**: PR #202 에 `/review-fix` 결과 reply 게시 시 body 가 "## /review 반영 완료\n\n..." 로 시작 → workflow `issue_comment` 트리거 발동 (2026-05-08T07:14:27Z). 사용자가 발견.
+
 ### 대범위 항목 — 이슈 등록 후 reply
 
 대범위로 판단한 항목은 코드 수정 대신 이슈를 등록하고 해당 댓글에 reply한다:


### PR DESCRIPTION
## Summary

작업 흐름 3건 통합 개선:

### 1. /planning + /build-with-teams 흐름 통합 (사용자 제안)

**현재 사고 패턴**:
- /planning 이 task PR 을 만들어 머지하면 결과물 없는 spec 만 main 으로 진입 → status="pending" 인 채 main 에 들어가 다른 세션에서 재실행 시 중복 작업 (실사례: fos-blog plan024/025)
- 옵션 A (이어서 작업) vs 옵션 B (별도 -impl 브랜치) 분기 결정이 매 plan 마다 발생 — skill 본문 비대 + 사용자 결정 부담

**변경**:
- **/planning**: PR 생성 폐기. `plan/{N}-{slug}` 브랜치 push 까지만 책임. PR 은 build-with-teams 가 결과물과 함께 만든다
- **/build-with-teams**: 옵션 A/B 분기 폐기. /planning 이 push 한 plan 브랜치 fetch → 같은 브랜치에서 phase commits 추가 → 결과물 + task 를 한 PR 로 묶어 생성/갱신
- **사전 검증 단순화**: 3중 체크 (main index.json + 원격 feat 브랜치 + 오픈 PR) → plan 브랜치 존재 + task 파일 존재 + 오픈 PR + 머지 이력 점검

### 2. /review-fix 에 Conflict 처리 추가

**근거**: 이번 PR #202 conflict 해결 (main 의 dependabot 머지 + react/pretendard 충돌) 패턴을 일반화. lockfile 은 항상 main 채택 + install 재생성 (자동), 코드 파일은 사용자 결정 분기.

**신규 2단계 "PR Conflict 사전 점검 및 해결"**:
- 2-1. `gh pr view --json mergeable,mergeStateStatus` 로 상태 확인
- 2-2. CONFLICTING 시 worktree 만들어 rebase 시도
- 2-3. conflict 분류 (lockfile 자동 / package.json 수동 / 코드 사용자 결정 / docs 양쪽 보존)
- 2-4. 검증 후 force-with-lease push
- 2-5. worktree 정리 + mergeable 재확인

**단계 번호 일괄 +1 갱신**: 기존 2~7단계 → 3~8단계.

## 변경 파일

- `.claude/skills/planning/SKILL.md` — "완료 후 (필수 수행 절차)" 섹션 재작성, "왜 PR 을 생성하지 않는가" 근거 추가
- `.claude/skills/build-with-teams/SKILL.md` — 사전 검증 / task 파일 단계 / 9. 완료+PR 생성 / worktree 생성 / 실행 흐름 요약 모두 신 흐름 반영. 옵션 A/B 권장 흐름 섹션 통째 삭제
- `.claude/skills/review-fix/SKILL.md` — 신규 2단계 추가, 단계 번호 +1

## 영향 받는 흐름 (이후 plan002~)

- 사용자가 `/planning plan002` 호출 → docs 갱신 + task 생성 + push (PR 미생성)
- 사용자가 `/build-with-teams plan002` 호출 → 같은 브랜치 fetch → phase 실행 → PR 생성
- PR conflict 시 `/review-fix <N>` 호출 → 2단계에서 자동 rebase + 해결

## Test plan

- [ ] plan002 (또는 다음 plan) 진행 시 신 흐름 동작 확인
  - /planning 이 PR 생성 안 하고 브랜치 push 만 하는지
  - /build-with-teams 가 같은 브랜치 fetch + PR 생성하는지
- [ ] PR 에 conflict 발생 시 /review-fix 가 2단계 처리 거치는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)