### PR TITLE
docs(plan003): expenses page redesign plan

### DIFF
--- a/tasks/plan003-expenses-redesign/index.json
+++ b/tasks/plan003-expenses-redesign/index.json
@@ -1,0 +1,58 @@
+{
+  "name": "plan003-expenses-redesign",
+  "description": "/transactions 페이지 Teal fintech 리디자인 — segmented tab(지출/수입/반복) + filter chips(카테고리/기간/금액/검색) + 일자별 그룹 + 일일 합계. 모바일+데스크톱 responsive.",
+  "status": "pending",
+  "created_at": "2026-05-09",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md",
+    "docs/code-architecture.md",
+    "CLAUDE.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 완료 (OKLCH/data-theme/Pretendard)",
+    "plan002 머지 완료 — RecentActivity 의 입력자 아바타 row 패턴 + category-tone.ts 토큰 헬퍼 재사용",
+    "handoff mockup: /tmp/handoff_fos/fos-accountbook/project/screens/{mobile,desktop}.jsx Screen 2"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "type/service/action — date 그룹 helper + 검색/금액 query param 확장 + backend 응답 실측",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "TransactionsTabs (segmented) + FilterChips 디자인 교체 (카테고리/기간)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "SearchBar + 금액 범위 필터 (Sheet/Popover) 신규",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "DateGroup + ExpenseRow/IncomeRow 행 디자인 (모바일 + 데스크톱 5-col grid)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan003-expenses-redesign/phase-01.md
+++ b/tasks/plan003-expenses-redesign/phase-01.md
@@ -1,0 +1,107 @@
+# Phase 01 — type/service/action (date 그룹 + 검색/금액 query)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: /transactions 리디자인의 데이터 토대 — 일자별 그룹 helper, 검색/금액 필터 query param 확장, backend 응답 실측.
+
+## Context (자기완결)
+
+- 현재 `src/app/(authenticated)/transactions/page.tsx` 는 `searchParams { tab, categoryId, startDate, endDate, page, limit }` 를 받아 service 호출.
+- handoff filter chips: 카테고리 / 기간 / **금액** / **검색** — `amountMin/amountMax/q` query param 신규.
+- ADR-F16 (카테고리 집계는 Server Action 측) 정신 동일하게 — 일자 그룹/일일 합계도 service 측 집계. backend endpoint 신설 회피.
+- 기존 `src/services/expense/` 에 list 서비스 있음 (실측 필요). plan002 의 `category-tone.ts` 헬퍼는 row 디자인에서 재사용.
+
+## 작업 항목
+
+### 1. backend 응답 실측 — 검색/금액 query param 지원 여부
+
+dev/staging 환경에서 `GET /families/{u}/expenses?q=foo&amountMin=1000&amountMax=50000` 호출. 결과를 phase commit message 에 명시 (`backend q/amount: 지원/미지원`).
+
+미지원 시 phase 3 의 검색/금액 필터는 클라 측 후처리 (받은 month 결과 안에서 필터). row 수가 임계 이내면 충분 (ADR-F16 임계 트리거 동일).
+
+### 2. type 추가
+
+`src/types/transaction.ts` (또는 expense.ts) 에:
+
+```ts
+export interface DateGroup<T> {
+  date: string;       // YYYY-MM-DD
+  totalAmount: number;
+  items: T[];
+}
+
+export interface TransactionFilters {
+  categoryUuid?: string;
+  startDate?: string;
+  endDate?: string;
+  amountMin?: number;
+  amountMax?: number;
+  q?: string;         // memo 검색
+}
+```
+
+### 3. service `groupTransactionsByDate(items)` 헬퍼
+
+`src/services/expense/expense-service.ts` 또는 새 파일 `src/services/transaction/transaction-service.ts`. 입력 expenses/incomes 배열, 출력 `DateGroup<T>[]` (date desc 정렬, 같은 date 안에서는 시간 desc).
+
+`expense.date` 가 ISO 문자열이면 `YYYY-MM-DD` 만 추출해 grouping key. 합계 = `Math.abs(item.amount)` 누적 (수입/지출 모두 양수).
+
+### 4. action 시그니처 확장 — 검색/금액 query
+
+기존 `getExpensesAction` (또는 동일 책임 action) 에 `amountMin?, amountMax?, q?` 옵션 인자 추가. backend 가 query param 지원 시 그대로 전달, 미지원 시 service 가 fetch 후 클라 필터.
+
+```ts
+export async function getExpensesAction(
+  filters: TransactionFilters & { tab: "expenses" | "incomes" | "recurring", page?: number },
+): Promise<ActionResult<{ items: Expense[]; dateGroups: DateGroup<Expense>[]; totalCount: number }>>
+```
+
+ADR-F04: action 은 인증·검증·service 호출만. 그룹화는 service 책임.
+
+### 5. service 단위 테스트
+
+`src/__tests__/services/transaction/groupTransactionsByDate.test.ts`. 케이스:
+- 정상 5건 → 3 date 그룹, 각 합계 정확
+- 빈 배열 → `[]`
+- 같은 date 다른 시간 → 시간 desc 정렬
+- amountMin/amountMax 클라 필터 (backend 미지원 시) 동작
+
+ADR-F09 jest.mock 방식.
+
+### 6. 자동 verification
+
+```bash
+pnpm lint
+pnpm tsc --noEmit
+pnpm test src/__tests__/services/transaction/ --run
+
+grep -nE 'DateGroup|TransactionFilters' src/types/ | wc -l   # >= 2
+grep -n 'groupTransactionsByDate' src/services/ -r | wc -l    # >= 1
+
+# ADR-F04 위반 없음
+! grep -nE 'from ["\x27]@/actions' src/services/transaction/ src/services/expense/expense-service.ts 2>/dev/null
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/types/transaction.ts` (또는 `expense.ts`) | 수정 — `DateGroup`, `TransactionFilters` 추가 |
+| `src/services/transaction/transaction-service.ts` (또는 기존 service) | 수정 — `groupTransactionsByDate` + 클라 필터 helper |
+| 기존 expenses/incomes action | 수정 — 시그니처에 `amountMin/amountMax/q` 추가 |
+| `src/__tests__/services/transaction/groupTransactionsByDate.test.ts` | 신규 |
+
+## Out of Scope
+
+- UI 컴포넌트 (phase 2~4)
+- backend `q/amountMin/amountMax` 신설 요청 — 부재 시 클라 필터로 우선 처리, plan004+ 에서 backend issue 분리
+- 페이지네이션 변경 (현재 `page/limit` 그대로)
+- `RecurringExpenseList` 의 데이터 구조 (탭 셋 안에 유지, row 디자인은 phase 4)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 월 거래수가 클라 필터 한계 (500+) 초과 | ADR-F16 임계 트리거 — backend query param 도입 plan 분리 |
+| backend 가 `q` 만 지원하고 `amount*` 미지원 (또는 반대) | service 측 hybrid — backend 지원 query 는 server, 미지원은 client. 결과는 동일 shape |
+| 그룹 key 가 timezone 영향 받음 | `date-timezone.ts` (이미 utils 에 있음) 사용 — UTC 기반 통일 |

--- a/tasks/plan003-expenses-redesign/phase-02.md
+++ b/tasks/plan003-expenses-redesign/phase-02.md
@@ -1,0 +1,84 @@
+# Phase 02 — TransactionsTabs (segmented) + FilterChips 디자인 교체
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 탭 UI 를 일반 탭에서 segmented control (rounded pill) 로 교체 + 기존 카테고리/기간 필터 chip 디자인을 handoff chip 패턴으로.
+
+## Context (자기완결)
+
+- 현재 `src/app/(authenticated)/transactions/_components/TransactionsPageClient.tsx` 가 탭 분기. 탭 UI 가 어떤 컴포넌트 (shadcn `Tabs` 등) 인지 실측 필요.
+- handoff segmented (mobile.jsx line 348~366):
+  - container: `bg-bg-muted rounded-md p-1`
+  - tab item: `flex-1 text-center py-2 text-sm font-semibold`
+  - active: `bg-bg-elev shadow-subtle text-fg`
+  - inactive: `text-fg-muted`
+- handoff filter chip (mobile.jsx line 369~382):
+  - `border border-border bg-bg-elev rounded-full px-3 py-1.5 text-xs text-fg-muted` + chevDown 아이콘
+- 데스크톱 mockup 의 chip 은 사각형 (`rounded-md`) — 모바일은 pill (`rounded-full`). 동일 컴포넌트, responsive 처리.
+
+## 작업 항목
+
+### 1. `TransactionsTabs` 신규 (segmented)
+
+`src/app/(authenticated)/transactions/_components/TransactionsTabs.tsx`. Props: `activeTab: "expenses"|"incomes"|"recurring"`, `onChange?: (tab) => void`. URL searchParams 기반 (next/navigation `useRouter`/`useSearchParams`) — 기존 페이지 패턴 유지.
+
+shadcn `Tabs` 가 내부 라디오 그룹 — wrap 또는 자체 구현. 자체 구현 권장 (handoff 디자인 정확 반영). 3 탭 (지출/수입/반복지출) 고정.
+
+### 2. `FilterChips` 디자인 교체
+
+기존 카테고리/기간 필터 트리거 컴포넌트 위치 파악 → 디자인 교체. handoff chip 패턴:
+- pill / rounded-md (mobile / desktop responsive)
+- chevDown lucide 아이콘 (`size={13}`)
+- 활성 상태 (값 선택됨): `border-brand-300 bg-brand-50 text-brand-700`
+- 기본: `border-border bg-bg-elev text-fg-muted`
+
+### 3. 기존 필터 트리거 호환
+
+기존 카테고리/기간 필터의 모달/sheet/popover 동작은 유지 — 트리거(chip) 디자인만 교체. Sheet/Dialog 본문은 plan003 범위 외.
+
+검색/금액 chip 자리는 phase 3 에서 신규 도입 — phase 2 에서는 placeholder chip (disabled, "준비 중") 표시 또는 자리만 잡고 비표시.
+
+### 4. `TransactionsPageClient.tsx` 통합
+
+기존 탭/필터 영역을 `<TransactionsTabs />` + `<FilterChips />` 로 교체. URL searchParams 동작 보존 — page.tsx 의 `searchParams` 파싱 로직은 변경 없음.
+
+### 5. 자동 verification
+
+```bash
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/transactions/_components/TransactionsTabs.tsx
+grep -n 'TransactionsTabs' src/app/\(authenticated\)/transactions/ -r | wc -l   # >= 2
+
+# segmented 디자인 토큰 사용
+grep -nE 'bg-bg-muted|bg-bg-elev|shadow-subtle' src/app/\(authenticated\)/transactions/_components/TransactionsTabs.tsx | wc -l   # >= 2
+
+# URL searchParams 보존
+grep -nE 'useSearchParams|useRouter' src/app/\(authenticated\)/transactions/_components/TransactionsTabs.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/transactions` → segmented tab 3개 표시. 탭 클릭 시 URL `?tab=...` 변화 + 페이지 데이터 갱신. 필터 chip 디자인 새 토큰.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/transactions/_components/TransactionsTabs.tsx` | 신규 |
+| `src/app/(authenticated)/transactions/_components/FilterChips.tsx` | 신규 또는 기존 트리거 수정 |
+| `src/app/(authenticated)/transactions/_components/TransactionsPageClient.tsx` | 수정 (tab/filter 통합) |
+
+## Out of Scope
+
+- 검색 / 금액 필터 도입 (phase 3)
+- 카테고리/기간 모달 본문 디자인 (기존 동작 유지, plan004+ 에서 검토)
+- Row 디자인 (phase 4)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| shadcn `Tabs` API 와 handoff segmented 시각이 안 맞을 수 있음 | 자체 구현 (rounded-md container + 활성 토큰) — shadcn 의존 X |
+| URL searchParams 동기화 깨짐 | 기존 useRouter/useSearchParams 로직을 그대로 wrap, 변경 최소화 |
+| 키보드 접근성 (탭 키 이동) | 자체 구현 시 `role="tablist"` / `role="tab"` + arrow key 처리. WAI-ARIA 패턴 준수 |

--- a/tasks/plan003-expenses-redesign/phase-03.md
+++ b/tasks/plan003-expenses-redesign/phase-03.md
@@ -1,0 +1,88 @@
+# Phase 03 — SearchBar + 금액 범위 필터 신규
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff 의 "검색" + "금액" filter chip + 본문(Sheet/Popover) 신규 도입.
+
+## Context (자기완결)
+
+- phase 1 결과로 `TransactionFilters.amountMin/amountMax/q` type + service 측 클라/서버 필터 로직 준비됨.
+- handoff mockup:
+  - 검색: 데스크톱 우측 240px input box (mobile.jsx 의 search 아이콘은 클릭 시 필드 노출 가정). desktop.jsx line 419~427.
+  - 금액 chip: filter chips 의 한 항목. 클릭 시 sheet/popover 에 min/max input 2개.
+- 모바일 검색은 expand-on-click 패턴 — 헤더의 search 아이콘 클릭 → 검색 input 노출. 데스크톱은 항상 노출.
+- shadcn `Sheet` 또는 `Popover` 가 이미 사용 중. 금액 필터 본문에 적합.
+
+## 작업 항목
+
+### 1. `SearchBar` 컴포넌트
+
+`src/app/(authenticated)/transactions/_components/SearchBar.tsx`.
+- 데스크톱: 항상 노출, `Input` (shadcn) + Search 아이콘.
+- 모바일: 트리거 아이콘 (헤더 우측) + 클릭 시 `Sheet` 또는 inline expand.
+- `useSearchParams` 의 `q` 와 동기화. 디바운스 300ms (lodash.debounce 미의존 — `setTimeout` 직접).
+
+URL 라우팅 — `?q=foo` 파라미터로 page.tsx 가 다시 fetch. 기존 페이지 패턴 (탭/카테고리) 동일.
+
+### 2. `AmountRangeFilter` 컴포넌트
+
+`src/app/(authenticated)/transactions/_components/AmountRangeFilter.tsx`.
+- chip trigger (phase 2 의 FilterChips 안에 통합 또는 별도)
+- popover/sheet 본문: `min` + `max` 두 input + "적용" / "초기화" 버튼
+- `Input type="number" inputMode="numeric"` + 천 단위 콤마 표시 (display only — 값은 raw number)
+- 활성 시 chip 라벨에 값 표시 (예: "1만~5만"). 미선택 시 "금액"
+
+### 3. URL 동기화 + 기존 page.tsx 통합
+
+기존 `searchParams` 인터페이스에 `q?, amountMin?, amountMax?` 추가. action 호출에 전달. 필터 변경 시 `router.replace('/transactions?' + new URLSearchParams(...))` 패턴.
+
+### 4. 빈 결과 / 로딩 처리
+
+검색/필터 결과 0건 시 "조건에 맞는 거래가 없어요" 안내 + 필터 초기화 링크. 로딩 중 (debounce 진행 중) skeleton 또는 기존 Suspense 활용.
+
+### 5. 자동 verification
+
+```bash
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/transactions/_components/SearchBar.tsx
+test -f src/app/\(authenticated\)/transactions/_components/AmountRangeFilter.tsx
+
+# URL searchParams 동기화
+grep -nE 'q\?:|amountMin\?:|amountMax\?:' src/app/\(authenticated\)/transactions/page.tsx | wc -l   # >= 3
+
+# 디바운스 300ms
+grep -n 'setTimeout.*300\|debounce.*300' src/app/\(authenticated\)/transactions/_components/SearchBar.tsx | wc -l   # >= 1
+```
+
+수동 smoke:
+- `/transactions` → 검색 input (데스크톱) 또는 검색 아이콘 (모바일) 클릭 → 검색어 타이핑 → 300ms 후 결과 갱신
+- 금액 chip 클릭 → popover/sheet → 1만~5만 입력 → "적용" → 결과 갱신, chip 라벨에 "1만~5만"
+- "초기화" 클릭 → URL 에서 amount 파라미터 제거
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/transactions/_components/SearchBar.tsx` | 신규 |
+| `src/app/(authenticated)/transactions/_components/AmountRangeFilter.tsx` | 신규 |
+| `src/app/(authenticated)/transactions/page.tsx` | 수정 — searchParams 인터페이스 확장 |
+| `src/app/(authenticated)/transactions/_components/TransactionsPageClient.tsx` | 수정 — chips 영역에 통합 |
+
+## Out of Scope
+
+- 검색 자동완성 / 최근 검색어 기록 (plan004+)
+- 금액 슬라이더 UI (현재 numeric input 으로 충분)
+- 검색 결과 하이라이트 (메모 안 keyword 강조) — plan004+
+- 다중 카테고리 선택 (현재 단일 categoryId 유지)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| backend `q` 또는 `amount*` 미지원 (phase 1 점검 결과) | service 측 클라 필터로 fallthrough — UI 동작은 동일, 단 페이지네이션 수치는 클라 필터 후 재계산 필요. phase 1 의 service 책임 |
+| URL 길이 폭증 (모든 필터 조합) | 빈 값은 URL 에서 제거 (`URLSearchParams` 정제). 기본값 1KB 이내 |
+| 디바운스 중 빠른 입력 시 race condition | latest-wins 패턴 — 가장 최근 입력만 적용. AbortController 또는 setState 콜백 |
+| 모바일 Sheet/Popover 가 가상 키보드와 충돌 | shadcn Sheet 의 `side="bottom"` + 가상 키보드 푸시 동작 확인 |

--- a/tasks/plan003-expenses-redesign/phase-04.md
+++ b/tasks/plan003-expenses-redesign/phase-04.md
@@ -1,0 +1,97 @@
+# Phase 04 — DateGroup + Row 디자인 (모바일 + 데스크톱 5-col grid)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 일자별 그룹 + 일일 합계 + Row 새 디자인 (모바일 카드형 / 데스크톱 5-col grid).
+
+## Context (자기완결)
+
+- phase 1 의 `groupTransactionsByDate` service + `DateGroup<T>` type 활용.
+- handoff Mobile (mobile.jsx line 384~412):
+  - 그룹 헤더: 날짜 (12.5px font-semibold text-fg-muted) + "합계 ₩X" (11.5px text-fg-subtle)
+  - 카드: `bg-bg-elev rounded-md border-border` 안에 TxRow 여러 개, 행 간 divider
+- handoff Desktop (desktop.jsx line 432~492):
+  - 그룹 헤더: 날짜 (13px font-bold) + 합계 (12px font-semibold text-fg-muted)
+  - DTTxRowFull: 5-col grid `44px 1fr 110px 28px 140px`
+    - 컬럼 1: CatIcon 38px
+    - 컬럼 2: memo + time
+    - 컬럼 3: 카테고리 chip (tinted bg/fg)
+    - 컬럼 4: 입력자 Avatar 22px
+    - 컬럼 5: 금액 right-aligned, 15px font-bold
+- plan002 의 `category-tone.ts` 헬퍼 + `--color-cat-*` 토큰 재사용.
+- plan002 의 RecentActivity Row 패턴이 모바일 TxRow 와 동일 — 컴포넌트 추출 검토.
+
+## 작업 항목
+
+### 1. `TransactionRow` 추출 (재사용 컴포넌트)
+
+`src/components/transactions/TransactionRow.tsx` 신규. plan002 의 RecentActivity 안 row 와 통합. Props: `tx: Expense | Income`, `variant: "compact" | "full"`.
+- compact (모바일): 카테고리 아이콘 + 메모/카테고리·시간 + 금액/아바타 — plan002 행 패턴과 동일
+- full (데스크톱): 5-col grid
+
+plan002 의 RecentActivity 가 이 컴포넌트를 import 하도록 리팩토링 (한 곳에서 row 정의 단일 소스).
+
+### 2. `DateGroupSection` 컴포넌트
+
+`src/components/transactions/DateGroupSection.tsx`. Props: `group: DateGroup<Expense | Income>`. 헤더 (날짜 + 합계) + 카드 안에 `TransactionRow` 리스트.
+
+날짜 포맷 헬퍼 (`formatDateHeader(date)` — "오늘 / 어제 / N월 N일 (요일)") `src/lib/utils/date-format.ts` 또는 기존 utils 재사용.
+
+### 3. `ExpenseList` / `IncomeList` 통합
+
+기존 `src/components/expenses/list/ExpenseList.tsx` 와 `src/components/incomes/list/IncomeList.tsx` 의 row 렌더 부분을 `DateGroupSection` 호출로 교체. 데이터를 `groupTransactionsByDate` (phase 1) 로 그룹화 후 전달.
+
+`RecurringExpenseList` 는 데이터 모델이 다름 (반복 스케줄) → 본 phase 에서 행 디자인만 동일 토큰 (TransactionRow 안 쓰고 별도 row, 단 색/typography 토큰 통일). 일자 그룹 미적용.
+
+### 4. 빈 상태 / 페이지네이션
+
+빈 결과: phase 3 의 빈 상태 메시지 일관 적용. 페이지네이션은 기존 `page/limit` 그대로 — DateGroup 단위로 끊지 않고 expenses 단위로 끊은 후 클라에서 그룹화.
+
+### 5. 자동 verification
+
+```bash
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/transactions/TransactionRow.tsx
+test -f src/components/transactions/DateGroupSection.tsx
+
+# 5-col desktop grid
+grep -nE 'grid-cols\[44px|md:grid-cols' src/components/transactions/TransactionRow.tsx | wc -l   # >= 1
+
+# 카테고리 톤 토큰 사용 (plan002 helper)
+grep -n 'category-tone\|--color-cat-' src/components/transactions/TransactionRow.tsx | wc -l   # >= 1
+
+# plan002 RecentActivity 가 TransactionRow 사용
+grep -n 'TransactionRow' src/components/dashboard/RecentActivity.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/transactions` 각 탭 → 일자별 그룹 + 합계 표시. 모바일/데스크톱 viewport 전환 시 row 디자인 변경. 카테고리 chip 색이 카테고리에 따라 달라짐.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/transactions/TransactionRow.tsx` | 신규 (compact/full variant) |
+| `src/components/transactions/DateGroupSection.tsx` | 신규 |
+| `src/components/expenses/list/ExpenseList.tsx` | 수정 — DateGroupSection 사용 |
+| `src/components/incomes/list/IncomeList.tsx` | 수정 — DateGroupSection 사용 |
+| `src/components/dashboard/RecentActivity.tsx` | 수정 — TransactionRow 재사용 |
+| `src/lib/utils/date-format.ts` | 신규 또는 수정 (formatDateHeader) |
+
+## Out of Scope
+
+- `RecurringExpenseList` row 디자인 (토큰만 적용, 그룹화 없음)
+- 거래 행 클릭 → 상세 sheet (기존 동작 유지)
+- 무한 스크롤 (현재 페이지네이션 유지)
+- 카테고리 chip 클릭 → 필터 적용 (drill-down) — plan004+
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| plan002 RecentActivity 와 row 통합 시 prop shape 충돌 | `TransactionRow` 가 union prop 받고 내부 분기. plan002 머지 후 패턴 점검 |
+| 페이지네이션 경계가 DateGroup 가운데 끊김 | UX 허용 — 다음 페이지 첫 그룹이 같은 날짜라도 별도 헤더 표시. 또는 클라 합치기 (오버엔지니어링 — 본 plan OOS) |
+| `RecurringExpenseList` 의 데이터 형식이 expenses/incomes 와 다름 | 별도 row 컴포넌트 (`RecurringRow`) 유지. TransactionRow 는 그룹화 가능한 거래만 |
+| 모바일/데스크톱 row 차이가 Tailwind responsive 만으로 어색할 수 있음 | variant prop 명시 (`compact`/`full`) — 단순 responsive 보다 명시적 분기. 5-col grid 는 `md:grid` 로 분기 |

--- a/tasks/plan003-expenses-redesign/phase-05.md
+++ b/tasks/plan003-expenses-redesign/phase-05.md
@@ -1,0 +1,90 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, legacy 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: type/service (1) + Tabs/FilterChips (2) + Search/AmountFilter (3) + DateGroup/Row (4).
+- legacy 잔재 후보: 기존 탭 UI 파편 (shadcn `<Tabs>` 의존 코드), 기존 row 디자인 (ExpenseList 의 inline JSX).
+- `_shared/common-pitfalls.md § 1-8` 패턴 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` 출력 후 어느 phase 산출물이 회귀를 만들었는지 식별 + 보고.
+
+### 2. 신규 컴포넌트 / 헬퍼 등록 확인
+
+```bash
+test -f src/app/\(authenticated\)/transactions/_components/TransactionsTabs.tsx
+test -f src/app/\(authenticated\)/transactions/_components/SearchBar.tsx
+test -f src/app/\(authenticated\)/transactions/_components/AmountRangeFilter.tsx
+test -f src/components/transactions/TransactionRow.tsx
+test -f src/components/transactions/DateGroupSection.tsx
+
+grep -n 'DateGroup\|TransactionFilters' src/types/ -r | wc -l   # >= 2
+grep -n 'groupTransactionsByDate' src/services/ -r | wc -l       # >= 1
+```
+
+### 3. 탭/필터 동작 검증 (URL searchParams)
+
+```bash
+# searchParams 인터페이스에 q/amountMin/amountMax 추가됨
+grep -nE 'q\?:|amountMin\?:|amountMax\?:' src/app/\(authenticated\)/transactions/page.tsx | wc -l   # >= 3
+
+# segmented 디자인 토큰 사용
+grep -nE 'bg-bg-muted|bg-bg-elev|shadow-subtle' src/app/\(authenticated\)/transactions/_components/TransactionsTabs.tsx | wc -l   # >= 2
+
+# plan002 RecentActivity 가 TransactionRow 재사용
+grep -n 'TransactionRow' src/components/dashboard/RecentActivity.tsx | wc -l   # >= 1
+```
+
+### 4. Hardcoded 색 잔재 0건 (plan001/002 효과 회귀 방지)
+
+```bash
+grep -rnE '#[0-9a-fA-F]{6}\b|hsl\(|rgb\(' src/components/transactions/ src/app/\(authenticated\)/transactions/ \
+  | grep -vE 'rgba\(255,\s*255,\s*255'
+# 결과 0줄
+```
+
+### 5. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan003-expenses-redesign/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan003-expenses-redesign/index.json
+grep -c '"status": "completed"' tasks/plan003-expenses-redesign/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan003-expenses-redesign/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan003-expenses-redesign/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan003-expenses-redesign/index.json` | 모든 status `completed` |
+| `tasks/plan003-expenses-redesign/phase-05.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- 시각 회귀 비교 스크린샷 (수동 smoke 항목으로만)
+- backend issue 등록 (q/amount 미지원 케이스) — plan004+ 사용자 결정
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 안 문자열) | JSX 태그 패턴 / 라인 시작 앵커 사용 |
+| macOS BSD `sed -i ''` vs Linux GNU `sed -i` | 본 plan macOS 환경 가정 (fos-blog 동일) |


### PR DESCRIPTION
## Summary

- /transactions 페이지 Teal fintech 리디자인 plan
- 5 phase: type/service → tabs/chips → search/amount → DateGroup/Row → 검증
- ADR-F16 reuse (일자별 그룹도 Server Action 측 집계)
- plan002 RecentActivity 와 TransactionRow 통합 — row 단일 소스

## 핵심 결정 (사용자 confirmed)

- 3탭 유지 (지출/수입/반복지출) — 시각만 segmented control
- filter 풀 기능 (금액/검색 모두 작동) — backend query 미지원 시 클라 필터 fallthrough
- 일자 그룹 + 일일 합계 = 클라이언트 집계 (ADR-F16 정신)
- 한 plan 에 모바일 + 데스크톱 (plan002 동일 패턴)

## 다음 단계

PR 머지 후 \`/build-with-teams plan003-expenses-redesign\` 호출 → phase 자동 실행 → 별도 PR 자동 생성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)