### PR TITLE
docs(claude): main branch protection 명시 (PR 우회 필수)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ Page (app/) → Action (actions/) → Service (services/) → lib/server/api
 
 ## Git & PR Conventions
 
+**main 직접 push 차단됨** — branch protection 으로 `git push origin main` 이 항상 거부된다 (`Changes must be made through a pull request`). 모든 변경은 작업 브랜치(`plan/NNN-...`, `chore/...`, `feat/...` 등) 에 commit + push 후 `gh pr create` 로 PR 생성. task 파일 + docs 변경도 동일 — 직접 push 시도하지 말고 처음부터 브랜치 + PR 패턴.
+
 PR 제목은 반드시 아래 형식을 따른다:
 
 ```


### PR DESCRIPTION
## Summary

- CLAUDE.md \`## Git & PR Conventions\` 섹션 첫 단락에 main 직접 push 차단 사실 명시
- 다음 세션이 매번 직접 push 시도 → 거부 → PR 우회 사이클을 반복하지 않도록 사전 안내

## 배경

plan001 (PR #201/202), plan003 (PR #205) 작성 시마다 main 직접 push 시도 → branch protection 거부 → PR 우회 사이클 반복. 한 줄 명시로 다음 세션 시간 절약.

🤖 Generated with [Claude Code](https://claude.com/claude-code)