### PR TITLE
chore(ci): claude code review workflow 를 fos-blog 패턴으로 동일화

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-name: Claude Code Review
+name: Claude 코드 리뷰
 
 on:
   pull_request:
@@ -17,9 +17,13 @@ jobs:
          contains(github.event.comment.body, '/review'))
       )
     runs-on: ubuntu-latest
+    # 정상 리뷰는 5~10분 내 완료. claude-code-action 이 hang 하는 경우
+    # (issue anthropics/claude-code-action#1290 등) GitHub Actions 기본 360분까지 대기되어
+    # 이전 stuck run 이 1.5시간 동안 방치된 사고 발생 — job-level timeout 으로 자동 fail.
     timeout-minutes: 15
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+    # 같은 PR에 대해 동시에 실행 중인 이전 리뷰 run을 취소하여 중복 코멘트 방지
     concurrency:
       group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
@@ -31,7 +35,7 @@ jobs:
       checks: write
 
     steps:
-      - name: Checkout repository
+      - name: 저장소 체크아웃
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
@@ -67,44 +71,36 @@ jobs:
           echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> "$GITHUB_ENV"
           echo "Check Run 시작: id=$CHECK_RUN_ID head_sha=$HEAD_SHA"
 
-      - name: Minimize old Claude bot comments
+      # 이전 봇 댓글 minimize 가 아닌 DELETE — minimized 블록 누적으로 PR 스레드가 지저분해지는
+      # 사고 회피 (fos-blog 정착 패턴). 이력 보존은 GitHub event log 로 충분.
+      - name: 이전 Claude 봇 댓글 삭제
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ env.PR_NUMBER }}"
 
-          # 이전 일반 PR 코멘트 숨기기
+          # 이전 일반 PR 코멘트 삭제 (claude[bot] 작성)
           gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "claude[bot]") | .node_id' \
-            | while read -r node_id; do
-              if [ -n "$node_id" ]; then
-                echo "Minimizing outdated Claude comment: $node_id"
-                gh api graphql -f query='
-                  mutation($id: ID!) {
-                    minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
-                      minimizedComment { isMinimized }
-                    }
-                  }' -f id="$node_id" || true
+            --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+            | while read -r comment_id; do
+              if [ -n "$comment_id" ]; then
+                echo "오래된 Claude 일반 댓글 삭제 중: $comment_id"
+                gh api "repos/$REPO/issues/comments/$comment_id" --method DELETE || true
               fi
             done
 
-          # 이전 인라인 리뷰 코멘트 숨기기
+          # 이전 인라인 리뷰 코멘트 삭제 (claude[bot] 작성)
           gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "claude[bot]") | .node_id' \
-            | while read -r node_id; do
-              if [ -n "$node_id" ]; then
-                echo "Minimizing outdated Claude inline comment: $node_id"
-                gh api graphql -f query='
-                  mutation($id: ID!) {
-                    minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
-                      minimizedComment { isMinimized }
-                    }
-                  }' -f id="$node_id" || true
+            --jq '.[] | select(.user.login == "claude[bot]") | .id' \
+            | while read -r comment_id; do
+              if [ -n "$comment_id" ]; then
+                echo "오래된 Claude 인라인 댓글 삭제 중: $comment_id"
+                gh api "repos/$REPO/pulls/comments/$comment_id" --method DELETE || true
               fi
             done
 
-      - name: Run Claude Code Review
+      - name: Claude 코드 리뷰 실행 (병렬 에이전트 + 인라인 리뷰)
         # v1 floating tag 가 install.sh 에서 silently 교체된 binary tarball 로 깨진 후
         # (issue anthropics/claude-code-action#1290, 2026-05-06 회귀) v1.0.111 로 pin.
         # upstream 픽스 후 다시 v1 으로 풀 것.
@@ -113,42 +109,53 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "*"
           prompt: |
-            You are a code review orchestrator for the fos-accountbook project (Next.js 16 family budget app).
-            Your job is to coordinate 4 parallel specialist reviewers, then post a single GitHub review.
+            당신은 fos-accountbook 프로젝트(Next.js 16 App Router 가족 가계부, TypeScript, NextAuth v5, Tailwind CSS v4 + Shadcn) 의 코드 리뷰 orchestrator 입니다.
+            4 개의 병렬 specialist reviewer 를 조율한 뒤 다음을 수행합니다:
+            1. GitHub review API 를 통해 변경된 라인에 인라인 리뷰 댓글 게시 (event: COMMENT)
+            2. 모든 발견사항을 모은 일반 요약 댓글 1 개 게시
 
-            ## Step 1: Fetch PR Data
+            ## 1단계: PR 데이터 수집
 
-            Run these commands first (lock files and snapshots are excluded from diff to reduce noise):
+            먼저 다음 명령을 실행한다 (lock 파일과 snapshot 은 noise 감소를 위해 diff 에서 제외됨):
             ```
             gh pr diff ${{ env.PR_NUMBER }} --repo ${{ github.repository }} -- ':!pnpm-lock.yaml' ':!*.lock' ':!*.snap'
             gh pr view ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --json title,body,additions,deletions
             ```
 
-            If the diff is empty after filtering, post a short approving review and stop.
+            필터링 후 diff 가 비어 있으면 짧은 긍정 댓글을 게시하고 종료한다.
 
-            ## Finding Format (used by all agents)
+            ## 2단계: 4 개 병렬 specialist 에이전트 spawn
 
-            Each agent outputs findings in this exact structure:
+            Agent tool 을 사용해 4 개 에이전트를 **동시에** 실행한다.
+            **각 에이전트는 반드시 `model: "haiku"` 를 사용** 해 토큰 사용을 최소화한다.
+            각 에이전트의 prompt 에 필터링된 전체 diff 를 전달한다.
+
+            각 에이전트는 반드시 다음 EXACT 구조로 발견사항을 포맷한다 (parse-friendly):
 
             ```
             FINDING_START
-            TYPE: INLINE or GENERAL
-            SEVERITY: 🔴 or 🟡
-            PATH: src/components/foo.tsx  (INLINE only — relative path matching diff)
-            LINE: 42                       (INLINE only — line number in new file)
+            TYPE: INLINE
+            SEVERITY: 🔴
+            PATH: src/components/foo.tsx
+            LINE: 42
             ISSUE: 문제 설명 (한국어)
             FIX: 수정 제안 (한국어)
             FINDING_END
+
+            FINDING_START
+            TYPE: GENERAL
+            SEVERITY: 🟡
+            ISSUE: 특정 라인을 꼬집기 어려운 일반적인 문제 (한국어)
+            FIX: 수정 제안 (한국어)
+            FINDING_END
             ```
-            - `TYPE: INLINE` — exact file+line identified in diff
-            - `TYPE: GENERAL` — spans multiple files or cannot be pinpointed
-            - No issues → output: `NO_ISSUES`
 
-            ## Step 2: Spawn 4 Parallel Specialist Agents
-
-            Launch all 4 agents **simultaneously** using the Agent tool.
-            **Each agent MUST use `model: "haiku"`** to minimize token usage.
-            Pass the full filtered diff in each agent's prompt.
+            TYPE 선택 규칙:
+            - diff 에서 정확한 파일 경로와 라인 번호를 식별 가능할 때만 `TYPE: INLINE` 사용
+            - PATH 는 diff 와 매치되는 상대 경로 (예: `src/components/foo.tsx`)
+            - LINE 은 NEW 파일 (diff 의 RIGHT 측, `+` 또는 context 라인) 의 실제 라인 번호
+            - 여러 파일에 걸치거나 단일 라인을 특정 못 하는 경우 `TYPE: GENERAL` 사용
+            - 발견사항이 전혀 없으면 `NO_ISSUES` 출력
 
             ---
 
@@ -156,20 +163,30 @@ jobs:
 
             Prompt:
             ```
-            You are a TypeScript specialist reviewer. Analyze this PR diff for type safety issues ONLY.
+            당신은 TypeScript specialist reviewer 입니다. 이 PR diff 를 타입 안전성 이슈만 분석한다.
 
             PR DIFF:
-            <insert full diff here>
+            <여기에 전체 diff 삽입>
 
-            Check for:
-            - `any` type (explicit or implicit)
-            - Non-nullable types that could be null/undefined at runtime
-            - Type assertions (`as X`) that bypass safety
-            - Incorrect return types on Server Actions or async functions
-            - Type definitions that don't match actual API response shape
+            확인 항목:
+            - `any` 타입 사용 (명시적 또는 암시적)
+            - 런타임에 null/undefined 가능한 non-nullable 타입 (optional chaining 누락)
+            - 안전성을 우회하는 타입 단언 (`as X`)
+            - Server Action 또는 async 함수의 잘못된 반환 타입
+            - 실제 API 응답 형태와 일치 안 하는 타입 정의
 
-            Output findings using the FINDING_START/FINDING_END format.
-            If no issues, output: NO_ISSUES
+            각 발견사항을 다음 형식 그대로 출력한다:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
+            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            발견사항이 없으면 `NO_ISSUES` 출력.
             ```
 
             ---
@@ -178,24 +195,36 @@ jobs:
 
             Prompt:
             ```
-            You are a code convention specialist. Analyze this PR diff for convention violations ONLY.
+            당신은 코드 컨벤션 specialist 입니다. 이 PR diff 를 컨벤션 위반만 분석한다.
 
             PR DIFF:
-            <insert full diff here>
+            <여기에 전체 diff 삽입>
 
-            🔴 MUST FIX:
-            - Hardcoded color values (`from-blue-500`, `#hexcolor`, `bg-white/20`) in JSX/TSX
-              → use semantic classes: gradient-expense, gradient-income, gradient-budget, gradient-primary, etc.
-            - `alert()`, `confirm()`, `prompt()` → use `toast` from sonner
-            - `console.log` in production code
+            🔴 필수 수정:
+            - JSX/TSX 의 하드코딩 색상 (`from-blue-500`, `#hexcolor`, `bg-white/20`)
+              → 시맨틱 클래스 사용: gradient-expense, gradient-income, gradient-budget, gradient-primary 등
+            - hex/rgb/hsl 직접 작성 (ADR-F13: OKLCH 토큰만)
+            - `alert()`, `confirm()`, `prompt()` → sonner `toast` 사용
+            - 프로덕션 코드의 `console.log`
+            - `.dark` 클래스 신규 추가 (ADR-F15: `[data-theme="dark"]` 만)
 
-            🟡 SHOULD FIX:
-            - `console.error` in client components
-            - Inline `style={{ }}` replaceable with Tailwind
-            - Magic numbers/strings without constants
+            🟡 권장 수정:
+            - 클라이언트 컴포넌트의 `console.error` (사용자 피드백 state 없이 단독)
+            - Tailwind 클래스로 표현 가능한 inline `style={{ }}` (단일 토큰은 `text-[var(--token)]` arbitrary class)
+            - 상수로 추출해야 할 매직 넘버/문자열
 
-            Output findings using the FINDING_START/FINDING_END format.
-            If no issues, output: NO_ISSUES
+            각 발견사항을 다음 형식 그대로 출력한다:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
+            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            발견사항이 없으면 `NO_ISSUES` 출력.
             ```
 
             ---
@@ -204,23 +233,34 @@ jobs:
 
             Prompt:
             ```
-            You are a security specialist. Analyze this PR diff for security issues ONLY.
+            당신은 security specialist 입니다. 이 PR diff 를 보안 이슈만 분석한다.
 
             PR DIFF:
-            <insert full diff here>
+            <여기에 전체 diff 삽입>
 
-            🔴 MUST FIX:
-            - Server Actions missing requireAuth() at start
-            - Env vars without NEXT_PUBLIC_ used in client components
-            - Unvalidated user input passed to external APIs
-            - Missing authorization (user can access other users' data)
+            확인 항목:
+            🔴 필수 수정:
+            - Server Action 시작에 `requireAuth()` 또는 `requireAuthOrRedirect()` 누락
+            - 클라이언트 컴포넌트에서 `NEXT_PUBLIC_` prefix 없는 환경변수 사용 (시크릿 노출)
+            - 검증 안 된 외부 입력이 외부 API 또는 DB 쿼리에 직접 전달
+            - 권한 검증 누락 (사용자가 다른 가족의 데이터 접근 가능)
 
-            🟡 SHOULD FIX:
-            - Missing Zod validation at form submissions / API boundaries
-            - Sensitive data logged to console
+            🟡 권장 수정:
+            - 폼 제출 / API 경계에서 Zod 검증 누락 (ADR-F06)
+            - 민감 데이터 (토큰, 가족 uuid 등) 가 console 에 로깅됨
 
-            Output findings using the FINDING_START/FINDING_END format.
-            If no issues, output: NO_ISSUES
+            각 발견사항을 다음 형식 그대로 출력한다:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
+            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            발견사항이 없으면 `NO_ISSUES` 출력.
             ```
 
             ---
@@ -229,43 +269,49 @@ jobs:
 
             Prompt:
             ```
-            You are a Next.js architecture specialist. Analyze this PR diff for architectural issues ONLY.
+            당신은 Next.js architecture specialist 입니다. 이 PR diff 를 아키텍처 이슈만 분석한다.
 
             PR DIFF:
-            <insert full diff here>
+            <여기에 전체 diff 삽입>
 
-            This project uses Next.js 16 App Router with layered architecture:
-            Page → Action (auth/validation/revalidatePath) → Service (API calls) → lib/server/api
+            이 프로젝트는 Next.js 16 App Router + 계층형 아키텍처를 사용한다:
+            Page → Action (auth/Zod/revalidatePath) → Service (API 호출) → lib/server/api
 
-            🔴 MUST FIX:
-            - React hooks (useState, useEffect, etc.) in Server Components (missing "use client")
-            - Server-only code in Client Components
-            - "use client"/"use server" not at the very first line
-            - Business logic (API calls) in Action layer instead of Service layer
-            - revalidatePath / requireAuth called from Service layer
+            🔴 필수 수정:
+            - Server Component 에서 React hooks (useState, useEffect, useRouter 등) 사용 ("use client" 누락)
+            - Client Component 에 server-only 코드 (백엔드 토큰 사용, requireAuth 등)
+            - "use client" 또는 "use server" directive 가 파일 첫 줄에 위치하지 않음
+            - Action 레이어에 비즈니스 로직 (API 호출) 혼재 — Service 책임 위반 (ADR-F04)
+            - Service 레이어에서 `revalidatePath` / `requireAuth` 호출 (ADR-F04)
+            - Page (Server Component) 에서 `serverApiGet` 직접 호출 (ADR-F12: Action 경유 필수)
 
-            🟡 SHOULD FIX:
-            - Unnecessary "use client" on components with no hooks/event handlers
-            - Data fetching in Client Components moveable to Server Components
-            - Missing loading.tsx or error.tsx for new routes
-            - Stale form state when dialog reopens
+            🟡 권장 수정:
+            - hooks/이벤트 핸들러 없는 컴포넌트의 불필요한 "use client" (Server Component 여야 함)
+            - Server Component 로 처리 가능한데 Client Component 에서 데이터 fetch
+            - 신규 라우트의 loading.tsx 또는 error.tsx 누락
+            - 다이얼로그 재오픈 시 stale form state
 
-            Output findings using the FINDING_START/FINDING_END format.
-            If no issues, output: NO_ISSUES
+            각 발견사항을 다음 형식 그대로 출력한다:
+
+            FINDING_START
+            TYPE: INLINE or GENERAL
+            SEVERITY: 🔴 or 🟡
+            PATH: exact/relative/path.ts  (INLINE 만 — diff 경로와 정확히 매치)
+            LINE: 42  (INLINE 만 — 새 파일의 정확한 라인 번호)
+            ISSUE: 한국어로 문제 설명
+            FIX: 한국어로 수정 제안
+            FINDING_END
+
+            발견사항이 없으면 `NO_ISSUES` 출력.
             ```
 
-            ## Step 3: Post Single GitHub Review
+            ## 3단계: 인라인 리뷰 댓글 게시
 
-            After all 4 agents complete, collect and deduplicate all FINDING_START/FINDING_END blocks.
+            4 개 에이전트 완료 후 모든 FINDING_START/FINDING_END 블록을 수집하고 중복 제거한다.
 
-            Determine the review event:
-            - If ANY 🔴 finding exists → `"REQUEST_CHANGES"`
-            - Otherwise → `"APPROVE"`
+            모든 `TYPE: INLINE` 발견사항을 모아 단일 GitHub PR review 를 만든다.
 
-            Build a single GitHub review containing:
-            - `body`: summary of all findings (both INLINE and GENERAL)
-            - `comments`: array of inline comments for TYPE: INLINE findings
-            - `event`: APPROVE or REQUEST_CHANGES
+            JSON 을 구성하고 다음 명령 실행 (comments 배열은 실제 파싱한 발견사항으로 교체):
 
             ```bash
             gh api repos/${{ github.repository }}/pulls/${{ env.PR_NUMBER }}/reviews \
@@ -273,11 +319,10 @@ jobs:
               --header "Content-Type: application/json" \
               --input - <<'REVIEW_EOF'
             {
-              "event": "APPROVE or REQUEST_CHANGES",
-              "body": "## 코드 리뷰 — [PR 제목 요약]\n\n[한 줄 전체 평가]\n\n---\n\n### 🔴 머스트 픽스\n\n...\n\n### 🟡 개선 권장\n\n...\n\n### 🟢 잘 된 점\n\n- ...\n\n---\n🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (Sonnet orchestrator · Haiku specialists: TypeScript · Conventions · Security · Architecture)",
+              "event": "COMMENT",
               "comments": [
                 {
-                  "path": "src/example.tsx",
+                  "path": "src/components/foo.tsx",
                   "line": 42,
                   "side": "RIGHT",
                   "body": "🔴 **문제**: ...\n\n**수정**: ..."
@@ -287,27 +332,66 @@ jobs:
             REVIEW_EOF
             ```
 
-            JSON `body` / inline `body` 필드 안의 `\n` 은 JSON parser 가 해석하므로 정상.
-            **단** 별도 `gh pr comment --body "..."` 형태로 추가 댓글을 게시할 일이 생기면 반드시
-            `--body-file - <<'EOF' ... EOF` HEREDOC 패턴 사용 — 큰따옴표 안의 `\n` 은 shell 이
-            literal 두 글자 그대로 GitHub API 에 전달해 댓글 포매팅이 깨진다 (fos-blog 관측 사고).
+            각 인라인 댓글 body 포맷:
+            `{SEVERITY} **문제**: {ISSUE}\n\n**수정**: {FIX}`
 
-            ## Review Body Format (Korean)
+            중요 규칙:
+            - `event` 는 항상 `"COMMENT"` (REQUEST_CHANGES 사용 안 함 — 머지 차단 방지, 리뷰는 권고)
+            - `path` 는 diff 와 정확히 매치되는 상대 경로 (앞에 `/` 추가 금지)
+            - `line` 은 해당 파일의 diff 에 등장하는 숫자여야 함 — 불확실하면 GENERAL 로 처리
+            - `side` 는 항상 `"RIGHT"` (NEW 파일 측)
+            - 인라인 발견사항이 없으면 이 단계 전체 skip
+            - `gh api` 호출이 실패하면 (예: 422 invalid line) 에러를 로그하고 재시도 없이 4단계로 진행
 
-            ```
-            ## 코드 리뷰 — [PR 제목 요약]
+            ## 4단계: 일반 요약 댓글 게시
+
+            모든 발견사항 (INLINE + GENERAL) 을 포함하는 일반 요약 댓글을 정확히 1 개 게시한다.
+
+            **CRITICAL — body 전달 방식**: 반드시 `--body-file -` + HEREDOC 패턴을 사용한다.
+            `--body "...\n..."` 처럼 큰따옴표 안에 `\n` escape 를 쓰면 shell 이 literal 두 글자
+            (`\` + `n`) 그대로 GitHub API 에 전달해 댓글 본문이 깨진다 (실제 줄바꿈으로 렌더 안 됨).
+
+            ```bash
+            gh pr comment ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --body-file - <<'COMMENT_EOF'
+            ## 코드 리뷰 [PR 제목 요약]
 
             [한 줄 전체 평가]
 
             ---
 
-            ### 🔴 머스트 픽스 (있는 경우만)
+            ### 🔴 머지 전 필수 수정 (있는 경우만)
 
-            **파일명:라인** 문제: ... / 수정: ...
+            ...
+
+            (이하 요약 댓글 포맷 그대로 — 실제 줄바꿈으로 작성)
+            COMMENT_EOF
+            ```
+
+            HEREDOC 안에서는 `\n` escape 없이 **실제 newline** 만 사용한다. backtick 코드 블록,
+            한국어, 이모지 모두 `'COMMENT_EOF'` (single-quoted) 안에서 안전하게 통과.
+
+            ## 요약 댓글 포맷
+
+            한국어로 작성. 다음 구조 그대로 사용:
+
+            ```
+            ## 코드 리뷰 [PR 제목 요약]
+
+            [한 줄 전체 평가]
+
+            ---
+
+            ### 🔴 머지 전 필수 수정 (있는 경우만)
+
+            **파일명 라인번호**
+            문제: ...
+            수정: ...
 
             ### 🟡 개선 권장 (있는 경우만)
 
-            **파일명:라인** 문제: ... / 수정: ...
+            **파일명 라인번호**
+            문제: ...
+            수정: ...
 
             ### 🟢 잘 된 점
 
@@ -315,37 +399,74 @@ jobs:
 
             ---
             🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (Sonnet orchestrator · Haiku specialists: TypeScript · Conventions · Security · Architecture)
+            💬 인라인 코멘트는 **Files changed** 탭에서 확인하세요
             ```
 
-            ## Critical Rules
+            ## 핵심 규칙
 
             - **PR 브랜치에 어떠한 파일도 git add / commit / push 금지** — review 작업은 read-only +
-              GitHub API 호출만. 임시 파일 (예: `.claude-pr/summary.md`) 도 만들지 말 것.
-              디스크에 파일을 만든 후 읽는 패턴 금지 (action wrapper 의 `git add -A` 가 그 파일을
-              PR 브랜치 commit 으로 흘려보냄 — fos-blog PR #83 실제 사고). API body 는 항상
-              stdin (`--input -` HEREDOC) 으로만 전달.
+              GitHub API 호출만. 임시 파일 (예: `.claude-pr/summary.md`) 도 만들지 말 것. 요약 댓글은
+              반드시 `gh pr comment ... --body-file - <<'COMMENT_EOF' ... COMMENT_EOF` HEREDOC 으로
+              stdin 전달만 사용. 디스크에 파일을 만든 후 읽는 패턴 금지 (action wrapper 의 `git add -A`
+              가 그 파일을 PR 브랜치 commit 으로 흘려보냄 — fos-blog PR #83 실제 사고).
             - **테스트 / 더미 / placeholder 댓글 게시 절대 금지** — 실제 production 리뷰임.
               사용자 토큰 낭비 + review-fix 흐름 오염. 게시 직전 다음 sanity check 통과해야 한다:
-              - body 가 `🔴`/`🟡` severity 마커 + `**문제**:` + `**수정**:` 패턴을 모두 포함하는가?
+              - body 가 specialist agent FINDING 의 `🔴`/`🟡` + `**문제**:` + `**수정**:` 패턴을 모두 포함하는가?
               - body 에 `test body`, `test 1`, `sample`, `placeholder`, `example`, `<여기에>`,
                 `{ISSUE}`, `{FIX}` 같은 dummy / template 잔재가 없는가?
               - body 가 12자 미만이거나 의미 있는 한국어 문장 0개면 reject
-              위 셋 중 하나라도 실패하는 entry 는 즉시 제거 후 게시. inline `comments` 배열이
-              비면 `comments` 키 자체를 생략하고 review body 에 "발견사항 없음 — 인라인 코멘트
-              skip" 한 줄로 갈음 (fos-blog PR #114 실제 사고 — Claude action 이 자연어 가이드를
-              무시하고 "test body" 같은 placeholder 게시).
-            - **Post exactly ONE review** — do not call the reviews API more than once
-            - **Do NOT post a separate general comment** — the review body IS the summary
-            - **Only include sections that have content** — omit empty 🔴 or 🟡 sections
-            - **If zero issues found**, post APPROVE review with 🟢 section only, no comments array
-            - **Be specific** — reference exact file names and line numbers
-            - Format inline comment body as: `{SEVERITY} **문제**: {ISSUE}\n\n**수정**: {FIX}`
-            - `path` must be relative (no leading `/`), exactly matching the diff
-            - `line` must appear in the diff — if unsure, treat as GENERAL in the body
-            - `side` is always `"RIGHT"`
-            - If `gh api` returns 422, log the error and do NOT retry
+              위 셋 중 하나라도 실패하는 entry 는 즉시 제거 후 게시. comments 배열이 비면 3단계
+              review 게시 자체 skip + 4단계 일반 요약 댓글에 "발견사항 없음 — 인라인 review skip"
+              한 줄로 갈음 (fos-blog PR #114 실제 사고).
+            - **일반 댓글은 정확히 1 개만 게시** (4단계) — `gh pr comment` 를 두 번 이상 호출 금지
+            - **인라인 리뷰 (3단계) 와 일반 댓글 (4단계) 은 분리** — 발견사항이 있으면 둘 다 게시
+            - **내용이 있는 섹션만 포함** — 비어 있는 🔴 또는 🟡 섹션은 완전히 생략
+            - **구체적으로 작성** — 정확한 파일명과 라인 번호 참조
+            - **이슈가 0 개면** 3단계 skip 후 4단계에서 🟢 섹션만 있는 짧은 긍정 댓글 작성
+            - **일반 댓글 작성 시 반드시 `--body-file -` HEREDOC 사용** — `--body "...\n..."` 는
+              shell 이 `\n` 을 literal 로 처리해 댓글 포매팅이 깨진다 (4단계의 CRITICAL 참조).
+              3단계의 인라인 review JSON body 안의 `\n` 은 JSON parser 가 해석하므로 정상.
 
-          claude_args: '--model claude-sonnet-4-6 --allowedTools "Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'
+          claude_args: '--model claude-sonnet-4-6 --allowedTools "Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'
+
+      # 게시된 인라인 댓글 중 dummy / 길이 미달 / 마커 부재 entry 를 자동 정리
+      # — Claude action 이 자연어 sanity check 를 무시하고 "test body" / "test2"
+      # 같은 placeholder 를 게시하는 사고 (fos-blog PR #114 관측) 를 강제 차단.
+      # always 실행해도 안전: 정상 댓글은 패턴에 매치 안 됨.
+      - name: 게시된 인라인 댓글의 dummy / 미달 entry 자동 삭제
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ env.PR_NUMBER }}"
+
+          # claude[bot] 가 작성한 인라인 댓글만 검사
+          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "claude[bot]") | "\(.id)\t\(.body)"' \
+            | while IFS=$'\t' read -r comment_id body; do
+              [ -z "$comment_id" ] && continue
+
+              # 정리 조건 (하나라도 만족하면 삭제):
+              # 1) 본문 길이 12자 미만
+              # 2) /^test\s*\d*$/i 같은 단순 placeholder (test, test1, test 2, sample, foo 등)
+              # 3) 🔴 / 🟡 severity 마커 부재 (정상 review 형식 미준수)
+              len=${#body}
+              should_delete=0
+
+              if [ "$len" -lt 12 ]; then
+                should_delete=1
+              elif printf '%s' "$body" | grep -qiE '^(test|sample|placeholder|foo|bar|example)[[:space:]]*[0-9]*$'; then
+                should_delete=1
+              elif ! printf '%s' "$body" | grep -qE '🔴|🟡'; then
+                should_delete=1
+              fi
+
+              if [ "$should_delete" = "1" ]; then
+                echo "dummy 인라인 댓글 자동 삭제: id=$comment_id body=\"$body\""
+                gh api "repos/$REPO/pulls/comments/$comment_id" --method DELETE || true
+              fi
+            done
 
       # 작업 결과를 /review 댓글에 ✅/❌ reaction 으로 표시 (success/failure 분기, always 실행)
       - name: /review 댓글에 종료 reaction 추가

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -149,29 +149,36 @@
 
 ---
 
-## ADR-F11: CI 코드 리뷰 워크플로 설계 (2026-04-04)
+## ADR-F11: CI 코드 리뷰 워크플로 설계 (2026-04-04, 2026-05-09 개정)
 
-**결정**: Claude Code Action 기반 자동 코드 리뷰 워크플로를 아래 방침으로 운영
+**결정**: Claude Code Action 기반 자동 코드 리뷰 워크플로를 아래 방침으로 운영. fos-blog 정착 패턴과 동일화 (2026-05-09 개정).
 
 **핵심 결정 사항**:
 
 | 항목 | 결정 | 이유 |
 |------|------|------|
 | 트리거 | `opened` + `/review` 수동 | `synchronize` 제거 — 매 push마다 토큰 소비 방지 |
-| Review Event | 🔴 → `REQUEST_CHANGES`, 없으면 `APPROVE` | PR 머지 안전망 역할 |
-| 일반 코멘트 | 제거 — Review body로 통합 | Review API의 body 필드가 요약 역할. 별도 코멘트는 중복 |
-| 코멘트 정리 | minimize (OUTDATED) | delete보다 이력 보존에 유리. 인라인 리뷰 코멘트도 포함 |
+| Review Event | 항상 `COMMENT` (🔴 있어도 차단 안 함) | 리뷰는 권고. 머지 차단은 인간 reviewer 책임. `REQUEST_CHANGES` 사고 회피 |
+| 일반 요약 댓글 | 인라인 리뷰와 분리해 1회 추가 게시 | Conversation 탭 가시성 확보. inline 만 두면 Files changed 탭에 묻힘 |
+| 댓글 정리 | DELETE (REST) | minimize 누적 시 PR 스레드 시각 답답. 이력은 GitHub event log 로 충분 |
+| Dummy 댓글 자동 정리 | post-step bash 로 길이/regex/severity 마커 검사 후 삭제 | Claude action 이 자연어 sanity check 무시하고 placeholder 게시하는 사고 (fos-blog PR #114) 강제 차단 |
 | 모델 | orchestrator=sonnet, specialist=haiku | 토큰 비용 최적화. haiku로 충분한 단일 관점 분석 |
-| allowed_bots | 필요한 봇만 명시 | `"*"` 와일드카드 보안 위험. 봇 추가 시 명시적 업데이트 |
+| allowed_bots | `"*"` | 광범위 허용 — Dependabot/Claude 모두 차단되지 않음. 보안 검증은 specialist agent 가 담당 |
 | diff 필터 | `pnpm-lock.yaml`, `*.lock`, `*.snap` 제외 | 노이즈 감소 |
 | Job timeout | 15분 | agent hang 시 불필요한 비용 방지 |
-| 프롬프트 관리 | yml 인라인 유지 | 4개 agent 규모에서 파일 분리는 오버엔지니어링. 단일 파일에서 전체 흐름 파악 가능 |
-| 소규모 PR 스킵 | 안 함 | 추후 재논의. 현재는 모든 PR 동일 리뷰 |
+| Check Run 수동 등록 | `issue_comment` 트리거 시 수동 생성 | issue_comment workflow run 이 PR Checks 탭에 자동 노출 안 됨 — 수동 Check Run 으로 진행 상태 가시화 |
+| 프롬프트 관리 | yml 인라인 유지 | 4개 agent 규모에서 파일 분리는 오버엔지니어링 |
+| 소규모 PR 스킵 | 안 함 | 모든 PR 동일 리뷰 |
 
-**트레이드오프**:
-- `/review` 수동 트리거는 리뷰를 잊을 수 있음 → `opened` 시 자동 1회 실행으로 보완
-- `REQUEST_CHANGES`는 머지를 차단할 수 있음 → 의도적 안전망으로 수용
-- minimize된 코멘트가 쌓이면 PR 스레드가 길어질 수 있음 → OUTDATED 라벨로 접힌 상태이므로 가독성 영향 최소
+**대안 기각**:
+- `REQUEST_CHANGES` event 유지: PR 머지 버튼 비활성으로 사용자가 매번 dismiss 해야 함 + Reviews 탭 빨간 X 가 시각적으로 부정적. 안전망 가치보다 마찰 비용 큼.
+- minimize 유지: PR 스레드에 minimized 블록 누적 → "Show outdated" 토글이 보이고 답답. 이력은 GitHub Activity 탭에서 보존.
+- 단일 review API 호출 (요약을 review body 안에): Files changed 탭에만 보이고 Conversation 탭에서 요약 가시성 떨어짐.
+
+**HEREDOC 패턴 강제 (실측 사고)**:
+- 일반 요약 댓글은 반드시 `gh pr comment --body-file - <<'COMMENT_EOF' ... COMMENT_EOF` HEREDOC 으로 stdin 전달.
+- `gh pr comment --body "...\n..."` 패턴은 shell 이 `\n` 을 literal 두 글자로 전달해 댓글 줄바꿈 깨짐.
+- review JSON body 안의 `\n` 은 JSON parser 가 해석하므로 정상.
 
 ---
 


### PR DESCRIPTION
## Summary

3개 레포(fos-accountbook / fos-blog / fos-accountbook-backend)의 claude-code-review.yml 비교 후 fos-blog 패턴으로 동일화. 시각 품질 개선 + 사고 방지.

## 변경 항목

| 항목 | Before | After |
|---|---|---|
| Review event | REQUEST_CHANGES (🔴 있을 때) / APPROVE | 항상 COMMENT (권고형) |
| 이전 봇 댓글 처리 | minimize (OUTDATED) GraphQL | DELETE REST |
| 요약 댓글 위치 | review body 안에 통합 | 별도 \`gh pr comment\` 추가 게시 |
| Dummy 댓글 정리 | prompt sanity check 만 의존 | post-step bash 자동 삭제 |

## 사용자 체감 개선

1. **PR 머지 차단 사라짐** — 빨간 X 대신 중립 댓글
2. **PR 스레드 깨끗** — 이전 리뷰 minimize 누적 사라짐
3. **요약 가시성** — Conversation 탭에서 한눈에 보임
4. **placeholder 댓글 자동 청소** — \`test body\` 같은 사고 차단

## 유지

- Check Run 수동 등록 (issue_comment 트리거가 PR Checks 탭 노출되는 fos-accountbook 고유 기능)
- /review reaction (👀 → +1/-1)
- 4-agent fan-out (TypeScript / Conventions / Security / Architecture)
- Sonnet orchestrator + Haiku specialist 모델 라우팅

## ADR-F11 개정

정책 변경 사항을 ADR-F11 에 반영 (2026-05-09 개정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)