### PR TITLE
chore(ci): claude review 댓글의 literal \n 두 글자 자동 보정

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -429,6 +429,48 @@ jobs:
 
           claude_args: '--model claude-sonnet-4-6 --allowedTools "Agent,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*)" --disallowedTools "Read,Write,Edit,Glob,Grep,LS"'
 
+      # 게시된 댓글 본문에 literal `\n` 두 글자가 박힌 경우 자동 보정.
+      # 사고 패턴: Claude action 이 prompt 의 `--body-file - <<'COMMENT_EOF'` HEREDOC
+      # 가이드를 무시하고 `gh pr comment --body "...\n..."` 호출 → shell 이 큰따옴표 안
+      # `\n` 을 literal 두 글자로 GitHub API 에 전달 → 마크다운 렌더 시 줄바꿈 안 됨.
+      # 실측 사고: PR #208 일반 댓글 (id 4412740228). jq contains("\\n") 으로 검출 후
+      # perl 로 실제 newline 으로 교체, PATCH API 로 본문 갱신.
+      - name: 게시된 댓글의 literal \n 두 글자 자동 보정
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          PR_NUMBER="${{ env.PR_NUMBER }}"
+
+          fix_one() {
+            local kind="$1"   # issues 또는 pulls
+            local id="$2"
+            local body
+            body=$(gh api "repos/$REPO/$kind/comments/$id" --jq .body)
+            if printf '%s' "$body" | grep -q '\\n'; then
+              echo "[literal \\n 검출] $kind#$id 본문 보정 중..."
+              local fixed
+              fixed=$(printf '%s' "$body" | perl -pe 's/\\n/\n/g')
+              gh api "repos/$REPO/$kind/comments/$id" --method PATCH \
+                --field body="$fixed" >/dev/null || true
+            fi
+          }
+
+          # 일반 PR 댓글 (issue comments)
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body | contains("\\n")) | .id' \
+            | while read -r id; do
+              [ -n "$id" ] && fix_one "issues" "$id"
+            done
+
+          # 인라인 리뷰 댓글 (PR review comments)
+          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "claude[bot]") | select(.body | contains("\\n")) | .id' \
+            | while read -r id; do
+              [ -n "$id" ] && fix_one "pulls" "$id"
+            done
+
       # 게시된 인라인 댓글 중 dummy / 길이 미달 / 마커 부재 entry 를 자동 정리
       # — Claude action 이 자연어 sanity check 를 무시하고 "test body" / "test2"
       # 같은 placeholder 를 게시하는 사고 (fos-blog PR #114 관측) 를 강제 차단.

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -162,6 +162,7 @@
 | 일반 요약 댓글 | 인라인 리뷰와 분리해 1회 추가 게시 | Conversation 탭 가시성 확보. inline 만 두면 Files changed 탭에 묻힘 |
 | 댓글 정리 | DELETE (REST) | minimize 누적 시 PR 스레드 시각 답답. 이력은 GitHub event log 로 충분 |
 | Dummy 댓글 자동 정리 | post-step bash 로 길이/regex/severity 마커 검사 후 삭제 | Claude action 이 자연어 sanity check 무시하고 placeholder 게시하는 사고 (fos-blog PR #114) 강제 차단 |
+| literal `\n` 자동 보정 | post-step bash 로 검출 후 perl 교체 + PATCH API | Claude action 이 HEREDOC 무시하고 `--body "...\n..."` 호출 시 literal 두 글자 박힘 (PR #208 사고). 보정 후 정상 줄바꿈 |
 | 모델 | orchestrator=sonnet, specialist=haiku | 토큰 비용 최적화. haiku로 충분한 단일 관점 분석 |
 | allowed_bots | `"*"` | 광범위 허용 — Dependabot/Claude 모두 차단되지 않음. 보안 검증은 specialist agent 가 담당 |
 | diff 필터 | `pnpm-lock.yaml`, `*.lock`, `*.snap` 제외 | 노이즈 감소 |


### PR DESCRIPTION
## Summary

PR #207 (workflow 동일화) 머지 후속 — Claude action 의 HEREDOC 무시 사고 회피책 한 단계 더 추가.

## 배경

PR #208 의 일반 댓글 (id 4412740228) 본문이 literal `\n` 두 글자로 깨져 있는 사고 발견:

```
## 코드 리뷰 — feat(dashboard): plan002 Teal fintech 리디자인\n\n전체적으로...
```

원인: Claude action 이 prompt 의 `--body-file - <<'COMMENT_EOF'` HEREDOC 가이드를 무시하고 `gh pr comment --body "...\n..."` 형태로 호출 → shell 이 literal 두 글자로 GitHub API 에 전달 → 마크다운 줄바꿈 안 됨.

PR #207 의 prompt 가이드 (자연어) 만으로는 Claude action 의 무시 행동을 막지 못함. fos-blog 도 동일 한계.

## 변경

post-step 추가 — `게시된 댓글의 literal \n 두 글자 자동 보정`:

1. `jq contains("\\n")` 으로 claude[bot] 작성 댓글 중 사고 케이스 검출
2. `perl -pe 's/\\n/\n/g'` 로 실제 newline 으로 교체
3. `PATCH /repos/.../comments/{id}` 로 본문 갱신
4. 일반 PR 댓글 + 인라인 리뷰 댓글 둘 다 대상

ADR-F11 정책 표에 항목 한 줄 추가.

## 효과

- Claude action 이 다음 사고를 일으켜도 사용자 눈에 보이기 전에 자동 보정
- 정상 댓글은 패턴 매치 안 되므로 영향 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)