### PR TITLE
docs(claude.md): plan task/구현 브랜치 분리 규칙 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,22 @@ type(scope): description
 
 이 형식에서 절대 벗어나지 않는다.
 
+### Plan 브랜치 분리 규칙
+
+plan task 와 실제 구현은 **분리된 브랜치 + 분리된 PR** 로 관리한다.
+
+| 단계 | 브랜치 | 내용 | 머지 후 |
+|---|---|---|---|
+| 계획 | `plan/{N}-{slug}` | `tasks/plan{N}-{slug}/` task 파일 + docs 갱신 | task 가 main 에 반영 |
+| 구현 | `feat/plan{N}-{slug}` | phase 별 코드 commit | 실제 기능이 main 에 반영 |
+
+**왜?** 머지 이력에서 "무엇이 계획이고 무엇이 구현인가" 즉시 식별. 검토 부담도 분산.
+
+**적용**:
+- `/planning N` → `plan/{N}-{slug}` 에 task + docs commit + PR
+- `/build-with-teams N` → main 의 task 를 base 로 **`feat/plan{N}-{slug}` 신규 브랜치** 생성 후 phase 실행
+- build-with-teams 사전 검증 4번이 plan task PR 머지를 잡아도 정상 — task-only 머지이므로 무시하고 신 브랜치로 진행
+
 ---
 
 ## PR 체크리스트

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,36 +177,25 @@ Page (app/) → Action (actions/) → Service (services/) → lib/server/api
 
 ## Git & PR Conventions
 
-**main 직접 push 차단됨** — branch protection 으로 `git push origin main` 이 항상 거부된다 (`Changes must be made through a pull request`). 모든 변경은 작업 브랜치(`plan/NNN-...`, `chore/...`, `feat/...` 등) 에 commit + push 후 `gh pr create` 로 PR 생성. task 파일 + docs 변경도 동일 — 직접 push 시도하지 말고 처음부터 브랜치 + PR 패턴.
+- **main 직접 push 차단** — branch protection 으로 거부됨. 모든 변경은 작업 브랜치 + PR (task 파일/docs 도 동일).
+- **PR 제목**: `type(scope): description` — 절대 벗어나지 않는다.
 
-PR 제목은 반드시 아래 형식을 따른다:
+### 브랜치 명명
 
-```
-type(scope): description
-```
+| 단계 | 브랜치 | 내용 |
+|---|---|---|
+| 계획 | `plan/{N}-{slug}` | `tasks/plan{N}-{slug}/` task 파일 + docs 갱신 (→ main 머지) |
+| 구현 | `feat/plan{N}-{slug}` | task 의 phase 별 코드 commit (→ main 머지) |
+| 기타 | `chore/...` · `fix/...` · `refactor/...` · `docs/...` | 일반 작업 |
 
-예시:
+plan 의 계획/구현 분리는 머지 이력에서 즉시 식별 + 검토 부담 분산이 목적.
+`/build-with-teams` 사전검증 4번이 task-only 머지를 잡아도 정상 — `feat/plan{N}-{slug}` 신 브랜치로 진행.
+
+### 예시
+
 - `feat(backend): add Prometheus config`
 - `fix(database): resolve Redis connection timeout`
 - `docs(task): add NSC slot engine abstraction`
-
-이 형식에서 절대 벗어나지 않는다.
-
-### Plan 브랜치 분리 규칙
-
-plan task 와 실제 구현은 **분리된 브랜치 + 분리된 PR** 로 관리한다.
-
-| 단계 | 브랜치 | 내용 | 머지 후 |
-|---|---|---|---|
-| 계획 | `plan/{N}-{slug}` | `tasks/plan{N}-{slug}/` task 파일 + docs 갱신 | task 가 main 에 반영 |
-| 구현 | `feat/plan{N}-{slug}` | phase 별 코드 commit | 실제 기능이 main 에 반영 |
-
-**왜?** 머지 이력에서 "무엇이 계획이고 무엇이 구현인가" 즉시 식별. 검토 부담도 분산.
-
-**적용**:
-- `/planning N` → `plan/{N}-{slug}` 에 task + docs commit + PR
-- `/build-with-teams N` → main 의 task 를 base 로 **`feat/plan{N}-{slug}` 신규 브랜치** 생성 후 phase 실행
-- build-with-teams 사전 검증 4번이 plan task PR 머지를 잡아도 정상 — task-only 머지이므로 무시하고 신 브랜치로 진행
 
 ---
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -69,18 +69,30 @@
 
 ---
 
-## ADR-F05: ky HTTP 클라이언트
+## ADR-F05: ky HTTP 클라이언트 (2026-05-09 v2 갱신)
 
-**결정**: axios 대신 ky 사용
+**결정**: axios 대신 ky 사용. **2026-05-09**: ky 1.x → 2.x 업그레이드 (plan004).
 
 **이유**:
 
-- Node 18+ native fetch 기반 → 추가 polyfill 없음
+- Node 22+ native fetch 기반 → 추가 polyfill 없음
 - 번들 크기: ky ~4KB vs axios ~13KB
 - TypeScript 타입 기본 제공
 - 자동 재시도 설정이 간결 (`retry` 옵션)
 
-**재시도 설정**: 408, 429, 5xx → 최대 2회 재시도
+**재시도 설정**: 408, 413, 429, 500, 502, 503, 504 → 최대 2회 재시도
+
+**ky 2.x 마이그레이션 결정 (2026-05-09)**:
+
+| 항목 | 결정 | 이유 |
+|---|---|---|
+| URL 베이스 옵션 | `prefixUrl` → `prefix` rename | 단순 string join 으로 현재 동작 유지. `baseUrl` 은 standard URL resolution 으로 leading slash 의미 달라져 회귀 위험 |
+| Hook signature | 단일 state object (`{request, options, retryCount, ...}`) | ky 2.0 강제 변경. 기존 위치 인자 폐지 |
+| `.json()` 빈 body 처리 | 204 / 빈 body 응답 분기에 명시 가드 | ky 2.0 이 빈 body / 204 에서 throw — 우리 응답 envelope (`ApiResponse<T>`) 가 모든 200 응답을 가정하므로 가드 필수 |
+| `HTTPError.data` 활용 | `beforeError` / catch 의 `.json().catch(() => null)` 패턴 제거 | ky 2.0 이 자동 파싱 + resource leak 해결. 코드 단순화 |
+| `beforeError` 시그니처 | 객체 인자 + 모든 에러 받음 (HTTPError 한정 아님) | ky 2.0 변경. `error.response` 가 undefined 가능 → 명시 가드 |
+
+**적용 범위**: `src/lib/server/api/client.ts`, `src/__mocks__/ky.ts`.
 
 ---
 

--- a/tasks/plan004-ky-v2-migration/index.json
+++ b/tasks/plan004-ky-v2-migration/index.json
@@ -1,0 +1,51 @@
+{
+  "name": "plan004-ky-v2-migration",
+  "description": "ky 1.14.3 → 2.0.2 major upgrade — Node 22 요구는 충족. prefixUrl → prefix rename, hook signature 단일 state object, .json() 빈 body throw 가드, HTTPError.data 자동 파싱 활용. PR #193 (Dependabot) 대체.",
+  "status": "pending",
+  "created_at": "2026-05-09",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "prerequisites": [
+    "ADR-F05 갱신 commit (이 PR 포함) — ky 2.x 결정 사항 docs 동기화",
+    "PR #193 (Dependabot ky bump) 은 본 plan PR 머지 후 close — 사용자 결정"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "package.json bump + Hook signature 단일 state object 마이그레이션",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "prefixUrl → prefix rename + leading slash 처리 점검",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": ".json() 빈 body 가드 + HTTPError.data 활용으로 catch 단순화",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "src/__mocks__/ky.ts 갱신 — HTTPError.data 속성 + 신 hook 시그니처",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan004-ky-v2-migration/phase-01.md
+++ b/tasks/plan004-ky-v2-migration/phase-01.md
@@ -1,0 +1,96 @@
+# Phase 01 — package.json bump + Hook signature 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: ky 의존성을 1.14.3 → 2.0.2 로 bump + 3개 hook (`beforeRequest`/`afterResponse`/`beforeError`) 시그니처를 ky 2.0 의 단일 state object 로 재작성.
+
+## Context (자기완결)
+
+- 사용처 단일 파일: `src/lib/server/api/client.ts` (316줄). hook 위치:
+  - `beforeRequest` — line 73 — 인자 `(request)` → `({ request, options })`
+  - `afterResponse` — line 97 — 인자 `(_request, _options, response)` → `({ request, options, response, retryCount })`
+  - `beforeError` — line 139 — 인자 `(error)` → `(error, { request, options })` (모든 에러 받음, `error.response` undefined 가능)
+- ky 2.0 release note: 모든 hook 이 단일 state object 받음. ADR-F05 갱신 (이 PR docs 변경) 참조.
+- `prefixUrl` rename / `.json()` 빈 body / `HTTPError.data` 활용은 phase 2~3 에서 처리. phase 01 은 dep bump + hook 변환만.
+
+## 작업 항목
+
+### 1. package.json + lock bump
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+pnpm add ky@^2.0.2
+```
+
+`package.json` 의 `"ky": "^1.14.3"` → `"^2.0.2"`. `pnpm-lock.yaml` 자동 갱신. 다른 dep 영향 0.
+
+### 2. `beforeRequest` hook 변환
+
+기존: `(request) => { ... request.headers.set(...) ... logRequest(request.method, request.url, ...) ... }`
+신규: `({ request }) => { ... }` (destructuring). 본문 그대로 — `request` 객체 동일.
+
+### 3. `afterResponse` hook 변환
+
+기존: `async (_request, _options, response) => { ... }`
+신규: `async ({ request, response, retryCount }) => { ... }` (destructuring).
+
+내부에서 `_request` → `request` 로 변수명 통일. 사용 안 하는 `options` / `retryCount` 는 destructuring 에서 생략 가능.
+
+### 4. `beforeError` hook 변환
+
+기존: `async (error) => { ... if (response) { ... } ... return error; }`
+신규: `async (error, { request, options }) => { ... }`.
+
+ky 2.0 변경: 이제 모든 에러를 받음 (HTTPError 한정 아님). `error.response` 가 undefined 일 수 있으므로 기존 line 143 `if (response)` 가드 그대로 보존 — 추가 변경 0. `request`/`options` state 는 사용 안 하면 destructuring 생략.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+pnpm install   # lock 동기화
+pnpm tsc --noEmit
+pnpm lint
+
+# package.json 의 ky 버전
+grep '"ky"' package.json   # = "^2.0.2"
+
+# hook signature — 단일 객체 인자 형태인지
+grep -nE 'beforeRequest:\s*\[\s*\(\s*\{' src/lib/server/api/client.ts | wc -l   # >= 1
+grep -nE 'afterResponse:\s*\[\s*async\s*\(\s*\{' src/lib/server/api/client.ts | wc -l   # >= 1
+# beforeError 는 (error, { ... }) 형태 — 첫 인자가 error 그대로
+grep -nE 'beforeError:\s*\[\s*async\s*\(\s*error,' src/lib/server/api/client.ts | wc -l   # >= 1
+
+# 기존 위치 인자 패턴 0건
+! grep -nE 'beforeRequest:\s*\[\s*\(\s*request\s*\)' src/lib/server/api/client.ts
+! grep -nE 'afterResponse:\s*\[\s*async\s*\(\s*_request,\s*_options' src/lib/server/api/client.ts
+```
+
+수동 smoke (`pnpm dev`):
+- 로그인 → 대시보드 → 데이터 fetch 정상 (요청/응답 로그 정상 출력)
+- 404 endpoint 호출 시 에러 메시지 정상 (`beforeError` 동작)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `package.json` / `pnpm-lock.yaml` | bump (^1.14.3 → ^2.0.2) |
+| `src/lib/server/api/client.ts` | 3개 hook 시그니처 재작성 |
+
+## Out of Scope
+
+- `prefixUrl` rename (phase 2)
+- `.json()` 빈 body 가드 (phase 3)
+- `HTTPError.data` 활용 (phase 3)
+- `__mocks__/ky.ts` 업데이트 (phase 4)
+- `NetworkError`, `totalTimeout` 등 신규 기능 도입 — 본 plan 범위 외, 후속 plan 검토
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| pnpm install 시 다른 dep 가 ky 1.x peer 의존 가능성 | install 후 `pnpm list ky` 로 단일 버전 확인. peer 충돌 시 보고 |
+| TypeScript 타입 에러 — `Options` / `KyOptions` 가 v2 에서 형 변경 | tsc --noEmit 으로 잡음. 잡히는 위치는 hook 외에는 거의 없을 것 (사용처 client.ts 단일) |
+| Node 22 미만 환경에서 빌드 실패 | project memory + package.json `"node": "22.x"` 일치 — 영향 없음. 사용자 로컬 환경만 점검 |

--- a/tasks/plan004-ky-v2-migration/phase-02.md
+++ b/tasks/plan004-ky-v2-migration/phase-02.md
@@ -1,0 +1,96 @@
+# Phase 02 — prefixUrl → prefix rename + leading slash 처리
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: ky 2.0 의 `prefixUrl` 폐지에 따라 `prefix` 옵션으로 rename. 현재 동작 (단순 string join) 유지.
+
+## Context (자기완결)
+
+- ky 2.0 변경: `prefixUrl` → `prefix` rename + leading slash 허용 (1f2ad7f).
+- 우리 코드:
+  - `client.ts:65` `prefixUrl: API_URL`
+  - `client.ts:189~192` endpoint 의 leading slash 제거 (`endpoint.slice(1)`) — ky 1.x 의 prefixUrl 가 leading slash 입력을 거부했기 때문
+- ky 2.0 의 `prefix` 는 leading slash 입력 허용 — 이론상 slice(1) 제거 가능하나, 회귀 위험 회피 위해 유지.
+- 사용자 결정 (이 PR PR description): `prefix` rename 만 (baseUrl 전환 X).
+
+## 작업 항목
+
+### 1. `prefixUrl: API_URL` → `prefix: API_URL`
+
+`client.ts:65` 한 줄 변경:
+
+```ts
+return ky.create({
+  prefix: API_URL,        // ← prefixUrl 에서 변경
+  retry: KY_RETRY_CONFIG,
+  hooks: { ... },
+});
+```
+
+### 2. leading slash 처리 정책 결정 (코드 변경 0)
+
+`client.ts:189~192`:
+
+```ts
+// endpoint에서 선행 슬래시 제거 (ky prefixUrl과 함께 사용 시)
+const normalizedEndpoint = endpoint.startsWith("/")
+  ? endpoint.slice(1)
+  : endpoint;
+```
+
+ky 2.0 의 `prefix` 는 leading slash 허용 → `slice(1)` 가 동작상 무해 (단순 join 시 / 가 두 번 안 들어가도록 보호하는 정도). 회귀 위험 회피 위해 **slice 로직 그대로 유지**, 주석만 업데이트:
+
+```ts
+// endpoint 의 선행 슬래시 정규화 (ky prefix 와 함께 사용 시 // 중복 방지)
+```
+
+### 3. action/service 계층 endpoint 호출 패턴 점검 (read-only)
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+# serverApiGet/Post/Put/Patch/Delete 호출 패턴 — leading slash 사용 빈도 점검
+grep -rnE 'serverApi(Get|Post|Put|Patch|Delete)\("[^"]+"' src/services/ src/actions/ | head -20
+```
+
+대부분 `"/families/..."` 형태로 leading slash 사용 추정 — slice(1) 가 처리. 변경 없음.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+
+# prefix 옵션 사용 + prefixUrl 잔재 0건
+grep -n 'prefix:\s*API_URL' src/lib/server/api/client.ts | wc -l   # = 1
+! grep -rnE 'prefixUrl' src/                                       # exit 1
+
+# slice(1) 정규화 로직 보존
+grep -n 'slice(1)' src/lib/server/api/client.ts | wc -l            # >= 1
+```
+
+수동 smoke: `/dashboard` → API 호출 정상 (URL 이 `${API_URL}/families/...` 형태로 빌드되는지 DevTools Network 탭 확인).
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/lib/server/api/client.ts` | `prefixUrl` → `prefix` 한 줄 + 주석 업데이트 |
+
+## Out of Scope
+
+- `baseUrl` 옵션 전환 (사용자 기각)
+- slice(1) 자체 제거 (회귀 위험 회피로 보존)
+- action/service 계층 endpoint 문자열 변경 — 현재 leading slash 패턴 그대로
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `prefix` 옵션 명이 ky 2.0 release note 와 다른 가능성 | release note (v2.0.0 섹션) 1f2ad7f 가 명시. tsc 타입 체크가 잘못된 옵션명 잡음 |
+| API_URL 끝에 trailing slash 가 있으면 `//` 중복 가능성 | `API_URL` (env `BACKEND_API_URL`) 의 형식 점검 — 일반적으로 `https://api.foo.com` 형태. trailing slash 있으면 별도 plan 으로 정규화 |

--- a/tasks/plan004-ky-v2-migration/phase-03.md
+++ b/tasks/plan004-ky-v2-migration/phase-03.md
@@ -1,0 +1,150 @@
+# Phase 03 — `.json()` 빈 body 가드 + HTTPError.data 활용
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: ky 2.0 가 빈 body / 204 응답에서 throw 하는 변경 대응 + `HTTPError.data` 자동 파싱 활용으로 catch 블록 단순화.
+
+## Context (자기완결)
+
+- ky 2.0 변경 (1b8e1ff): `.json()` 이 빈 body 또는 204 응답에서 throw (기존: 빈 문자열 반환).
+  - 영향: `client.ts:216` `response.json<T>()` — DELETE 응답이 보통 204 No Content. 우리 envelope 가 200/JSON 가정이므로 가드 필요.
+- ky 2.0 변경 (1341f5c): `HTTPError.data` 신규 — 응답 body 자동 파싱. `await error.response.json().catch(() => null)` 패턴 폐기 가능.
+  - 영향: `client.ts:144` `beforeError` 안의 raw 파싱 + `client.ts:219` catch 블록의 동일 패턴.
+
+## 작업 항목
+
+### 1. `serverApiClient` 의 `response.json<T>()` 빈 body 가드
+
+`client.ts:213~216`:
+
+```ts
+// HTTP 메서드에 따른 호출
+const response = await kyInstance[method](normalizedEndpoint, kyOptions);
+return response.json<T>();
+```
+
+방어 패턴:
+
+```ts
+const response = await kyInstance[method](normalizedEndpoint, kyOptions);
+
+// 204 No Content 또는 빈 body 응답 — DELETE 등에서 발생
+if (response.status === 204 || response.headers.get("content-length") === "0") {
+  return null as T;
+}
+
+return response.json<T>();
+```
+
+`null as T` 는 호출자 (`serverApiDelete` 등) 가 `data` 필드를 안 쓰는 케이스에 맞춤. envelope 응답 (`ApiResponse<T>`) 검사 (line 311 `if (!response.success)`) 는 호출자에서 분기 — 빈 body 시 success 검증 자체를 건너뛰는 분기 추가:
+
+```ts
+// serverApiDelete 등에서:
+const response = await serverApiClient<ApiResponse<T> | null>(endpoint, { method: "DELETE" });
+if (response === null) return null as T;   // 204 No Content
+if (!response.success) throw new ServerApiError(...);
+return response.data;
+```
+
+5개 helper (`serverApiGet`/`Post`/`Put`/`Patch`/`Delete`) 모두 동일 패턴 가드 추가.
+
+### 2. `beforeError` 의 `HTTPError.data` 활용
+
+`client.ts:139~169`:
+
+기존:
+```ts
+const raw = await response.json().catch(() => null);
+const errorData = raw !== null && typeof raw === "object" && !Array.isArray(raw)
+  ? (raw as { message?: string; error?: string })
+  : null;
+```
+
+신규 (ky 2.0 의 `error.data`):
+```ts
+const data = error.data;   // 자동 파싱됨
+const errorData = data !== null && typeof data === "object" && !Array.isArray(data)
+  ? (data as { message?: string; error?: string })
+  : null;
+```
+
+장점: `await response.json()` resource leak 회피 + try/catch 불필요.
+
+### 3. `serverApiClient` catch 블록의 `error.response.json()` → `error.data`
+
+`client.ts:217~231`:
+
+기존:
+```ts
+if (error instanceof HTTPError) {
+  const errorData = (await error.response.json().catch(() => null)) as {
+    message?: string;
+    error?: string;
+  } | null;
+  ...
+}
+```
+
+신규:
+```ts
+if (error instanceof HTTPError) {
+  const errorData = (error.data ?? null) as {
+    message?: string;
+    error?: string;
+  } | null;
+  ...
+}
+```
+
+`error.data` 는 `unknown` 타입이라 type narrowing 후 사용. shape 점검 (object && !Array) 추가하면 안전:
+
+```ts
+const data = error.data;
+const errorData = data && typeof data === "object" && !Array.isArray(data)
+  ? (data as { message?: string; error?: string })
+  : null;
+```
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+pnpm test --run
+
+# 빈 body 가드 도입
+grep -nE 'response\.status === 204|content-length' src/lib/server/api/client.ts | wc -l   # >= 1
+
+# HTTPError.data 활용 (await error.response.json 패턴 0건)
+! grep -nE 'await error\.response\.json' src/lib/server/api/client.ts
+! grep -nE 'await response\.json\(\)\.catch' src/lib/server/api/client.ts
+grep -nE 'error\.data' src/lib/server/api/client.ts | wc -l   # >= 2
+```
+
+수동 smoke:
+- DELETE endpoint (예: 거래 삭제) → 204 응답 → throw 없음, UI 정상 갱신
+- 의도적으로 404/500 endpoint → ServerApiError 메시지에 backend message 포함 (errorData?.message 경로)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/lib/server/api/client.ts` | 빈 body 가드 + `error.data` 활용 + catch 단순화 |
+
+## Out of Scope
+
+- `__mocks__/ky.ts` 의 `HTTPError.data` 추가 (phase 4)
+- `NetworkError` 분기 처리 (본 plan 범위 외)
+- 호출자측 (action/service) 의 null 응답 처리 정책 — `null as T` 캐스팅 유지, 사용처에서 분기 안 해도 동작 (data 안 쓰는 케이스)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `error.data` 가 ky 2.0 에서 lazy 파싱이라 첫 접근 시 비동기 가능성 | release note (1341f5c) 가 "automatically consumed and parsed" 로 즉시 사용 명시. `await` 불필요 |
+| 빈 body 가드가 200 + 빈 body (비정상 응답) 도 null 처리해버림 | `content-length === "0"` 가드 — 정상 envelope 응답은 항상 length > 0. 의도적 정책 |
+| 호출자가 `null` 응답을 success 로 가정 안 하면 회귀 | helper 5개 모두 `null` 체크 → success false 분기 X. 변경 후 통합 테스트 (phase 5) |

--- a/tasks/plan004-ky-v2-migration/phase-04.md
+++ b/tasks/plan004-ky-v2-migration/phase-04.md
@@ -1,0 +1,96 @@
+# Phase 04 — `__mocks__/ky.ts` 갱신
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: jest.mock 기반 테스트 (ADR-F09) 가 ky 2.0 의 `HTTPError.data` + 신 hook 시그니처를 정확히 반영하도록 mock 파일 갱신.
+
+## Context (자기완결)
+
+- `src/__mocks__/ky.ts` (84줄) — `HTTPError` mock class 정의 (line 67~78).
+- ADR-F09 jest.mock 방식 — service 단위 테스트가 `jest.mock("ky", ...)` 으로 mock 사용. ky 2.0 변경에 mock 도 동조해야 테스트가 실 코드 동작과 일치.
+- HTTPError 의 새 `data` 속성 (1341f5c) — 응답 body 자동 파싱. mock 도 이 속성 노출해야 service 코드의 `error.data` 접근이 정상 mocked.
+
+## 작업 항목
+
+### 1. `__mocks__/ky.ts` 의 HTTPError class 에 `data` 속성 추가
+
+기존 (line 67~):
+```ts
+export class HTTPError extends Error {
+  response: Response;
+  request: Request;
+  options: NormalizedOptions;
+  // ...
+  this.name = "HTTPError";
+}
+```
+
+신규:
+```ts
+export class HTTPError extends Error {
+  response: Response;
+  request: Request;
+  options: NormalizedOptions;
+  data: unknown;        // ← ky 2.0 신규: 자동 파싱된 응답 body
+
+  constructor(response: Response, request: Request, options: NormalizedOptions, data?: unknown) {
+    super(...);
+    // ...
+    this.data = data ?? null;
+    this.name = "HTTPError";
+  }
+}
+```
+
+테스트에서 사용 시:
+```ts
+const error = new HTTPError(mockResponse, mockRequest, mockOptions, { message: "Not Found" });
+```
+
+### 2. mock 사용처 (테스트 파일) 점검
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+# HTTPError 를 직접 throw 하는 테스트 위치
+grep -rn 'new HTTPError\|throw new HTTPError' src/__tests__/ 2>/dev/null
+```
+
+각 위치에서 `new HTTPError(response, request, options)` 형태가 4번째 인자 `data` 없이 호출되어도 동작 (옵션 인자). 단 `error.data` 동작 검증 테스트가 필요하면 4번째 인자 명시.
+
+### 3. ky default export mock 의 `prefix` 옵션 점검
+
+mock 파일에 `prefixUrl` / `prefix` 옵션 처리 코드가 있다면 `prefix` 로 통일. 단 jest.mock 은 보통 `ky.create` 만 mock 하고 옵션은 무시 — 실측 후 변경.
+
+### 4. 단위 테스트 통과 확인
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+pnpm test --run
+
+# mock 의 HTTPError 가 data 속성 노출
+grep -n 'data' src/__mocks__/ky.ts | wc -l   # >= 1 (data 속성 + 기타)
+grep -n 'data:\s*unknown' src/__mocks__/ky.ts | wc -l   # = 1 (속성 선언)
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/__mocks__/ky.ts` | HTTPError class 에 `data` 속성 추가 |
+| `src/__tests__/**/*.test.ts` | (해당 시) HTTPError throw 위치 확인 |
+
+## Out of Scope
+
+- 새 테스트 케이스 추가 (HTTPError.data 동작 검증) — 기존 테스트 통과만 목표
+- ky 2.0 의 `NetworkError` mock 추가 (사용 시 별도 plan)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 기존 테스트가 HTTPError 4-인자 시그니처에 의존하지 않으면 영향 0 | grep 으로 사용처 0~소수 추정. 영향 시 4번째 인자 추가만 |
+| mock 의 옵션 처리 코드가 `prefixUrl` literal 의존 시 silent break | mock 파일 본문 검토 시 발견. 일반적으로 mock 은 옵션 무시 |

--- a/tasks/plan004-ky-v2-migration/phase-05.md
+++ b/tasks/plan004-ky-v2-migration/phase-05.md
@@ -1,0 +1,100 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, ky 1.x 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: dep bump + hook (1) + prefix rename (2) + .json 가드/HTTPError.data (3) + mock 갱신 (4).
+- legacy 잔재 후보: `prefixUrl`, `(_request, _options, response)` 위치 인자, `await error.response.json` 패턴.
+- `_shared/common-pitfalls.md § 1-8` 패턴 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/004-ky-v2-migration
+
+pnpm install
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` 출력 후 어느 phase 산출물이 회귀를 만들었는지 식별 + 보고.
+
+### 2. ky 1.x 잔재 grep — 0건 증명
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+
+# package.json 에서 v2.x lock
+grep '"ky"' package.json   # = "^2.0.2"
+
+# prefixUrl 잔재 0건 (phase 02)
+! grep -rnE 'prefixUrl' src/
+
+# 위치 인자 hook 시그니처 잔재 0건 (phase 01)
+! grep -nE 'beforeRequest:\s*\[\s*\(\s*request\s*\)' src/lib/server/api/client.ts
+! grep -nE 'afterResponse:\s*\[\s*async\s*\(\s*_request,\s*_options' src/lib/server/api/client.ts
+
+# .json().catch(() => null) 패턴 잔재 0건 (phase 03)
+! grep -nE 'await error\.response\.json' src/lib/server/api/client.ts
+! grep -nE 'await response\.json\(\)\.catch' src/lib/server/api/client.ts
+```
+
+### 3. ky 2.0 신규 패턴 등록 확인
+
+```bash
+# prefix 옵션 사용
+grep -n 'prefix:\s*API_URL' src/lib/server/api/client.ts | wc -l   # = 1
+
+# 단일 state object hook signature
+grep -nE 'beforeRequest:\s*\[\s*\(\s*\{' src/lib/server/api/client.ts | wc -l   # >= 1
+grep -nE 'afterResponse:\s*\[\s*async\s*\(\s*\{' src/lib/server/api/client.ts | wc -l   # >= 1
+
+# HTTPError.data 활용
+grep -nE 'error\.data' src/lib/server/api/client.ts | wc -l   # >= 2
+
+# 빈 body 가드
+grep -nE 'response\.status === 204|content-length' src/lib/server/api/client.ts | wc -l   # >= 1
+
+# mock 갱신
+grep -n 'data:\s*unknown\|this\.data' src/__mocks__/ky.ts | wc -l   # >= 1
+```
+
+### 4. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan004-ky-v2-migration/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan004-ky-v2-migration/index.json
+grep -c '"status": "completed"' tasks/plan004-ky-v2-migration/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan004-ky-v2-migration/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan004-ky-v2-migration/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan004-ky-v2-migration/index.json` | 모든 status `completed` |
+| `tasks/plan004-ky-v2-migration/phase-05.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- PR #193 close — 본 plan PR 머지 후 사용자가 GitHub UI 에서 직접 close (또는 plan PR description 에 "Closes #193" 마커로 자동 close 트리거)
+- ky 2.0 신규 기능 (NetworkError, totalTimeout, baseUrl, Standard Schema) — 후속 plan 검토
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 안 문자열) | 라인 시작 앵커 / 정확한 토큰 매치로 한정 |
+| 통합 테스트 부족 (jest.mock 만으로는 실 ky 동작 미검증) | 수동 smoke 단계에서 dev backend 호출 — 정상/에러/204 케이스 점검 |


### PR DESCRIPTION
## Summary

- plan task PR (`plan/{N}-{slug}`) 와 구현 PR (`feat/plan{N}-{slug}`) 분리 규칙을 CLAUDE.md `Git & PR Conventions` 섹션에 명시
- build-with-teams 사전 검증 4번 (머지 이력) 이 task-only 머지를 잡았을 때의 처리도 명시

## Test plan
- [ ] CLAUDE.md 형식 정상 (Markdown 표 렌더링 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)