### PR TITLE
docs(plan004): ky 1.x → 2.0 major migration plan

### DIFF
--- a/tasks/plan004-ky-v2-migration/phase-01.md
+++ b/tasks/plan004-ky-v2-migration/phase-01.md
@@ -42,7 +42,23 @@ pnpm add ky@^2.0.2
 기존: `async (error) => { ... if (response) { ... } ... return error; }`
 신규: `async (error, { request, options }) => { ... }`.
 
-ky 2.0 변경: 이제 모든 에러를 받음 (HTTPError 한정 아님). `error.response` 가 undefined 일 수 있으므로 기존 line 143 `if (response)` 가드 그대로 보존 — 추가 변경 0. `request`/`options` state 는 사용 안 하면 destructuring 생략.
+ky 2.0 변경: 이제 모든 에러를 받음 (HTTPError 한정 아님). 비-HTTPError (예: NetworkError, AbortError) 는 `response`/`data` 속성이 없으므로 **`instanceof HTTPError` 타입 가드로 early return** 명시:
+
+```ts
+beforeError: [
+  async (error, { request, options }) => {
+    if (!(error instanceof HTTPError)) return error;   // 비-HTTPError 는 변환 없이 반환
+
+    const { response } = error;
+    if (response) {
+      // 기존 errorData 추출 + error.message 갱신 로직
+    }
+    return error;
+  },
+],
+```
+
+기존 line 143 `if (response)` 가드는 `instanceof HTTPError` 통과 후 추가 안전망 (response 가 일부 케이스에서 undefined 가능). 두 가드 동시 보존. `request`/`options` state 는 사용 안 하면 destructuring 생략.
 
 ### 5. 자동 verification
 

--- a/tasks/plan004-ky-v2-migration/phase-03.md
+++ b/tasks/plan004-ky-v2-migration/phase-03.md
@@ -23,30 +23,33 @@ const response = await kyInstance[method](normalizedEndpoint, kyOptions);
 return response.json<T>();
 ```
 
-방어 패턴:
+방어 패턴 — `serverApiClient<T>` 의 반환 타입을 `Promise<T | null>` 로 변경하고, 빈 body 응답은 status 코드 기반으로 판정 (Content-Length 헤더는 chunked 응답에서 부재할 수 있어 신뢰성 부족):
 
 ```ts
+// serverApiClient<T>(...): Promise<T | null>
 const response = await kyInstance[method](normalizedEndpoint, kyOptions);
 
-// 204 No Content 또는 빈 body 응답 — DELETE 등에서 발생
-if (response.status === 204 || response.headers.get("content-length") === "0") {
-  return null as T;
+// 204 No Content / 304 Not Modified — body 없음 보장된 status
+if (response.status === 204 || response.status === 304) {
+  return null;
 }
 
 return response.json<T>();
 ```
 
-`null as T` 는 호출자 (`serverApiDelete` 등) 가 `data` 필드를 안 쓰는 케이스에 맞춤. envelope 응답 (`ApiResponse<T>`) 검사 (line 311 `if (!response.success)`) 는 호출자에서 분기 — 빈 body 시 success 검증 자체를 건너뛰는 분기 추가:
+5개 helper (`serverApiGet`/`Post`/`Put`/`Patch`/`Delete`) 모두 반환 타입을 `Promise<T | null>` 로 변경 + null 분기 명시:
 
 ```ts
 // serverApiDelete 등에서:
-const response = await serverApiClient<ApiResponse<T> | null>(endpoint, { method: "DELETE" });
-if (response === null) return null as T;   // 204 No Content
-if (!response.success) throw new ServerApiError(...);
-return response.data;
+export async function serverApiDelete<T>(endpoint: string): Promise<T | null> {
+  const response = await serverApiClient<ApiResponse<T>>(endpoint, { method: "DELETE" });
+  if (response === null) return null;          // 204/304 — body 없음
+  if (!response.success) throw new ServerApiError(response.message || response.error || "API 오류");
+  return response.data;
+}
 ```
 
-5개 helper (`serverApiGet`/`Post`/`Put`/`Patch`/`Delete`) 모두 동일 패턴 가드 추가.
+호출자 (action/service) 도 `null` 가능성을 타입으로 인지 — phase 5 에서 `grep serverApiDelete` 후 호출자 null 분기 점검.
 
 ### 2. `beforeError` 의 `HTTPError.data` 활용
 
@@ -116,8 +119,12 @@ pnpm lint
 pnpm build
 pnpm test --run
 
-# 빈 body 가드 도입
-grep -nE 'response\.status === 204|content-length' src/lib/server/api/client.ts | wc -l   # >= 1
+# 빈 body 가드 도입 (status 코드 기반 — Content-Length 헤더 의존 X)
+grep -nE 'response\.status === 204|response\.status === 304' src/lib/server/api/client.ts | wc -l   # >= 1
+! grep -nE 'content-length|Content-Length' src/lib/server/api/client.ts   # exit 1 — 헤더 체크 잔재 0건
+
+# 5개 helper 가 Promise<T | null> 시그니처
+grep -cE 'Promise<.*\| null>' src/lib/server/api/client.ts   # >= 5
 
 # HTTPError.data 활용 (await error.response.json 패턴 0건)
 ! grep -nE 'await error\.response\.json' src/lib/server/api/client.ts
@@ -139,12 +146,10 @@ grep -nE 'error\.data' src/lib/server/api/client.ts | wc -l   # >= 2
 
 - `__mocks__/ky.ts` 의 `HTTPError.data` 추가 (phase 4)
 - `NetworkError` 분기 처리 (본 plan 범위 외)
-- 호출자측 (action/service) 의 null 응답 처리 정책 — `null as T` 캐스팅 유지, 사용처에서 분기 안 해도 동작 (data 안 쓰는 케이스)
 
 ## Risks
 
 | 리스크 | 완화 |
 |---|---|
 | `error.data` 가 ky 2.0 에서 lazy 파싱이라 첫 접근 시 비동기 가능성 | release note (1341f5c) 가 "automatically consumed and parsed" 로 즉시 사용 명시. `await` 불필요 |
-| 빈 body 가드가 200 + 빈 body (비정상 응답) 도 null 처리해버림 | `content-length === "0"` 가드 — 정상 envelope 응답은 항상 length > 0. 의도적 정책 |
-| 호출자가 `null` 응답을 success 로 가정 안 하면 회귀 | helper 5개 모두 `null` 체크 → success false 분기 X. 변경 후 통합 테스트 (phase 5) |
+| 호출자가 `null` 응답에 분기 안 해서 런타임 에러 | helper 5개 반환 타입을 `Promise<T \| null>` 로 명시 → TypeScript 컴파일 단계에서 호출자 분기 강제. phase 5 의 `grep serverApiDelete` 점검으로 cross-check |

--- a/tasks/plan004-ky-v2-migration/phase-04.md
+++ b/tasks/plan004-ky-v2-migration/phase-04.md
@@ -31,16 +31,18 @@ export class HTTPError extends Error {
   response: Response;
   request: Request;
   options: NormalizedOptions;
-  data: unknown;        // ← ky 2.0 신규: 자동 파싱된 응답 body
+  data: unknown;        // ← ky 2.0 신규: 자동 파싱된 응답 body (always defined)
 
-  constructor(response: Response, request: Request, options: NormalizedOptions, data?: unknown) {
+  constructor(response: Response, request: Request, options: NormalizedOptions, data: unknown = null) {
     super(...);
     // ...
-    this.data = data ?? null;
+    this.data = data;
     this.name = "HTTPError";
   }
 }
 ```
+
+`data` 는 `unknown = null` 기본값으로 항상 정의됨 (ky 2.0 실제 타입과 일치) — 호출자에서 `error.data === undefined` 분기 불필요. body 없이 throw 하는 테스트는 4번째 인자 생략 시 자동으로 `null`.
 
 테스트에서 사용 시:
 ```ts

--- a/tasks/plan004-ky-v2-migration/phase-05.md
+++ b/tasks/plan004-ky-v2-migration/phase-05.md
@@ -60,14 +60,33 @@ grep -nE 'afterResponse:\s*\[\s*async\s*\(\s*\{' src/lib/server/api/client.ts | 
 # HTTPError.data 활용
 grep -nE 'error\.data' src/lib/server/api/client.ts | wc -l   # >= 2
 
-# 빈 body 가드
-grep -nE 'response\.status === 204|content-length' src/lib/server/api/client.ts | wc -l   # >= 1
+# 빈 body 가드 (status 코드 기반 — Content-Length 헤더 의존 X)
+grep -nE 'response\.status === 204|response\.status === 304' src/lib/server/api/client.ts | wc -l   # >= 1
+! grep -nE 'content-length|Content-Length' src/lib/server/api/client.ts   # exit 1
+
+# 5개 helper 가 Promise<T | null> 시그니처
+grep -cE 'Promise<.*\| null>' src/lib/server/api/client.ts   # >= 5
 
 # mock 갱신
 grep -n 'data:\s*unknown\|this\.data' src/__mocks__/ky.ts | wc -l   # >= 1
 ```
 
-### 4. `index.json` + 본 phase status → `completed`
+### 4. DELETE 호출자 null 처리 점검 (phase 03 후속)
+
+`serverApiClient<T>` 반환 타입이 `Promise<T | null>` 로 변경됨에 따라 호출자가 null 분기를 명시했는지 cross-check:
+
+```bash
+# DELETE 사용처 식별 — 모두 null 가능 응답
+grep -rn 'serverApiDelete' src/services/ src/actions/ 2>/dev/null
+
+# 각 호출처가 결과 변수에 대한 null 체크 (?., ?? null, if (... === null)) 가지는지 점검.
+# 누락 시 TypeScript strict 가 컴파일 에러 → tsc --noEmit 통과로 1차 검증.
+# 단 `result.someField` 직접 접근 시 strict 에러. 해당 위치 식별 후 fix 또는 보고.
+```
+
+다른 helper (`Get`/`Post`/`Put`/`Patch`) 도 동일 — 단 200 응답이 일반적이라 null 케이스 드뭄. tsc 가 잡도록 둠.
+
+### 5. `index.json` + 본 phase status → `completed`
 
 ```bash
 sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan004-ky-v2-migration/index.json


### PR DESCRIPTION
## Summary

ky 1.14.3 → 2.0.2 major upgrade plan. Dependabot PR #193 (단순 dep bump) 은 코드 마이그레이션 미포함 — 본 plan 이 dep + 코드 한 PR 로 대체.

## ADR

- ADR-F05 갱신 (ky 2.x 결정 표 추가)
  - URL 옵션: `prefixUrl` → `prefix` rename (단순 join 유지)
  - Hook signature: 단일 state object
  - `.json()` 빈 body / 204 throw → 명시 가드
  - `HTTPError.data` 자동 파싱 활용

## Phase 구조 (5 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | package.json bump + 3 hook 시그니처 | sonnet |
| 02 | prefixUrl → prefix rename | sonnet |
| 03 | .json() 빈 body 가드 + HTTPError.data | sonnet |
| 04 | __mocks__/ky.ts 갱신 | sonnet |
| 05 | 통합 검증 + completed | haiku |

## 사용자 결정

- `prefix` 옵션 (현재 동작 유지 — `baseUrl` 전환 X)
- ADR-F05 갱신 (신규 ADR-F17 X)
- PR #193 close 후 본 PR 이 대체

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)