### PR TITLE
docs(plan005): add-expense form redesign plan

### DIFF
--- a/tasks/plan005-add-expense-redesign/index.json
+++ b/tasks/plan005-add-expense-redesign/index.json
@@ -1,0 +1,57 @@
+{
+  "name": "plan005-add-expense-redesign",
+  "description": "지출 추가/편집 폼 Teal fintech 리디자인 — 큰 금액 input(56px num) + 빠른 추가 칩(+1k/+5k/+10k) + 카테고리 grid(plan002 톤 토큰) + Mobile bottom Sheet/Desktop 720px Dialog responsive. Edit 폼도 같이 통일.",
+  "status": "pending",
+  "created_at": "2026-05-10",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md",
+    "docs/code-architecture.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 완료 (OKLCH/data-theme/Pretendard)",
+    "plan002 머지 완료 — `--color-cat-*` 토큰 22개 + `src/lib/utils/category-tone.ts` 헬퍼 재사용",
+    "handoff mockup: /tmp/handoff_fos/fos-accountbook/project/screens/{mobile,desktop}.jsx Screen 3"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "AmountInput 신규 — 56px num input + 빠른 추가 칩 (+1k/+5k/+10k)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "CategoryGrid 신규 — 5×2 mobile / 10×1 desktop + 톤 ring (plan002 헬퍼 재사용)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "ExpenseFormFields 통합 + AddExpenseForm/EditExpenseDialog 마이그레이션",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "AddExpenseSheet (mobile) / AddExpenseDialog (desktop) responsive wrapper + 진입점 분기",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan005-add-expense-redesign/phase-01.md
+++ b/tasks/plan005-add-expense-redesign/phase-01.md
@@ -1,0 +1,84 @@
+# Phase 01 — AmountInput 신규 (56px num + 빠른 추가 칩)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 지출 금액 입력을 큰 num display (56px mobile / 64px desktop) + 빠른 추가 칩(+1,000 / +5,000 / +10,000) 패턴으로 신규.
+
+## Context (자기완결)
+
+- handoff mockup:
+  - mobile.jsx line 449~477 — 56px num + 3 chip (+1k/+5k/+10k)
+  - desktop.jsx line 510~537 — 64px num + 4 chip (+1k/+5k/+10k/+50k)
+- 현재 코드 `src/components/expenses/forms/AddExpenseForm.tsx` (153줄) — shadcn `<Input>` 기본 폼 사용. 빠른 추가 칩 없음.
+- plan001 의 `.num` 클래스 (Inter + tabular-nums) + `--font-num` 토큰 사용. ADR-F14.
+- 입력자 (`createdBy`) 토글은 본 plan 미도입 — auth user 자동 (사용자 결정).
+
+## 작업 항목
+
+### 1. `AmountInput` 신규 컴포넌트
+
+`src/components/expenses/forms/AmountInput.tsx`. Props: `value: number`, `onChange: (next: number) => void`, `disabled?: boolean`.
+
+Layout:
+- "얼마를 썼나요?" 라벨 (12px, `text-fg-muted`)
+- ₩ prefix (28px mobile / 32px desktop, `text-fg-muted`) + amount span (56px mobile / 64px desktop, `font-bold`, `.num` 클래스, `letter-spacing: -0.035em`)
+- amount 는 `value.toLocaleString('ko-KR')` 표기. 0 일 때 `"0"` 표시.
+- 빠른 추가 칩 row: 모바일 `[1000, 5000, 10000]` / 데스크톱 `[1000, 5000, 10000, 50000]`. 모바일은 `md:hidden`, 데스크톱 추가 칩은 `hidden md:inline-flex`.
+- 칩 클릭 시 `onChange(value + delta)` 호출. tap feedback (active scale).
+- 음수 / 비정상 값 가드: `Math.max(0, ...)`.
+
+큰 num display 영역 자체는 read-only display + 빠른 추가 칩 + (수동 입력은 별도 numeric input). 키보드 직접 입력 패턴:
+- 큰 display 옆 또는 아래에 hidden `<input type="number" inputMode="numeric">` 두고 click 시 focus.
+- 또는 큰 display 자체가 button 처럼 클릭 가능 → 모달 keypad (별도 plan, OOS).
+- 본 phase 는 hidden numeric input 패턴 — 큰 display tap 시 input focus, 키보드 입력 시 display 동기화.
+
+### 2. 단위 테스트
+
+`src/__tests__/components/expenses/AmountInput.test.tsx`. 케이스:
+- 칩 클릭 시 `onChange(value + delta)` 호출 (1k/5k/10k 각각)
+- value=0 → "0" 표시 + ₩ prefix
+- value=38400 → "38,400" 표시 (콤마)
+- 음수 입력 가드 (`onChange` 호출값 0 이상)
+- ADR-F09 jest.mock 방식. shadcn 의존 없음 — 단순 컴포넌트라 RTL 만.
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm test src/__tests__/components/expenses/AmountInput.test.tsx --run
+
+test -f src/components/expenses/forms/AmountInput.tsx
+test -f src/__tests__/components/expenses/AmountInput.test.tsx
+
+# .num 클래스 사용 (Inter tabular-nums)
+grep -nE 'className=["\x27].*\bnum\b' src/components/expenses/forms/AmountInput.tsx | wc -l   # >= 1
+
+# 빠른 추가 칩 delta 배열
+grep -nE '1000.*5000.*10000' src/components/expenses/forms/AmountInput.tsx | wc -l   # >= 1
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/expenses/forms/AmountInput.tsx` | 신규 |
+| `src/__tests__/components/expenses/AmountInput.test.tsx` | 신규 |
+
+## Out of Scope
+
+- 모달 keypad UI (큰 display 클릭 → 별도 keypad) — 후속 plan
+- 통화 다중화 (KRW 외 USD/EUR 등) — 본 plan 범위 외
+- AddExpenseForm 통합 (phase 03)
+- Edit 폼 적용 (phase 03)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| iOS Safari 의 `inputMode="numeric"` 가 일부 버전에서 키패드 미표시 | 모바일 smoke 테스트로 점검. 미표시 시 `type="tel"` 대체 패턴 검토 (별도 plan) |
+| 큰 num display 가 매우 긴 자릿수 시 viewport 밖 넘침 | `text-overflow: ellipsis` 또는 `font-size: clamp(...)` 적용. 1억 이상 입력 케이스는 도메인상 드물어 우선 ellipsis |
+| value prop 외부 동기화 깨짐 (controlled 패턴 위반) | `onChange` 만 호출 + 내부 state 0건. 부모가 단일 source of truth |

--- a/tasks/plan005-add-expense-redesign/phase-02.md
+++ b/tasks/plan005-add-expense-redesign/phase-02.md
@@ -1,0 +1,104 @@
+# Phase 02 — CategoryGrid 신규 (5×2 mobile / 10×1 desktop + 톤 ring)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 카테고리 선택을 라벨/select 형에서 grid + 톤 ring 패턴으로 교체. plan002 의 `category-tone.ts` + `--color-cat-*` 토큰 재사용.
+
+## Context (자기완결)
+
+- handoff mockup:
+  - mobile.jsx line 480~511 — `grid-cols-5` 2 row (5×2 = 10 카테고리)
+  - desktop.jsx line 542~573 — `grid-cols-10` 1 row + 약간 더 큰 padding
+- 선택 시각: 카테고리 톤 `bg` 가 cell 배경으로, `fg` 가 1.5px border (ring 효과). 비선택은 `bg-bg` + `border-border`.
+- plan002 산출물:
+  - `src/lib/utils/category-tone.ts` — 한국어 카테고리명 → 토큰 키 (`food`/`cafe`/...) 매핑 헬퍼
+  - `src/app/globals.css` 의 `--color-cat-{food,cafe,transit,...}-bg` / `-fg` 토큰 22개
+- 본 phase 는 plan002 헬퍼만 import 하고 토큰 추가 없음.
+
+## 작업 항목
+
+### 1. `CategoryGrid` 신규 컴포넌트
+
+`src/components/expenses/forms/CategoryGrid.tsx`. Props:
+
+```ts
+interface CategoryGridProps {
+  categories: CategoryResponse[];   // backend Category 응답
+  selectedUuid: string | null;
+  onSelect: (uuid: string) => void;
+  disabled?: boolean;
+}
+```
+
+Layout:
+- container `grid gap-2 grid-cols-5 md:grid-cols-10`
+- cell: 32px (mobile) / 28px (desktop) icon + 11px label
+- 선택 시: `bg-[var(--color-cat-{key}-bg)]` + `border-[var(--color-cat-{key}-fg)]` (1.5px) + label `text-[var(--color-cat-{key}-fg)]` `font-bold`
+- 비선택: `bg-bg` + `border-border` + label `text-fg-muted` `font-medium`
+
+`category-tone.ts` 의 `getCategoryToneKey(category.name)` 으로 톤 키 추출. 매칭 실패 시 `etc` 톤 (plan002 기본 동작).
+
+### 2. 아이콘 매핑
+
+backend `Category.icon` 필드와 lucide-react 아이콘 이름이 다를 수 있음. plan002 의 매핑 테이블이 있으면 재사용, 없으면 본 phase 에서 신규 (간단한 record):
+
+```ts
+import { Utensils, Coffee, Bus, Smartphone, Home, ShoppingBag, ... } from "lucide-react";
+const TONE_ICON: Record<string, LucideIcon> = {
+  food: Utensils,
+  cafe: Coffee,
+  // ...
+};
+```
+
+### 3. 단위 테스트
+
+`src/__tests__/components/expenses/CategoryGrid.test.tsx`. 케이스:
+- 카테고리 10개 렌더 (5×2 grid 확인 — `grid-cols-5` 클래스 검증)
+- selectedUuid 일치 cell 만 톤 활성 (`bg-[var(--color-cat-` 클래스 매치)
+- onSelect 호출 시 uuid 전달
+- 매칭 실패 시 `etc` 톤 fallback
+- ADR-F09 jest.mock 방식
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm test src/__tests__/components/expenses/CategoryGrid.test.tsx --run
+
+test -f src/components/expenses/forms/CategoryGrid.tsx
+
+# plan002 헬퍼 재사용
+grep -n 'category-tone\|getCategoryToneKey' src/components/expenses/forms/CategoryGrid.tsx | wc -l   # >= 1
+
+# 톤 토큰 사용
+grep -nE 'color-cat-' src/components/expenses/forms/CategoryGrid.tsx | wc -l   # >= 1
+
+# responsive grid 클래스
+grep -nE 'grid-cols-5.*md:grid-cols-10|grid-cols-10' src/components/expenses/forms/CategoryGrid.tsx | wc -l   # >= 1
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/expenses/forms/CategoryGrid.tsx` | 신규 |
+| `src/__tests__/components/expenses/CategoryGrid.test.tsx` | 신규 |
+
+## Out of Scope
+
+- 톤 토큰 신규 추가 (plan002 의 22 토큰으로 충분)
+- 카테고리 신규/수정 UI (기존 categories 페이지 그대로)
+- backend `Category.icon` 필드 schema 변경 — 매핑은 클라 측 record
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| backend `Category.name` 이 한국어 외 문자 (영어 코드 등) 가능성 | `category-tone.ts` 매핑이 한글 위주. 매칭 실패 시 `etc` 톤 graceful. backend 응답 형식 변경되면 plan002 헬퍼 직접 갱신 |
+| `CategoryResponse` 가 10개 미만 (가족이 일부 카테고리 비활성화) | grid 가 자연스럽게 가용 cell 만 채움. 빈 cell 없음 |
+| Tailwind v4 의 arbitrary class `bg-[var(--color-cat-food-bg)]` 가 dynamic key 일 때 빌드에서 누락 가능성 | `category-tone.ts` 의 모든 키를 globals.css `@source inline(...)` 또는 컴포넌트 안 정적 매핑 record 로 사용. dynamic class 회피 |

--- a/tasks/plan005-add-expense-redesign/phase-03.md
+++ b/tasks/plan005-add-expense-redesign/phase-03.md
@@ -1,0 +1,118 @@
+# Phase 03 — ExpenseFormFields 통합 + AddExpenseForm/EditExpenseDialog 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: phase 1~2 의 신규 컴포넌트 (`AmountInput`, `CategoryGrid`) 와 기존 Date/Memo 필드를 묶은 공용 `ExpenseFormFields` 신규. Add 와 Edit 폼 둘 다 이 묶음을 사용하도록 마이그레이션.
+
+## Context (자기완결)
+
+- 현재 코드:
+  - `src/components/expenses/forms/AddExpenseForm.tsx` (153줄) — `useActionState` + `createExpenseAction`
+  - `src/components/expenses/dialogs/EditExpenseDialog.tsx` (184줄) — Edit 폼 본문
+  - `src/components/expenses/dialogs/AddExpenseDialog.tsx` (257줄) — Dialog wrapper (phase 4 에서 다룸)
+- 두 폼이 동일 필드 (금액/카테고리/날짜/메모) 사용 — DRY 위해 공용 fields 컴포넌트 추출.
+- handoff 의 Date 필드는 calendar 아이콘 + "2026년 5월 8일 (목)" 텍스트 + 우측 chevron — shadcn Popover + react-day-picker 패턴 (기존 코드 점검 후 재사용).
+- handoff 의 Memo 필드는 단일 line input — shadcn Input 그대로.
+
+## 작업 항목
+
+### 1. `ExpenseFormFields` 신규
+
+`src/components/expenses/forms/ExpenseFormFields.tsx`. Props:
+
+```ts
+interface ExpenseFormFieldsProps {
+  categories: CategoryResponse[];
+  amount: number;
+  onAmountChange: (next: number) => void;
+  categoryUuid: string | null;
+  onCategoryChange: (uuid: string) => void;
+  date: string;             // ISO YYYY-MM-DD
+  onDateChange: (next: string) => void;
+  memo: string;
+  onMemoChange: (next: string) => void;
+  disabled?: boolean;
+}
+```
+
+Layout (top → bottom):
+1. AmountInput (phase 1)
+2. divider (border-bottom)
+3. FieldLabel "카테고리" + CategoryGrid (phase 2)
+4. FieldLabel "날짜" + DateField (calendar Popover trigger)
+5. FieldLabel "메모" + Input (memo)
+
+`FieldLabel` / `FieldRow` 헬퍼는 컴포넌트 안 사적 정의 (handoff mockup line 277~285 참조).
+
+### 2. `AddExpenseForm` 마이그레이션
+
+`src/components/expenses/forms/AddExpenseForm.tsx` 재작성:
+- `useActionState` + `createExpenseAction` 흐름 그대로
+- form 본문을 `<ExpenseFormFields />` 로 교체
+- 4개 필드 state (amount/categoryUuid/date/memo) 는 `useState` 로 유지
+- form submit 시 hidden input 또는 FormData 로 action 에 전달 (기존 패턴 그대로)
+
+### 3. `EditExpenseDialog` 마이그레이션
+
+`src/components/expenses/dialogs/EditExpenseDialog.tsx` 의 폼 본문을 `<ExpenseFormFields />` 로 교체. initial value 는 expense props 에서 추출:
+
+```ts
+<ExpenseFormFields
+  categories={categories}
+  amount={Number(expense.amount)}
+  onAmountChange={setAmount}
+  categoryUuid={expense.category.uuid}
+  // ...
+/>
+```
+
+`updateExpenseAction` 호출 흐름은 그대로.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+pnpm test --run
+
+test -f src/components/expenses/forms/ExpenseFormFields.tsx
+
+# Add / Edit 둘 다 ExpenseFormFields 사용
+grep -n 'ExpenseFormFields' src/components/expenses/forms/AddExpenseForm.tsx | wc -l   # >= 1
+grep -n 'ExpenseFormFields' src/components/expenses/dialogs/EditExpenseDialog.tsx | wc -l   # >= 1
+
+# AmountInput / CategoryGrid 가 ExpenseFormFields 안에서 사용
+grep -nE 'AmountInput|CategoryGrid' src/components/expenses/forms/ExpenseFormFields.tsx | wc -l   # >= 2
+```
+
+수동 smoke (`pnpm dev`):
+- BottomNav FAB → 다이얼로그 → 새 디자인 fields 표시 (큰 num + 카테고리 grid + 날짜 + 메모)
+- 거래 row 우측 메뉴 → "수정" → Edit 다이얼로그 → 동일 디자인 + initial values 채워짐
+- 폼 제출 후 toast / revalidate 정상
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/expenses/forms/ExpenseFormFields.tsx` | 신규 |
+| `src/components/expenses/forms/AddExpenseForm.tsx` | 수정 (fields 묶음 import 로 단순화) |
+| `src/components/expenses/dialogs/EditExpenseDialog.tsx` | 수정 (동일 묶음) |
+
+## Out of Scope
+
+- Sheet/Dialog wrapper 변경 (phase 4)
+- 새 action 추가 — 기존 `createExpenseAction` / `updateExpenseAction` 시그니처 그대로
+- `revalidatePath` 정책 변경
+- DateField 의 react-day-picker 자체 디자인 — Popover 안 calendar 는 plan001 토큰 자동 적용
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `useActionState` 와 controlled fields state 충돌 (action submit 시 state reset) | submit 후 state 명시 reset (`onSuccess` 콜백에서 `setAmount(0)` 등). 기존 AddExpenseForm 패턴 점검 후 동일 처리 |
+| EditExpenseDialog 의 expense.amount 타입 (string vs number) | type 점검 후 `Number()` 변환 명시. `RecentExpense.amount` 가 string 이라 변환 필요 |
+| Date 형식 (ISO vs YYYY-MM-DD) 불일치 | 기존 `date-timezone.ts` / `format.ts` 헬퍼 사용. `toLocalDateInput` 이미 import 되어있음 |

--- a/tasks/plan005-add-expense-redesign/phase-04.md
+++ b/tasks/plan005-add-expense-redesign/phase-04.md
@@ -1,0 +1,138 @@
+# Phase 04 — Mobile Sheet / Desktop Dialog responsive wrapper
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: Add 진입 패턴을 viewport 별로 분기 — 모바일은 `<Sheet side="bottom">` (풀화면), 데스크톱은 `<Dialog>` (중앙 720px). 기존 `AddExpenseDialog.tsx` 가 두 패턴 모두 처리.
+
+## Context (자기완결)
+
+- 현재: `src/components/expenses/dialogs/AddExpenseDialog.tsx` (257줄) 가 모든 viewport 에서 Dialog 사용.
+- handoff:
+  - mobile.jsx line 428 — `MobileShell ... hideTab` (BottomNav 가려진 풀화면 모드)
+  - desktop.jsx line 504 — `DesktopShell title="지출 추가" subtitle="..."` 안에 720px centered card
+- shadcn 컴포넌트:
+  - `src/components/ui/sheet.tsx` (이미 사용 중)
+  - `src/components/ui/dialog.tsx` (이미 사용 중)
+- 진입점:
+  - `src/components/layout/BottomNavigation.tsx:97` — FAB → AddExpenseDialog
+  - `src/components/dashboard/QuickActions.tsx:47` — 버튼 → AddExpenseDialog
+  - `src/app/(authenticated)/transactions/_components/ExpenseTabContent.tsx` — 페이지 내 추가
+- 모든 진입점이 `AddExpenseDialog` 호출 → wrapper 한 곳만 고치면 전파.
+
+## 작업 항목
+
+### 1. `AddExpenseDialog` responsive 분기
+
+`src/components/expenses/dialogs/AddExpenseDialog.tsx` 재작성:
+
+```tsx
+"use client";
+// ... imports
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useMediaQuery } from "@/hooks/useMediaQuery"; // 신규 또는 기존 점검
+
+export function AddExpenseDialog({ open, onOpenChange, ... }) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[720px]">
+          <DialogHeader><DialogTitle>지출 추가</DialogTitle></DialogHeader>
+          <AddExpenseForm ... onSuccess={() => onOpenChange(false)} />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[100dvh] p-0">
+        <SheetHeader className="px-5 py-3 flex-row justify-between">
+          <SheetTitle>지출 추가</SheetTitle>
+        </SheetHeader>
+        <div className="px-5 pb-5 overflow-y-auto">
+          <AddExpenseForm ... onSuccess={() => onOpenChange(false)} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+`useMediaQuery` 훅이 codebase 에 이미 있는지 점검:
+```bash
+grep -rn "useMediaQuery\|useBreakpoint\|matchMedia" src/hooks src/lib 2>/dev/null
+```
+없으면 신규 (`src/hooks/useMediaQuery.ts` — `window.matchMedia` 기반, SSR safe — 초기값 false).
+
+### 2. SSR 안전 점검
+
+`AddExpenseDialog` 가 `"use client"`. `useMediaQuery` 의 초기 렌더는 SSR 에서 false (모바일 가정) → hydration mismatch 회피. 클라이언트 mount 후 첫 effect 에서 정확한 값으로 설정.
+
+또는 CSS-only 분기 (`md:hidden` / `hidden md:block` 두 wrapper 모두 렌더) 가능하나 — 두 트리 모두 mount 되면 form state 가 둘로 나뉨. JS hook 분기가 단순.
+
+### 3. 진입점 검증 (변경 0)
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+# 진입점 3곳에서 AddExpenseDialog 호출 그대로
+grep -rn 'AddExpenseDialog' src/components/layout/ src/components/dashboard/QuickActions.tsx src/app/\(authenticated\)/transactions/ 2>/dev/null
+```
+
+각 호출 site 변경 0. props (open/onOpenChange/categories) 시그니처 동일.
+
+### 4. EditExpenseDialog 도 동일 패턴
+
+`src/components/expenses/dialogs/EditExpenseDialog.tsx` 도 같은 responsive 분기 적용 — 거래 row 수정 진입도 모바일에서 풀화면 sheet 가 일관.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+pnpm test --run
+
+# Sheet + Dialog 둘 다 import
+grep -nE 'from ["\x27]@/components/ui/sheet|from ["\x27]@/components/ui/dialog' src/components/expenses/dialogs/AddExpenseDialog.tsx | wc -l   # >= 2
+
+# useMediaQuery 사용 (또는 동등 viewport hook)
+grep -n 'useMediaQuery\|matchMedia' src/components/expenses/dialogs/AddExpenseDialog.tsx | wc -l   # >= 1
+
+# Edit 도 동일 패턴
+grep -nE 'from ["\x27]@/components/ui/sheet|from ["\x27]@/components/ui/dialog' src/components/expenses/dialogs/EditExpenseDialog.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+- 모바일 viewport (375px) → FAB → bottom sheet 가 위로 슬라이드 + 풀화면. 닫기 (drag-down 또는 X 버튼) 정상
+- 데스크톱 viewport (1280px) → FAB 위치 다르겠으나 진입점 클릭 → 중앙 720px Dialog
+- viewport 회전 (mobile landscape ↔ portrait) 시 wrapper 재선택 — 폼 state 보존 필요 (open prop 유지)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/expenses/dialogs/AddExpenseDialog.tsx` | 수정 — responsive 분기 |
+| `src/components/expenses/dialogs/EditExpenseDialog.tsx` | 수정 — 동일 분기 |
+| `src/hooks/useMediaQuery.ts` | 신규 (codebase 에 없을 시) |
+
+## Out of Scope
+
+- BottomNavigation FAB 디자인 변경 — 별도 plan
+- /add 전용 라우트 신설 (사용자 결정으로 X)
+- ExpenseFilters / Recurring sheet 의 responsive 패턴 — 별도 plan
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| viewport 전환 시 폼 state 손실 (Dialog → Sheet 또는 반대) | 부모 컴포넌트에서 form state 관리 + AddExpenseDialog 는 단순 wrapper. open prop 만 부모가 통제. 단 phase 03 의 form state 위치 점검 — 폼 컴포넌트 내부면 wrapper 교체 시 unmount 됨 |
+| `useMediaQuery` SSR hydration mismatch | 초기값 false (모바일 가정) + `useEffect` 로 mount 후 갱신. 첫 렌더 mismatch 가능성 있으면 `suppressHydrationWarning` 명시 또는 `useSyncExternalStore` 패턴 |
+| Sheet `h-[100dvh]` 가 iOS Safari 의 동적 viewport 와 충돌 | `100dvh` 가 표준. 폴백 `100vh` 하드코딩 회피 — 표준 단위 사용 |

--- a/tasks/plan005-add-expense-redesign/phase-05.md
+++ b/tasks/plan005-add-expense-redesign/phase-05.md
@@ -1,0 +1,94 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, 신규 컴포넌트 등록 확인, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: AmountInput (1) + CategoryGrid (2) + ExpenseFormFields 통합 (3) + responsive Sheet/Dialog (4).
+- legacy 잔재 후보: AddExpenseForm 안의 기존 inline 금액 input / 카테고리 select 잔재.
+- `_shared/common-pitfalls.md § 1-8` 패턴 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/005-add-expense-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` 출력 후 어느 phase 산출물이 회귀를 만들었는지 식별 + 보고.
+
+### 2. 신규 컴포넌트 / 통합 등록 확인
+
+```bash
+test -f src/components/expenses/forms/AmountInput.tsx
+test -f src/components/expenses/forms/CategoryGrid.tsx
+test -f src/components/expenses/forms/ExpenseFormFields.tsx
+
+# Add / Edit 둘 다 ExpenseFormFields 사용
+grep -n 'ExpenseFormFields' src/components/expenses/forms/AddExpenseForm.tsx | wc -l   # >= 1
+grep -n 'ExpenseFormFields' src/components/expenses/dialogs/EditExpenseDialog.tsx | wc -l   # >= 1
+
+# Add/Edit 둘 다 Sheet+Dialog responsive
+grep -nE 'from ["\x27]@/components/ui/sheet|from ["\x27]@/components/ui/dialog' src/components/expenses/dialogs/AddExpenseDialog.tsx | wc -l   # >= 2
+grep -nE 'from ["\x27]@/components/ui/sheet|from ["\x27]@/components/ui/dialog' src/components/expenses/dialogs/EditExpenseDialog.tsx | wc -l   # >= 2
+```
+
+### 3. plan002 헬퍼 재사용 확인
+
+```bash
+# CategoryGrid 가 plan002 의 category-tone 헬퍼 사용
+grep -n 'category-tone\|getCategoryToneKey' src/components/expenses/forms/CategoryGrid.tsx | wc -l   # >= 1
+
+# --color-cat-* 토큰 활용
+grep -nE 'color-cat-' src/components/expenses/forms/CategoryGrid.tsx | wc -l   # >= 1
+```
+
+### 4. Hardcoded 색 잔재 0건 (plan001/002 효과 회귀 방지)
+
+```bash
+grep -rnE '#[0-9a-fA-F]{6}\b|hsl\(|rgb\(' src/components/expenses/forms/ src/components/expenses/dialogs/ \
+  | grep -vE 'rgba\(255,\s*255,\s*255' \
+  | grep -vE '\.test\.tsx?:'
+# 결과 0줄
+```
+
+### 5. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan005-add-expense-redesign/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan005-add-expense-redesign/index.json
+grep -c '"status": "completed"' tasks/plan005-add-expense-redesign/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan005-add-expense-redesign/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan005-add-expense-redesign/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan005-add-expense-redesign/index.json` | 모든 status `completed` |
+| `tasks/plan005-add-expense-redesign/phase-05.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- 시각 회귀 비교 스크린샷 (수동 smoke 항목으로만, 이전 phase 들에 분산)
+- BottomNav FAB 디자인 (별도 plan)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 안 문자열) | grep 패턴 구체화. 라인 시작 앵커 (`^`) 사용 |
+| macOS BSD `sed -i ''` vs Linux GNU `sed -i` | 본 plan macOS 환경 가정 (fos-blog 동일) |


### PR DESCRIPTION
## Summary

지출 추가/편집 폼 Teal fintech 리디자인 plan. plan002 의 카테고리 톤 토큰 + helper 재사용.

## 핵심 결정 (사용자 confirmed)

- 입력자 토글 도입 X (현재 자동 createdBy 유지 — backend 변경 0)
- Mobile: bottom Sheet (풀화면) / Desktop: Dialog (720px centered) responsive 분기
- Edit 폼도 동일 디자인 통일 (`ExpenseFormFields` 공용 import)
- 한 plan 안에 Mobile + Desktop (plan002~004 동일 패턴)

## Phase 구조 (5 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | AmountInput (56px num + 빠른 추가 칩) | sonnet |
| 02 | CategoryGrid (5×2/10×1 + 톤 ring) | sonnet |
| 03 | ExpenseFormFields 통합 + Add/Edit 마이그레이션 | sonnet |
| 04 | Sheet (mobile) / Dialog (desktop) responsive | sonnet |
| 05 | 통합 검증 + completed | haiku |

## 다음 단계

`/build-with-teams plan005-add-expense-redesign` 호출 시 같은 브랜치에서 phase 실행.

## 의존성

- plan001 머지 완료 (OKLCH/Pretendard) ✅
- plan002 머지 완료 (\`--color-cat-*\` 22 토큰 + \`category-tone.ts\`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)