### PR TITLE
docs(adr): F17 + review-fix 학습 단계 — URL state 동기화 패턴

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ Claude Code가 항상 따라야 할 규칙과 참조 문서 포인터.
 | 폰트 추가 / 수치 표기 | ADR-F14 — Pretendard Variable + Inter (`.num` / tabular-nums) |
 | dark mode 셀렉터 | ADR-F15 — `[data-theme="dark"]` 만. `.dark` 신규 사용 금지 |
 | 카테고리 분포·월 집계 stat 추가 | ADR-F16 — Server Action 측 집계. backend endpoint 신설 전 임계 트리거 확인 |
+| URL searchParams 기반 input/필터 | ADR-F17 — useEffect 안 setState 금지, `draft ?? current` derived value 패턴 |
 | `alert/confirm/prompt` 대체 | ADR-F08 — sonner 토스트 사용 |
 | Jest 테스트 추가 | ADR-F09 — MSW 아닌 jest.mock 방식 |
 | 실시간 업데이트 vs revalidate | ADR-F10 — Server Action + `revalidatePath` 유지 |

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -261,3 +261,25 @@
   - 기존 `getDashboardStats` 응답에 카테고리 합계 끼워넣기: stats DTO 비대해지고 다른 호출처가 불필요 데이터 수신.
 - **임계 트리거** (재논의 조건): 가구당 월 평균 거래수 500건 초과 또는 dashboard 진입 TTI 700ms 초과 측정 시 backend endpoint 분리 검토.
 - **적용 범위**: `services/dashboard/dashboard-service.ts`, `actions/dashboard/get-monthly-category-breakdown-action.ts`.
+
+## ADR-F17: URL searchParams ↔ Client state 동기화는 draft 패턴 (2026-05-11)
+
+- **결정**: URL searchParams 를 입력 폼 (input/select) 의 초기값으로 쓰면서 외부 URL 변경 (브라우저 뒤로/앞으로, 다른 컴포넌트의 router.replace) 에도 추종해야 할 때, **useEffect 안 setState 가 아닌 derived value 패턴** 을 사용한다.
+
+  ```tsx
+  // ✅ draft 패턴
+  const [draft, setDraft] = useState<string | null>(null);
+  const value = draft ?? searchParams.get("q") ?? "";
+  // 사용자 입력: setDraft(newValue)
+  // URL apply 후: setDraft(null) — URL 단일 진실원 복귀
+  ```
+
+- **맥락**: React 19 의 `react-hooks/cascading-render` 규칙이 `useEffect` 안 `setState` 직접 호출을 차단. URL 변경을 감지해서 input state 를 다시 set 하는 직관적 코드가 lint 오류 + 잠재적 cascading render 위험. 사용자 입력 (draft) 과 URL (current) 의 두 진실원을 단일 derived value 로 합쳐 effect 제거.
+
+- **대안 기각**:
+  - `useEffect(() => setState(currentValue), [currentValue])`: eslint rule 위반 + cascading render 위험.
+  - URL 만 진실원 + 모든 입력 즉시 router.replace: 사용자 타이핑마다 navigation 발생 → 성능/UX 저하.
+  - `key={searchParams}` 로 force-remount: 컴포넌트 내부 다른 state (Popover open 등) 도 reset 되는 부수효과.
+
+- **적용 범위**: URL searchParams 기반 client 필터 컴포넌트 전반. 첫 적용 사례 — `AmountRangeFilter.tsx` (plan003).
+


### PR DESCRIPTION
## Summary

PR #223 리뷰 fix 시 발견된 패턴 ADR 명문화.

- React 19 `react-hooks/cascading-render` 규칙이 useEffect 안 setState 차단
- URL searchParams 변경 추종 시 직관적 코드가 lint 오류
- 해결: \`draft ?? current\` derived value 패턴 (single source of truth = URL, draft 는 사용자 입력 buffer)

## Test plan

- [x] CLAUDE.md 상황별 ADR 표에 ADR-F17 추가
- [x] docs/adr.md ADR-F17 신설 (결정/맥락/대안 기각/적용 범위)

🤖 Generated with [Claude Code](https://claude.com/claude-code)