### PR TITLE
docs(plan006): analytics page redesign plan

### DIFF
--- a/tasks/plan006-analytics-redesign/index.json
+++ b/tasks/plan006-analytics-redesign/index.json
@@ -1,0 +1,57 @@
+{
+  "name": "plan006-analytics-redesign",
+  "description": "/analytics 페이지 Teal fintech 리디자인 — 기간 토글 4종(m1/m3/m6/y1) + Donut + 월별 추이 bar (Daily 제거) + 카테고리 progress/delta. 클라 우선 구현 + 동일 plan 에서 backend monthly-trend endpoint issue 등록.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign",
+    "plan003-expenses-redesign"
+  ],
+  "prerequisites": [
+    "plan001~003 머지 완료 (OKLCH/data-theme/Pretendard, CategoryDistribution Donut 패턴, TransactionsTabs segmented 패턴)",
+    "handoff mockup: /tmp/handoff_fos/fos-accountbook/project/screens/{mobile,desktop}.jsx Screen 4",
+    "backend issue (이번 plan phase-01 에서 등록): GET /families/{u}/stats/monthly-trend?from=YYYY-MM&to=YYYY-MM"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "type/service/action — 월별 추이 + 전월 delta 클라 집계 + backend issue 등록",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "PeriodToggle (m1/m3/m6/y1) — plan003 segmented 패턴 재사용 + URL searchParams (ADR-F17)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "CategoryDonut + 전월 delta 표기 (plan002 Donut 패턴 재사용)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "MonthlyTrendBar 신규 (DailyBarChart 제거) + CategoryDetailList (progress + delta 2-col grid)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan006-analytics-redesign/phase-01.md
+++ b/tasks/plan006-analytics-redesign/phase-01.md
@@ -1,0 +1,163 @@
+# Phase 01 — type/service/action + backend issue 등록
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 월별 지출 추이 + 전월 대비 delta 데이터 layer 신규. 클라 집계 우선 구현 + backend `monthly-trend` endpoint issue 동시 등록 (후속 plan 에서 backend endpoint 전환).
+
+## Context (자기완결)
+
+- 현재 코드: `src/app/(authenticated)/analytics/_components/{AnalyticsClient,CategoryPieChart,DailyBarChart}.tsx`. service/action layer 미존재 (page.tsx 가 직접 처리하거나 dashboard action 재사용 추정 — 점검).
+- plan002 의 `getMonthlyCategoryBreakdownAction(year, month)` 가 존재 (ADR-F16) — 본 plan 재사용 + 직전 달 호출로 delta 계산.
+- handoff 가 요구하는 데이터:
+  - 월별 합계 추이 (6~12 month: 기간 토글 m3/m6/y1)
+  - 카테고리별 전월 대비 delta % (이번 달 + 직전 달 비교)
+- ADR-F16 임계 트리거 (월 500건 / TTI 700ms) 가 6개월/1년 fetch 시 도달 가능 → backend endpoint 필요. 본 plan 은 클라 집계 + backend issue 등록 두 트랙.
+
+## 작업 항목
+
+### 1. type 추가
+
+`src/types/analytics.ts` 신규 (또는 `dashboard.ts` 확장):
+
+```ts
+export type AnalyticsPeriod = "m1" | "m3" | "m6" | "y1";
+
+export interface MonthlyTrendPoint {
+  year: number;
+  month: number;          // 1~12
+  totalExpense: number;
+}
+
+export interface MonthlyTrend {
+  period: AnalyticsPeriod;
+  points: MonthlyTrendPoint[];   // 시간 asc 정렬
+  average: number;               // 기간 평균
+}
+
+export interface CategoryWithDelta {
+  categoryUuid: string;
+  name: string;
+  icon: string;
+  totalAmount: number;
+  percentage: number;
+  deltaPercent: number | null;   // 전월 대비 %, null = 직전 달 데이터 없음
+}
+```
+
+### 2. service `getMonthlyTrend` + `getCategoryBreakdownWithDelta`
+
+`src/services/analytics/analytics-service.ts` 신규:
+
+- `getMonthlyTrend(familyUuid, period)`: period 에 따라 시작 월 계산 (m1=1, m3=3, m6=6, y1=12). 각 월별 expenses fetch 후 합계 누적. 평균 계산.
+- `getCategoryBreakdownWithDelta(familyUuid, year, month)`: plan002 `getMonthlyCategoryBreakdown` 을 이번 달 + 직전 달 두 번 호출. 각 카테고리 uuid 매칭으로 delta % 계산 (`((cur - prev) / prev) * 100`). 직전 달 부재 시 deltaPercent=null.
+
+ADR-F04: services 가 actions 호출 금지. 기존 expense service 재사용.
+
+### 3. action 신규
+
+- `src/actions/analytics/get-monthly-trend-action.ts`
+- `src/actions/analytics/get-category-breakdown-with-delta-action.ts`
+
+기존 `get-dashboard-stats-action.ts` 패턴 동일. `requireAuth` + `getSelectedFamilyUuid` + service 호출.
+
+### 4. backend issue 등록 — `monthly-trend` endpoint 요청
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+gh issue create --repo jon890/fos-accountbook-backend \
+  --title "feat(stats): GET /families/{uuid}/stats/monthly-trend endpoint" \
+  --body "$(cat <<'EOF'
+## 배경
+
+frontend plan006 (analytics 리디자인) 에서 월별 지출 추이 + 카테고리 전월 대비 delta 가 핵심 시각화 요소. 현재 ADR-F16 정신으로 클라 집계 우선 구현 중이지만, 기간 토글 6개월/1년 옵션에서 클라가 6~12개월 expenses 를 한 번에 fetch → ADR-F16 임계 트리거 (월 500건 / TTI 700ms) 도달 위험.
+
+## 요청 endpoint
+
+- `GET /families/{uuid}/stats/monthly-trend?from=YYYY-MM&to=YYYY-MM` — 월별 합계 + 평균
+- `GET /families/{uuid}/stats/category-breakdown?year=Y&month=M&compareWithPrev=true` — 카테고리 분포 + 전월 delta 통합
+
+## 응답 스키마 초안
+
+\`\`\`json
+// monthly-trend
+{
+  \"points\": [{ \"year\": 2026, \"month\": 5, \"totalExpense\": 2170000 }],
+  \"average\": 1985000
+}
+
+// category-breakdown with delta
+{
+  \"year\": 2026, \"month\": 5, \"totalExpense\": 2170000,
+  \"items\": [
+    { \"categoryUuid\": \"...\", \"name\": \"식비\", \"totalAmount\": 480000,
+      \"percentage\": 22, \"deltaPercent\": 12 }
+  ]
+}
+\`\`\`
+
+## frontend 측 동작
+
+- backend endpoint 도착 전: 클라 집계 (plan006 phase-01 구현)
+- backend endpoint 도착 후: plan007 또는 plan006-2 에서 service 측 호출 전환. type 시그니처 동일하게 설계 (DTO 호환)
+
+## 관련
+
+- frontend plan006: tasks/plan006-analytics-redesign/
+- ADR-F16 (frontend): 임계 트리거 도달 시 backend 분리 결정
+EOF
+)"
+```
+
+issue URL 을 commit message 본문에 명시.
+
+### 5. service 단위 테스트
+
+`src/__tests__/services/analytics/`:
+- `getMonthlyTrend.test.ts` — m1/m3/m6/y1 각 기간별 점 개수 + 평균 검증, 빈 월 (expenses 0건) 처리
+- `getCategoryBreakdownWithDelta.test.ts` — 이번 달 only / 직전 달 only / 양쪽 있음 케이스, delta % 정확성, deltaPercent=null 케이스
+- ADR-F09 jest.mock 방식
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test src/__tests__/services/analytics/ --run
+
+test -f src/types/analytics.ts
+test -f src/services/analytics/analytics-service.ts
+test -f src/actions/analytics/get-monthly-trend-action.ts
+test -f src/actions/analytics/get-category-breakdown-with-delta-action.ts
+
+# ADR-F04 위반 없음
+! grep -nE 'from ["\x27]@/actions' src/services/analytics/
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/types/analytics.ts` | 신규 |
+| `src/services/analytics/analytics-service.ts` | 신규 |
+| `src/actions/analytics/get-monthly-trend-action.ts` | 신규 |
+| `src/actions/analytics/get-category-breakdown-with-delta-action.ts` | 신규 |
+| `src/__tests__/services/analytics/*.test.ts` | 신규 2건 |
+
+## Out of Scope
+
+- UI 컴포넌트 (phase 2~4)
+- backend endpoint 구현 자체 — issue 등록만, 실제 구현은 backend 팀
+- backend endpoint 도착 후 service 전환 — plan007 (또는 plan006-2)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 1년 (y1) 기간 토글 시 12개월 × 평균 200건 = 2400건 fetch — 클라 처리 한계 | backend issue 등록으로 후속 전환 경로 확보. 사용자 측에서 y1 사용 빈도 낮으면 클라 집계로도 감당 가능 |
+| 직전 달 expenses 가 0건이라 delta 분모 0 | `deltaPercent: null` 반환. UI 측에서 "신규" 또는 "—" 표시 (phase 4) |
+| service 가 dashboard service 와 중복 fetch 로직 | `getMonthlyCategoryBreakdown` (plan002) 직접 import 재사용. fetch helper 도 공통 추출 검토 |

--- a/tasks/plan006-analytics-redesign/phase-02.md
+++ b/tasks/plan006-analytics-redesign/phase-02.md
@@ -1,0 +1,120 @@
+# Phase 02 — PeriodToggle (m1/m3/m6/y1) + URL searchParams
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 4종 기간 토글 (이번 달 / 3개월 / 6개월 / 1년) segmented control + URL searchParams 동기화 (ADR-F17 draft 패턴).
+
+## Context (자기완결)
+
+- handoff:
+  - mobile.jsx line 628~645 — 4개 segmented pill (`bg-bg-muted` container + active `bg-bg-elev shadow-subtle`)
+  - desktop.jsx line 672~696 — 동일 + 우측 날짜 범위 chip
+- plan003 의 `TransactionsTabs.tsx` 가 동일 segmented 패턴 — 컴포넌트 일반화 가능.
+- ADR-F17 (URL state draft 패턴) — plan003 에서 도출. URL searchParams 와 client state 동기화 시 commit 시점 명시.
+- 기간 변경 시 page.tsx 가 새 데이터 fetch (Server Component re-render) → `useRouter().replace('?period=m3')` 패턴.
+
+## 작업 항목
+
+### 1. `SegmentedToggle` 일반화 (plan003 패턴 추출)
+
+기존 `src/app/(authenticated)/transactions/_components/TransactionsTabs.tsx` 가 expenses 전용 — 본 phase 에서 generic `SegmentedToggle<TKey>` 신규 추출:
+
+`src/components/ui/segmented-toggle.tsx` 신규. Props:
+
+```ts
+interface SegmentedToggleProps<T extends string> {
+  options: ReadonlyArray<{ key: T; label: string }>;
+  value: T;
+  onChange: (next: T) => void;
+  disabled?: boolean;
+}
+```
+
+스타일 토큰 (`bg-bg-muted` / 활성 `bg-bg-elev shadow-subtle`) 은 그대로. plan003 TransactionsTabs 는 후속 plan 에서 이 generic 으로 마이그레이션 — 본 plan 범위 외 (Out of Scope).
+
+### 2. `AnalyticsPeriodToggle` 신규
+
+`src/app/(authenticated)/analytics/_components/AnalyticsPeriodToggle.tsx`. Props: `period: AnalyticsPeriod`, `onChange: (next: AnalyticsPeriod) => void`. 내부에서 `SegmentedToggle<AnalyticsPeriod>` 사용.
+
+옵션 4종:
+```ts
+const PERIOD_OPTIONS = [
+  { key: "m1", label: "이번 달" },
+  { key: "m3", label: "3개월" },
+  { key: "m6", label: "6개월" },
+  { key: "y1", label: "1년" },
+] as const;
+```
+
+### 3. URL searchParams 동기화
+
+`analytics/page.tsx` 가 `searchParams.period` 파싱:
+
+```ts
+interface AnalyticsSearchParams {
+  period?: AnalyticsPeriod;
+}
+const period: AnalyticsPeriod = ["m1","m3","m6","y1"].includes(rawPeriod) ? rawPeriod as AnalyticsPeriod : "m1";
+```
+
+`AnalyticsClient` 또는 신규 wrapper 가 `useRouter().replace('?period=...')` 로 URL 갱신. ADR-F17 패턴:
+- draft state 는 local (즉시 시각 반영)
+- URL commit 은 onChange 즉시 (debounce 불필요 — 4종 토글이라 빈번한 변경 X)
+
+### 4. 데스크톱 날짜 범위 chip (선택 표시)
+
+desktop.jsx line 688~696 의 우측 날짜 chip — 현재 period 의 from~to 표시:
+
+```tsx
+<DateRangeChip from={periodStartDate} to={today} />
+```
+
+읽기 전용 표시. 클릭 동작 (커스텀 범위) 는 plan007+ 로 보류.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/ui/segmented-toggle.tsx
+test -f src/app/\(authenticated\)/analytics/_components/AnalyticsPeriodToggle.tsx
+
+# segmented 디자인 토큰 사용
+grep -nE 'bg-bg-muted|bg-bg-elev|shadow-subtle' src/components/ui/segmented-toggle.tsx | wc -l   # >= 2
+
+# URL searchParams 동기화
+grep -nE 'period\?: AnalyticsPeriod|searchParams.*period' src/app/\(authenticated\)/analytics/page.tsx | wc -l   # >= 1
+
+# 4 옵션 정의
+grep -nE 'm1.*m3.*m6.*y1|key:\s*"m1"' src/app/\(authenticated\)/analytics/_components/AnalyticsPeriodToggle.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/analytics` → 4개 토글 표시. 클릭 시 URL `?period=m3` 변경 + 페이지 데이터 갱신.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/ui/segmented-toggle.tsx` | 신규 (generic) |
+| `src/app/(authenticated)/analytics/_components/AnalyticsPeriodToggle.tsx` | 신규 |
+| `src/app/(authenticated)/analytics/page.tsx` | 수정 (searchParams 파싱 + 액션 호출에 period 전달) |
+| `src/app/(authenticated)/analytics/_components/AnalyticsClient.tsx` | 수정 (period 상태 + URL 동기화) |
+
+## Out of Scope
+
+- TransactionsTabs (plan003) 의 SegmentedToggle 마이그레이션 — 후속 plan
+- 데스크톱 날짜 범위 chip 의 커스텀 범위 선택 (지금은 읽기 전용)
+- 모바일 sticky/scroll 동작 (스크롤 시 토글 고정)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| URL ?period 가 잘못된 값 (예: ?period=foo) | page.tsx 의 includes 가드. 기본값 m1 |
+| `useRouter().replace` 가 Server Component re-render 트리거 | 정상 동작 — 새 searchParams 로 Server Component 가 새 데이터 fetch. ADR-F12 패턴 |
+| 4개 토글이 모바일 너비에서 좁아 보임 | 12.5px font + `flex: 1` 등분. 4종이 한계 — 5개 이상이면 가로 스크롤 검토 (현재는 4개라 안전) |

--- a/tasks/plan006-analytics-redesign/phase-03.md
+++ b/tasks/plan006-analytics-redesign/phase-03.md
@@ -1,0 +1,103 @@
+# Phase 03 — CategoryDonut + 전월 delta 표기
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 카테고리 분포 Donut + 중앙 합계 + 전월 대비 delta 표시. plan002 의 Donut 패턴 재사용.
+
+## Context (자기완결)
+
+- handoff:
+  - mobile.jsx line 647~685 — Donut 172px + 중앙 "5월 지출" + 합계 + ↓13.8% 전월 delta + legend (6개 카테고리 dot+이름)
+  - desktop.jsx line 700~741 — Donut 160px + 우측 legend (6개 카테고리 dot+이름+%)
+- plan002 `src/components/dashboard/CategoryDistribution.tsx` 가 동일 Donut + 리스트 패턴. 컴포넌트 직접 재사용 또는 일반화.
+- 현재 `_components/CategoryPieChart.tsx` (52줄) — recharts Pie 기본 사용. 디자인 교체.
+- 데이터: phase 01 의 `getCategoryBreakdownWithDelta` (delta 포함).
+
+## 작업 항목
+
+### 1. `AnalyticsCategoryDonut` 신규
+
+`src/app/(authenticated)/analytics/_components/AnalyticsCategoryDonut.tsx`. Props:
+
+```ts
+interface AnalyticsCategoryDonutProps {
+  breakdown: {
+    totalExpense: number;
+    items: CategoryWithDelta[];
+    year: number;
+    month: number;
+  };
+  topN?: number;   // default 6
+}
+```
+
+Layout:
+- 모바일: Donut 172px 위에 + 중앙에 "5월 지출" 라벨 + 22px num 합계 + `text-expense` 11px delta (이전 달 합계 대비 — 전체 합계의 delta 계산)
+- 데스크톱: Donut 160px 좌측 + 1fr legend 우측 (이름 + %)
+- Donut 색: plan002 의 `getCategoryToneKey` + `--color-cat-{key}-fg` 토큰 (Pie cell fill)
+
+### 2. 전체 합계 delta 계산
+
+`getCategoryBreakdownWithDelta` 의 각 item 은 카테고리 별 delta. **전체 합계 delta** 는 별도 — `items.reduce((s, i) => s + i.totalAmount, 0)` 이번 달 vs 직전 달 동일 계산. service 측에서 함께 반환하거나 (phase-01 추가) 클라 계산.
+
+→ service 반환에 `totalDelta: number | null` 추가 (phase-01 type 보강 필요. 본 phase 시작 시 점검).
+
+### 3. `CategoryPieChart.tsx` 제거
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+grep -rn 'CategoryPieChart' src/   # 사용처 확인
+git rm src/app/\(authenticated\)/analytics/_components/CategoryPieChart.tsx
+```
+
+`AnalyticsClient.tsx` 의 import + 사용처를 `AnalyticsCategoryDonut` 로 교체.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/analytics/_components/AnalyticsCategoryDonut.tsx
+test ! -e src/app/\(authenticated\)/analytics/_components/CategoryPieChart.tsx
+
+grep -rn 'CategoryPieChart' src/ | wc -l   # = 0
+grep -n 'AnalyticsCategoryDonut' src/app/\(authenticated\)/analytics/ -r | wc -l   # >= 2
+
+# 카테고리 톤 토큰 사용 (plan002 헬퍼)
+grep -nE 'getCategoryToneKey|color-cat-' src/app/\(authenticated\)/analytics/_components/AnalyticsCategoryDonut.tsx | wc -l   # >= 1
+
+# .num 클래스 (합계 표기)
+grep -nE 'className=["\x27].*num' src/app/\(authenticated\)/analytics/_components/AnalyticsCategoryDonut.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/analytics?period=m1` → Donut + 중앙 합계 + delta. delta=null (직전 달 없음) 케이스에서 "—" 또는 숨김 표시.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/analytics/_components/AnalyticsCategoryDonut.tsx` | 신규 |
+| `src/app/(authenticated)/analytics/_components/CategoryPieChart.tsx` | 삭제 |
+| `src/app/(authenticated)/analytics/_components/AnalyticsClient.tsx` | 수정 (import 교체) |
+| `src/types/analytics.ts` 또는 `services/analytics/` | 수정 — `totalDelta` 필드 추가 |
+
+## Out of Scope
+
+- 카테고리별 클릭 → drill-down (`/transactions?categoryId=...`) — plan007+
+- 기간 m3/m6/y1 의 합계 표기 ("5월 지출" → "3개월 합계" 등 라벨 분기) — plan007+
+- 다중 카테고리 grouping (예: "기타 N개")
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 카테고리 7개 이상 시 legend 줄바꿈 어색 | `flex-wrap` + `topN=6` slice. 7번째부터 "기타" 합산은 plan007+ |
+| delta=null (직전 달 데이터 없음) UX | "—" 또는 영역 숨김. 첫 가입 가구 케이스 점검 |
+| recharts Pie 의 `minAngle` (0~3% 카테고리 가시성) | 4도 이상 보장. legend 가 백업 정보 |

--- a/tasks/plan006-analytics-redesign/phase-04.md
+++ b/tasks/plan006-analytics-redesign/phase-04.md
@@ -1,0 +1,139 @@
+# Phase 04 — MonthlyTrendBar + CategoryDetailList
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 월별 지출 추이 bar chart 신규 (Daily 제거) + 카테고리 상세 리스트 (progress + 전월 delta).
+
+## Context (자기완결)
+
+- handoff:
+  - mobile.jsx line 687~720 — bar chart 140px height, 마지막 막대 `--ab-brand-500` 강조 + 라벨 굵게
+  - desktop.jsx line 743~786 — 180px height + 평균 표기 + 막대 위 수치 라벨
+  - mobile.jsx line 722~770 / desktop.jsx line 789~838 — 카테고리 리스트 progress bar + 전월 delta % (양수=expense 색, 음수=income 색)
+- 데이터: phase-01 의 `MonthlyTrend` (월별 추이) + `CategoryWithDelta[]`
+- 현재 `_components/DailyBarChart.tsx` (74줄) — recharts Bar 일별. **제거 + Monthly 신규**.
+
+## 작업 항목
+
+### 1. `MonthlyTrendBar` 신규
+
+`src/app/(authenticated)/analytics/_components/MonthlyTrendBar.tsx`. Props:
+
+```ts
+interface MonthlyTrendBarProps {
+  trend: MonthlyTrend;       // phase-01
+}
+```
+
+Layout:
+- 헤더: "월별 지출 추이" 제목 + 우측 "평균 ₩X" (데스크톱만)
+- bars: `flex items-end` + 각 막대 height = `(point.totalExpense / max) * 100%`
+- 마지막 막대 (현재 월): `bg-brand-500` + 라벨 `font-bold`
+- 그 외: `bg-brand-100` + 라벨 `font-medium text-fg-muted`
+- 모바일 140px / 데스크톱 180px (`h-[140px] md:h-[180px]`)
+- 데스크톱은 막대 위에 `text-brand-700` 으로 `₩X만` 표기
+
+recharts 가 아닌 순수 CSS bar (단순 div 비율). handoff 가 recharts 의존 안 함. recharts 도입 시 ResponsiveContainer 등 오버헤드 — 단순 막대라 div 가 자연스러움.
+
+### 2. `CategoryDetailList` 신규
+
+`src/app/(authenticated)/analytics/_components/CategoryDetailList.tsx`. Props:
+
+```ts
+interface CategoryDetailListProps {
+  items: CategoryWithDelta[];      // phase-01
+  totalExpense: number;
+  topN?: number;                   // default 6
+}
+```
+
+Layout:
+- 헤더: "카테고리별" / 데스크톱은 "카테고리별 상세" + 우측 "전월 대비 증감 포함" 라벨
+- 모바일: vertical list — row 마다 icon(36px) + 이름 / 금액 / progress bar + delta %
+- 데스크톱: 2-col grid (`grid-cols-2 gap-x-6`) — row 5-col grid (icon 34 / 이름+progress 1fr / 금액 90 / delta 56)
+- progress bar: `bg-bg-muted` track + `bg-[var(--color-cat-{key}-fg)]` fill (plan002 톤)
+- delta: 양수 → `text-expense` + `+N%` / 음수 → `text-income` + `−N%` / null → "—" 또는 숨김
+
+### 3. `DailyBarChart.tsx` 제거
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+grep -rn 'DailyBarChart' src/   # 사용처 확인
+git rm src/app/\(authenticated\)/analytics/_components/DailyBarChart.tsx
+```
+
+`AnalyticsClient.tsx` 의 import + 사용처 제거. backend 의 daily endpoint (`getMonthlyDailyStatsAction`) 호출도 plan006 분석에서 제거되면 정리.
+
+### 4. `AnalyticsClient.tsx` 레이아웃 재구성
+
+handoff 순서로 JSX 재배열:
+
+**모바일** (single column):
+```
+AnalyticsPeriodToggle (phase 2)
+AnalyticsCategoryDonut (phase 3)
+MonthlyTrendBar
+CategoryDetailList
+```
+
+**데스크톱** (responsive grid):
+```
+AnalyticsPeriodToggle (+ DateRangeChip 우측)
+[Donut 1fr | MonthlyTrendBar 1.2fr] 2-col grid
+CategoryDetailList (full width, 2-col grid 내부)
+```
+
+`md:grid-cols-[1fr_1.2fr]` 패턴.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/analytics/_components/MonthlyTrendBar.tsx
+test -f src/app/\(authenticated\)/analytics/_components/CategoryDetailList.tsx
+test ! -e src/app/\(authenticated\)/analytics/_components/DailyBarChart.tsx
+
+grep -rn 'DailyBarChart' src/ | wc -l   # = 0
+
+# brand-500/100 토큰 (마지막 막대 vs 나머지)
+grep -nE 'bg-brand-500|bg-brand-100' src/app/\(authenticated\)/analytics/_components/MonthlyTrendBar.tsx | wc -l   # >= 2
+
+# delta 색 분기 (expense/income 토큰)
+grep -nE 'text-expense|text-income' src/app/\(authenticated\)/analytics/_components/CategoryDetailList.tsx | wc -l   # >= 2
+
+# 4 컴포넌트 page.tsx 순서
+node -e "const s=require('fs').readFileSync('src/app/(authenticated)/analytics/_components/AnalyticsClient.tsx','utf8'); const order=['<AnalyticsPeriodToggle','<AnalyticsCategoryDonut','<MonthlyTrendBar','<CategoryDetailList']; let last=-1; for (const c of order) { const i=s.indexOf(c); if (i<0||i<=last) { console.error('order broken:', c); process.exit(1) } last=i; } console.log('ok')"
+```
+
+수동 smoke: `/analytics?period=m6` → Donut + 6개 월 trend bar + 카테고리 리스트. 마지막 bar (현재 월) brand-500 강조. delta % 색 정상 (expense 빨강 / income 초록).
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/analytics/_components/MonthlyTrendBar.tsx` | 신규 |
+| `src/app/(authenticated)/analytics/_components/CategoryDetailList.tsx` | 신규 |
+| `src/app/(authenticated)/analytics/_components/DailyBarChart.tsx` | 삭제 |
+| `src/app/(authenticated)/analytics/_components/AnalyticsClient.tsx` | 수정 (레이아웃 재구성 + import 교체) |
+
+## Out of Scope
+
+- 막대 hover tooltip (recharts 없이 직접 구현은 plan007+ 검토)
+- delta=null 케이스의 시각 처리 정밀화 ("—" 또는 영역 숨김 — phase 본문 결정 따라 단순 구현)
+- 카테고리 클릭 → /transactions filter — plan007+
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `getMonthlyDailyStatsAction` 가 dashboard CalendarView 에서도 사용 중일 가능성 | grep 으로 사용처 확인 — analytics 외 사용처 있으면 action 자체는 보존, AnalyticsClient 의 호출만 제거 |
+| 막대 라벨 (y1 12개월) 이 좁아서 어색함 | `text-xs` + 모바일은 짝수 월만 표기 같은 분기 가능 — 본 plan 은 매월 표기, 가독성 부족 시 plan007+ 조정 |
+| delta 색이 카테고리 톤과 충돌 (식비 cell 안의 + delta 가 같은 톤?) | delta 는 별도 영역 (progress 우측) 에 표기 — cell 톤과 분리. 시각 충돌 0 |

--- a/tasks/plan006-analytics-redesign/phase-05.md
+++ b/tasks/plan006-analytics-redesign/phase-05.md
@@ -1,0 +1,112 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, legacy 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: type/service/action + backend issue (1) + PeriodToggle URL (2) + CategoryDonut (3) + MonthlyTrendBar/CategoryDetailList (4).
+- legacy 잔재 후보: `CategoryPieChart`, `DailyBarChart` 두 컴포넌트 — 모두 삭제 대상.
+- `_shared/common-pitfalls.md § 1-8` 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/006-analytics-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` + 어느 phase 가 회귀를 만들었는지 식별.
+
+### 2. Legacy 컴포넌트 삭제 검증
+
+```bash
+test ! -e src/app/\(authenticated\)/analytics/_components/CategoryPieChart.tsx
+test ! -e src/app/\(authenticated\)/analytics/_components/DailyBarChart.tsx
+
+grep -rn 'CategoryPieChart\|DailyBarChart' src/ | wc -l   # = 0
+```
+
+### 3. 신규 컴포넌트 / 헬퍼 / action 등록 확인
+
+```bash
+test -f src/app/\(authenticated\)/analytics/_components/AnalyticsPeriodToggle.tsx
+test -f src/app/\(authenticated\)/analytics/_components/AnalyticsCategoryDonut.tsx
+test -f src/app/\(authenticated\)/analytics/_components/MonthlyTrendBar.tsx
+test -f src/app/\(authenticated\)/analytics/_components/CategoryDetailList.tsx
+test -f src/components/ui/segmented-toggle.tsx
+test -f src/types/analytics.ts
+test -f src/services/analytics/analytics-service.ts
+test -f src/actions/analytics/get-monthly-trend-action.ts
+test -f src/actions/analytics/get-category-breakdown-with-delta-action.ts
+
+grep -n 'AnalyticsPeriod\|MonthlyTrend\|CategoryWithDelta' src/types/analytics.ts | wc -l   # >= 3
+```
+
+### 4. page.tsx 4섹션 순서
+
+```bash
+node -e "const s=require('fs').readFileSync('src/app/(authenticated)/analytics/_components/AnalyticsClient.tsx','utf8'); const order=['<AnalyticsPeriodToggle','<AnalyticsCategoryDonut','<MonthlyTrendBar','<CategoryDetailList']; let last=-1; for (const c of order) { const i=s.indexOf(c); if (i<0||i<=last) { console.error('order broken:', c); process.exit(1) } last=i; } console.log('ok')"
+```
+
+### 5. Hardcoded 색 잔재 0건 (plan001/002 효과 회귀 방지)
+
+```bash
+grep -rnE '#[0-9a-fA-F]{6}\b|hsl\(|rgb\(' src/app/\(authenticated\)/analytics/ \
+  | grep -vE 'rgba\(255,\s*255,\s*255' \
+  | grep -vE '\.test\.tsx?:'
+# 결과 0줄
+```
+
+### 6. URL searchParams 동기화 (ADR-F17 패턴)
+
+```bash
+grep -nE 'period\?: AnalyticsPeriod|searchParams.*period' src/app/\(authenticated\)/analytics/page.tsx | wc -l   # >= 1
+grep -nE 'useRouter|useSearchParams' src/app/\(authenticated\)/analytics/_components/AnalyticsClient.tsx | wc -l   # >= 1
+```
+
+### 7. backend issue 등록 확인 (phase-01 산출물)
+
+phase-01 commit message 또는 별도 본문에 backend issue URL 명시됨. plan006 PR description 에 issue 링크 포함.
+
+### 8. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan006-analytics-redesign/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan006-analytics-redesign/index.json
+grep -c '"status": "completed"' tasks/plan006-analytics-redesign/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan006-analytics-redesign/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan006-analytics-redesign/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan006-analytics-redesign/index.json` | 모든 status `completed` |
+| `tasks/plan006-analytics-redesign/phase-05.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- 시각 회귀 비교 스크린샷 (수동 smoke 항목으로만)
+- backend endpoint 도착 후 service 전환 — plan007 (또는 plan006-2)
+- DateRangeChip 의 커스텀 범위 선택 (현재 읽기 전용)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 안 문자열) | 라인 시작 앵커 + 정확한 토큰 매치 |
+| macOS BSD `sed -i ''` vs Linux GNU `sed -i` | 본 plan macOS 환경 가정 |
+| `getMonthlyDailyStatsAction` 가 dashboard 에서 사용 중이면 analytics 외 영향 | phase 4 의 grep 결과로 식별 후 보존 또는 보고 |


### PR DESCRIPTION
## Summary

/analytics 페이지 Teal fintech 리디자인 plan. handoff 4번째(마지막) 핵심 화면. plan002 Donut + plan003 segmented + ADR-F16/F17 패턴 재사용.

## 핵심 결정 (사용자 confirmed)

- 전월 대비 delta = 클라이언트 집계 (이번 달 + 직전 달 stats 두 번 호출)
- 기간 토글 4종 모두 (m1/m3/m6/y1)
- Daily 제거 + Monthly 신규 (handoff 그대로)
- **backend issue 동시 등록** (phase-01 에서) — 6개월/1년 기간 시 클라 부담 회피용. backend endpoint 도착 후 plan007 에서 전환

## Phase 구조 (5 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | type/service/action + backend issue 등록 | sonnet |
| 02 | PeriodToggle (m1/m3/m6/y1) + URL searchParams | sonnet |
| 03 | CategoryDonut + delta | sonnet |
| 04 | MonthlyTrendBar + CategoryDetailList | sonnet |
| 05 | 통합 검증 + completed | haiku |

## 의존성

- plan001 머지 완료 ✅ (OKLCH/Pretendard)
- plan002 머지 완료 ✅ (category-tone helper, Donut 패턴)
- plan003 머지 완료 ✅ (segmented 패턴, ADR-F17)

## 다음 단계

\`/build-with-teams plan006-analytics-redesign\` 호출 시 같은 브랜치에서 phase 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)