### PR TITLE
feat(expenses): add-expense 폼 Teal 리디자인 (plan005)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -281,5 +281,7 @@
   - URL 만 진실원 + 모든 입력 즉시 router.replace: 사용자 타이핑마다 navigation 발생 → 성능/UX 저하.
   - `key={searchParams}` 로 force-remount: 컴포넌트 내부 다른 state (Popover open 등) 도 reset 되는 부수효과.
 
-- **적용 범위**: URL searchParams 기반 client 필터 컴포넌트 전반. 첫 적용 사례 — `AmountRangeFilter.tsx` (plan003).
+- **적용 범위**: URL searchParams 기반 client 필터 컴포넌트 전반. 첫 적용 사례 — `AmountRangeFilter.tsx` (plan003). props 기반 추종에도 변형 적용 가능 (`AddExpenseDialog.tsx` 의 `activeTypeDraft ?? defaultType`, plan005).
+
+- **예외 — 외부 부수효과 진입 신호 (fetch trigger, subscription 등)**: `useEffect` 안 `setState(true)` 가 명백히 필요한 경우 (예: dialog open 시 fetch 시작 → `setIsLoadingCategories(true)` → fetch 결과로 `false`. derived value 로 대체 불가 — fetch 실패 시 영원히 loading) 는 해당 라인에 `// eslint-disable-next-line react-hooks/set-state-in-effect` + 1줄 사유 주석으로 허용. 신규 코드 작성 시 우선 derived 시도 → 막힐 경우만 적용. 첫 적용 사례 — `AddExpenseDialog.tsx:67` (plan005).
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -58,21 +58,22 @@
 ```
 [트랜잭션 페이지 또는 대시보드]
     │
-    └─ "+ 지출 추가" 버튼
-            └─ AddExpenseDialog (Sheet) 열림
+    └─ "+ 지출 추가" 버튼 (BottomNav FAB / QuickActions)
+            └─ AddExpenseDialog (responsive: mobile Sheet / md+ Dialog 720px)
                     │
-                    ├─ 카테고리 선택 (드롭다운)
-                    ├─ 금액 입력 (숫자)
-                    ├─ 날짜 선택 (DatePicker, default: 오늘)
-                    └─ 메모 입력 (선택)
-                            │
-                            └─ 저장 → createExpenseAction()
-                                    ├─ requireAuthOrRedirect()
-                                    ├─ getSelectedFamilyUuid()
-                                    ├─ Zod 검증
-                                    └─ createExpense() → POST /families/{uuid}/expenses
-                                            └─ revalidatePath 3곳
-                                                    └─ toast 성공 메시지
+                    ├─ Segmented toggle: 지출 / 수입 (gradient-expense / gradient-income)
+                    │
+                    ├─ ExpenseFormFields
+                    │   ├─ AmountInput (₩ + 56/64px num, 빠른 추가 칩 +1k/+5k/+10k, md+ 추가 +50k)
+                    │   ├─ CategoryGrid (5×2 mobile / 10×1 desktop, role=radiogroup, --color-cat-*-bg/-fg 톤)
+                    │   ├─ Date input (type="date", default: 오늘)
+                    │   └─ Description input (name="description", FormData key 보존)
+                    │
+                    └─ 저장 → createExpenseAction() / createIncomeAction()
+                            ├─ requireAuthOrRedirect()
+                            ├─ Zod 검증
+                            └─ create* → POST /families/{uuid}/{expenses|incomes}
+                                    └─ revalidatePath → toast 성공 메시지
 ```
 
 ---

--- a/src/__tests__/components/expenses/AmountInput.test.tsx
+++ b/src/__tests__/components/expenses/AmountInput.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * AmountInput 컴포넌트 테스트
+ *
+ * 테스트 범위:
+ * - 칩 클릭 시 onChange(value + delta) 호출
+ * - value=0 → "0" 표시 + ₩ prefix
+ * - value=38400 → "38,400" 표시 (콤마)
+ * - 음수 입력 가드 (onChange 호출값 0 이상)
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AmountInput } from "@/components/expenses/forms/AmountInput";
+
+describe("AmountInput", () => {
+  it("value=0일 때 '0'과 ₩ prefix를 표시한다", () => {
+    // Given & When
+    render(<AmountInput value={0} onChange={jest.fn()} />);
+
+    // Then
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("₩")).toBeInTheDocument();
+  });
+
+  it("value=38400일 때 '38,400'으로 표시한다 (콤마 구분)", () => {
+    // Given & When
+    render(<AmountInput value={38400} onChange={jest.fn()} />);
+
+    // Then
+    expect(screen.getByText("38,400")).toBeInTheDocument();
+  });
+
+  it("+1,000 칩 클릭 시 onChange(value + 1000)을 호출한다", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<AmountInput value={5000} onChange={onChange} />);
+
+    // When
+    const chip = screen.getByText("+1,000");
+    await user.click(chip);
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(6000);
+  });
+
+  it("+5,000 칩 클릭 시 onChange(value + 5000)을 호출한다", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<AmountInput value={0} onChange={onChange} />);
+
+    // When
+    const chip = screen.getByText("+5,000");
+    await user.click(chip);
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(5000);
+  });
+
+  it("+10,000 칩 클릭 시 onChange(value + 10000)을 호출한다", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<AmountInput value={10000} onChange={onChange} />);
+
+    // When
+    const chip = screen.getByText("+10,000");
+    await user.click(chip);
+
+    // Then
+    expect(onChange).toHaveBeenCalledWith(20000);
+  });
+
+  it("음수가 되는 경우 onChange(0)을 호출한다 (음수 가드)", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    // value=0인 상태에서 +1000 칩은 양수이므로, hidden input에 음수 직접 입력 테스트
+    const { container } = render(<AmountInput value={0} onChange={onChange} />);
+
+    // When: hidden input에 음수값 입력 시뮬레이션
+    const hiddenInput = container.querySelector('input[type="number"]');
+    expect(hiddenInput).toBeInTheDocument();
+
+    if (hiddenInput) {
+      await user.clear(hiddenInput);
+      await user.type(hiddenInput, "-500");
+    }
+
+    // Then: onChange가 0 이상 값으로만 호출되어야 함
+    const calls = onChange.mock.calls;
+    calls.forEach(([calledValue]) => {
+      expect(calledValue).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it("'얼마를 썼나요?' 라벨을 렌더링한다", () => {
+    // Given & When
+    render(<AmountInput value={0} onChange={jest.fn()} />);
+
+    // Then
+    expect(screen.getByText("얼마를 썼나요?")).toBeInTheDocument();
+  });
+
+  it("disabled 상태에서는 칩 버튼이 비활성화된다", () => {
+    // Given & When
+    render(<AmountInput value={0} onChange={jest.fn()} disabled />);
+
+    // Then
+    const chip = screen.getByText("+1,000");
+    expect(chip.closest("button")).toBeDisabled();
+  });
+});

--- a/src/__tests__/components/expenses/CategoryGrid.test.tsx
+++ b/src/__tests__/components/expenses/CategoryGrid.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CategoryGrid } from "@/components/expenses/forms/CategoryGrid";
+import type { CategoryResponse } from "@/types/category";
+
+function makeCategory(uuid: string, name: string, icon = "📦"): CategoryResponse {
+  return {
+    uuid,
+    familyUuid: "fam-1",
+    name,
+    icon,
+    createdAt: "2026-05-01T00:00:00Z",
+    updatedAt: "2026-05-01T00:00:00Z",
+  };
+}
+
+const sample10: CategoryResponse[] = [
+  makeCategory("c1", "식비"),
+  makeCategory("c2", "카페"),
+  makeCategory("c3", "교통"),
+  makeCategory("c4", "통신"),
+  makeCategory("c5", "주거"),
+  makeCategory("c6", "쇼핑"),
+  makeCategory("c7", "의료"),
+  makeCategory("c8", "여가"),
+  makeCategory("c9", "교육"),
+  makeCategory("c10", "기타"),
+];
+
+describe("CategoryGrid", () => {
+  it("renders all categories", () => {
+    render(<CategoryGrid categories={sample10} selectedUuid={null} onSelect={() => {}} />);
+    expect(screen.getAllByRole("radio")).toHaveLength(10);
+    expect(screen.getByText("식비")).toBeInTheDocument();
+    expect(screen.getByText("기타")).toBeInTheDocument();
+  });
+
+  it("uses responsive grid (grid-cols-5 + md:grid-cols-10)", () => {
+    const { container } = render(
+      <CategoryGrid categories={sample10} selectedUuid={null} onSelect={() => {}} />,
+    );
+    const grid = container.querySelector("[role=radiogroup]");
+    expect(grid?.className).toMatch(/grid-cols-5/);
+    expect(grid?.className).toMatch(/md:grid-cols-10/);
+  });
+
+  it("marks selected category with aria-checked and tone class", () => {
+    render(<CategoryGrid categories={sample10} selectedUuid="c1" onSelect={() => {}} />);
+    const selected = screen.getByRole("radio", { checked: true });
+    expect(selected).toHaveTextContent("식비");
+    expect(selected.className).toMatch(/bg-\[var\(--color-cat-food-bg\)\]/);
+  });
+
+  it("calls onSelect with uuid when clicked", () => {
+    const handler = jest.fn();
+    render(<CategoryGrid categories={sample10} selectedUuid={null} onSelect={handler} />);
+    fireEvent.click(screen.getByText("교통"));
+    expect(handler).toHaveBeenCalledWith("c3");
+  });
+
+  it("falls back to etc tone for unknown category name", () => {
+    const custom = [makeCategory("cx", "기상천외 카테고리")];
+    render(<CategoryGrid categories={custom} selectedUuid="cx" onSelect={() => {}} />);
+    const selected = screen.getByRole("radio", { checked: true });
+    expect(selected.className).toMatch(/bg-\[var\(--color-cat-etc-bg\)\]/);
+  });
+
+  it("disables all buttons when disabled prop is true", () => {
+    render(<CategoryGrid categories={sample10} selectedUuid={null} onSelect={() => {}} disabled />);
+    screen.getAllByRole("radio").forEach((btn) => {
+      expect(btn).toBeDisabled();
+    });
+  });
+});

--- a/src/components/expenses/dialogs/AddExpenseDialog.tsx
+++ b/src/components/expenses/dialogs/AddExpenseDialog.tsx
@@ -1,12 +1,7 @@
-/**
- * 거래 추가 다이얼로그 (지출 / 수입 전환 가능)
- */
-
 "use client";
 
 import { getFamilyCategoriesAction } from "@/actions/category/get-categories-action";
 import { createExpenseAction } from "@/actions/expense/create-expense-action";
-import type { CreateIncomeFormState } from "@/types/income";
 import { createIncomeAction } from "@/actions/income/create-income-action";
 import { cn } from "@/lib/client/utils";
 import { Button } from "@/components/ui/button";
@@ -16,12 +11,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { ExpenseFormFields } from "@/components/expenses/forms/ExpenseFormFields";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { toLocalDateInput } from "@/lib/utils/format";
 import type { CreateExpenseFormState } from "@/types/expense";
+import type { CreateIncomeFormState } from "@/types/income";
 import type { CategoryResponse } from "@/types/category";
-import { Loader2, TrendingDown, TrendingUp } from "lucide-react";
+import { TrendingDown, TrendingUp } from "lucide-react";
 import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -33,65 +36,56 @@ interface AddExpenseDialogProps {
   defaultType?: TransactionType;
 }
 
-const initialExpenseState: CreateExpenseFormState = {
-  message: "",
-  errors: {},
-  success: false,
-};
-
-const initialIncomeState: CreateIncomeFormState = {
-  message: "",
-  errors: {},
-  success: false,
-};
+const initialExpenseState: CreateExpenseFormState = { message: "", errors: {}, success: false };
+const initialIncomeState: CreateIncomeFormState = { message: "", errors: {}, success: false };
 
 export function AddExpenseDialog({
   open,
   onOpenChange,
   defaultType = "expense",
 }: AddExpenseDialogProps) {
-  const [activeType, setActiveType] = useState<TransactionType>(defaultType);
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [activeTypeDraft, setActiveTypeDraft] = useState<TransactionType | null>(null);
+  const activeType = activeTypeDraft ?? defaultType;
+  const setActiveType = setActiveTypeDraft;
   const [categories, setCategories] = useState<CategoryResponse[]>([]);
   const [familyUuid, setFamilyUuid] = useState<string>("");
   const [isLoadingCategories, setIsLoadingCategories] = useState(false);
 
-  const [expenseState, expenseFormAction] = useActionState(
-    createExpenseAction,
-    initialExpenseState
-  );
-  const [incomeState, incomeFormAction] = useActionState(
-    createIncomeAction,
-    initialIncomeState
-  );
+  const [amount, setAmount] = useState(0);
+  const [categoryUuid, setCategoryUuid] = useState<string | null>(null);
+  const [date, setDate] = useState(toLocalDateInput());
+  const [description, setDescription] = useState("");
+
+  const [expenseState, expenseFormAction] = useActionState(createExpenseAction, initialExpenseState);
+  const [incomeState, incomeFormAction] = useActionState(createIncomeAction, initialIncomeState);
 
   useEffect(() => {
-    if (open) {
-      setActiveType(defaultType);
-      loadData();
-    } else {
-      setCategories([]);
-      setFamilyUuid("");
-    }
-  }, [open, defaultType]);
-
-  const loadData = async () => {
+    if (!open) return;
+    let cancelled = false;
+    // open 진입 시점에 fetch 시작 신호 — derived value 로 대체 불가 (fetch 실패 시 영원히 loading)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsLoadingCategories(true);
-    try {
-      const result = await getFamilyCategoriesAction();
-      if (result.success) {
-        setCategories(result.data);
-        if (result.data.length > 0) {
-          setFamilyUuid(result.data[0].familyUuid);
+    getFamilyCategoriesAction()
+      .then((result) => {
+        if (cancelled) return;
+        if (result.success) {
+          setCategories(result.data);
+          if (result.data.length > 0) setFamilyUuid(result.data[0].familyUuid);
+        } else {
+          toast.error(result.error.message);
         }
-      } else {
-        toast.error(result.error.message);
-      }
-    } catch {
-      toast.error("카테고리를 불러오는데 실패했습니다");
-    } finally {
-      setIsLoadingCategories(false);
-    }
-  };
+      })
+      .catch(() => {
+        if (!cancelled) toast.error("카테고리를 불러오는데 실패했습니다");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingCategories(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   useEffect(() => {
     if (expenseState.success) {
@@ -115,143 +109,86 @@ export function AddExpenseDialog({
   const formAction = isExpense ? expenseFormAction : incomeFormAction;
   const errors = isExpense ? expenseState.errors : incomeState.errors;
 
+  const body = (
+    <form action={formAction} className="space-y-5">
+      <input type="hidden" name="familyUuid" value={familyUuid} />
+      <div className="flex gap-1 bg-bg-muted p-1 rounded-xl">
+        <button
+          type="button"
+          onClick={() => setActiveType("expense")}
+          className={cn(
+            "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-sm font-semibold transition-all",
+            isExpense ? "gradient-expense text-white shadow-sm" : "text-fg-muted hover:text-fg",
+          )}
+        >
+          <TrendingDown className="w-4 h-4" />
+          지출
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveType("income")}
+          className={cn(
+            "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-sm font-semibold transition-all",
+            !isExpense ? "gradient-income text-white shadow-sm" : "text-fg-muted hover:text-fg",
+          )}
+        >
+          <TrendingUp className="w-4 h-4" />
+          수입
+        </button>
+      </div>
+
+      <ExpenseFormFields
+        categories={categories}
+        amount={amount}
+        onAmountChange={setAmount}
+        categoryUuid={categoryUuid}
+        onCategoryChange={setCategoryUuid}
+        date={date}
+        onDateChange={setDate}
+        description={description}
+        onDescriptionChange={setDescription}
+        isLoadingCategories={isLoadingCategories}
+        errors={errors}
+      />
+
+      <div className="flex gap-2 pt-2">
+        <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+          취소
+        </Button>
+        <SubmitButton
+          className={cn(
+            "flex-1 text-white hover:opacity-90",
+            isExpense ? "gradient-expense" : "gradient-income",
+          )}
+          pendingText="추가 중..."
+        >
+          {isExpense ? "지출" : "수입"} 추가
+        </SubmitButton>
+      </div>
+    </form>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[720px] bg-bg-elev">
+          <DialogHeader>
+            <DialogTitle className="sr-only">거래 추가</DialogTitle>
+          </DialogHeader>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md bg-white">
-        <DialogHeader>
-          <DialogTitle className="sr-only">거래 추가</DialogTitle>
-          {/* 지출 / 수입 타입 토글 */}
-          <div className="flex gap-1 bg-gray-100 p-1 rounded-xl">
-            <button
-              type="button"
-              onClick={() => setActiveType("expense")}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-sm font-semibold transition-all duration-200",
-                isExpense
-                  ? "gradient-expense text-white shadow-sm"
-                  : "text-gray-500 hover:text-gray-700 hover:bg-white/60"
-              )}
-            >
-              <TrendingDown className="w-4 h-4" />
-              지출
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveType("income")}
-              className={cn(
-                "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-sm font-semibold transition-all duration-200",
-                !isExpense
-                  ? "gradient-income text-white shadow-sm"
-                  : "text-gray-500 hover:text-gray-700 hover:bg-white/60"
-              )}
-            >
-              <TrendingUp className="w-4 h-4" />
-              수입
-            </button>
-          </div>
-        </DialogHeader>
-
-        <form action={formAction} className="space-y-4">
-          <input type="hidden" name="familyUuid" value={familyUuid} />
-
-          {/* 금액 */}
-          <div className="space-y-2">
-            <Label htmlFor="amount">금액 *</Label>
-            <div className="relative">
-              <Input
-                id="amount"
-                name="amount"
-                type="number"
-                placeholder="0"
-                className="text-right pr-8"
-                required
-              />
-              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                원
-              </span>
-            </div>
-            {errors?.amount && (
-              <p className="text-sm text-red-500">{errors.amount[0]}</p>
-            )}
-          </div>
-
-          {/* 카테고리 */}
-          <div className="space-y-2">
-            <Label htmlFor="categoryId">카테고리 *</Label>
-            {isLoadingCategories ? (
-              <div className="flex items-center justify-center py-2">
-                <Loader2 className="w-4 h-4 animate-spin" />
-              </div>
-            ) : (
-              <select
-                id="categoryId"
-                name="categoryId"
-                className="w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                required
-              >
-                <option value="">카테고리를 선택하세요</option>
-                {categories.map((cat) => (
-                  <option key={cat.uuid} value={cat.uuid}>
-                    {cat.icon} {cat.name}
-                  </option>
-                ))}
-              </select>
-            )}
-            {errors?.categoryId && (
-              <p className="text-sm text-red-500">{errors.categoryId[0]}</p>
-            )}
-          </div>
-
-          {/* 날짜 */}
-          <div className="space-y-2">
-            <Label htmlFor="date">날짜 *</Label>
-            <Input
-              id="date"
-              name="date"
-              type="date"
-              defaultValue={new Date().toISOString().split("T")[0]}
-              required
-            />
-            {errors?.date && (
-              <p className="text-sm text-red-500">{errors.date[0]}</p>
-            )}
-          </div>
-
-          {/* 메모 */}
-          <div className="space-y-2">
-            <Label htmlFor="description">메모</Label>
-            <Input
-              id="description"
-              name="description"
-              placeholder="간단한 메모를 입력하세요 (선택사항)"
-            />
-            {errors?.description && (
-              <p className="text-sm text-red-500">{errors.description[0]}</p>
-            )}
-          </div>
-
-          {/* 버튼 */}
-          <div className="flex gap-2 pt-4">
-            <Button
-              type="button"
-              variant="outline"
-              className="flex-1"
-              onClick={() => onOpenChange(false)}
-            >
-              취소
-            </Button>
-            <SubmitButton
-              className={cn(
-                "flex-1 text-white hover:opacity-90",
-                isExpense ? "gradient-expense" : "gradient-income"
-              )}
-              pendingText="추가 중..."
-            >
-              {isExpense ? "지출" : "수입"} 추가
-            </SubmitButton>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[100dvh] p-0 bg-bg-elev">
+        <SheetHeader className="px-5 py-3 border-b border-border">
+          <SheetTitle>거래 추가</SheetTitle>
+        </SheetHeader>
+        <div className="px-5 py-4 overflow-y-auto h-[calc(100dvh-56px)]">{body}</div>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/src/components/expenses/dialogs/EditExpenseDialog.tsx
+++ b/src/components/expenses/dialogs/EditExpenseDialog.tsx
@@ -9,8 +9,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { ExpenseFormFields } from "@/components/expenses/forms/ExpenseFormFields";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { UpdateExpenseFormState } from "@/types/expense";
 import type { CategoryResponse } from "@/types/category";
 import { toLocalDateInput } from "@/lib/utils/format";
@@ -32,11 +39,7 @@ interface EditExpenseDialogProps {
   isLoadingCategories?: boolean;
 }
 
-const initialState: UpdateExpenseFormState = {
-  message: "",
-  errors: {},
-  success: false,
-};
+const initialState: UpdateExpenseFormState = { message: "", errors: {}, success: false };
 
 export function EditExpenseDialog({
   open,
@@ -46,6 +49,7 @@ export function EditExpenseDialog({
   categories,
   isLoadingCategories = false,
 }: EditExpenseDialogProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
   const [state, formAction] = useActionState(updateExpenseAction, initialState);
   const [amount, setAmount] = useState(Number(expense.amount));
   const [categoryUuid, setCategoryUuid] = useState<string | null>(expense.categoryUuid);
@@ -61,40 +65,56 @@ export function EditExpenseDialog({
     }
   }, [state, onOpenChange]);
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>지출 수정</DialogTitle>
-          <DialogDescription>지출 내역을 수정합니다</DialogDescription>
-        </DialogHeader>
+  const body = (
+    <form action={formAction} className="space-y-5">
+      <input type="hidden" name="expenseUuid" value={expense.uuid} />
+      <input type="hidden" name="familyUuid" value={familyUuid} />
+      <ExpenseFormFields
+        categories={categories}
+        amount={amount}
+        onAmountChange={setAmount}
+        categoryUuid={categoryUuid}
+        onCategoryChange={setCategoryUuid}
+        date={date}
+        onDateChange={setDate}
+        description={description}
+        onDescriptionChange={setDescription}
+        isLoadingCategories={isLoadingCategories}
+        errors={state.errors}
+      />
+      <div className="flex gap-2 pt-2">
+        <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+          취소
+        </Button>
+        <SubmitButton className="flex-1" pendingText="수정 중...">
+          수정하기
+        </SubmitButton>
+      </div>
+    </form>
+  );
 
-        <form action={formAction} className="space-y-5">
-          <input type="hidden" name="expenseUuid" value={expense.uuid} />
-          <input type="hidden" name="familyUuid" value={familyUuid} />
-          <ExpenseFormFields
-            categories={categories}
-            amount={amount}
-            onAmountChange={setAmount}
-            categoryUuid={categoryUuid}
-            onCategoryChange={setCategoryUuid}
-            date={date}
-            onDateChange={setDate}
-            description={description}
-            onDescriptionChange={setDescription}
-            isLoadingCategories={isLoadingCategories}
-            errors={state.errors}
-          />
-          <div className="flex gap-2 pt-2">
-            <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
-              취소
-            </Button>
-            <SubmitButton className="flex-1" pendingText="수정 중...">
-              수정하기
-            </SubmitButton>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[720px] bg-bg-elev">
+          <DialogHeader>
+            <DialogTitle>지출 수정</DialogTitle>
+            <DialogDescription>지출 내역을 수정합니다</DialogDescription>
+          </DialogHeader>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-[100dvh] p-0 bg-bg-elev">
+        <SheetHeader className="px-5 py-3 border-b border-border">
+          <SheetTitle>지출 수정</SheetTitle>
+        </SheetHeader>
+        <div className="px-5 py-4 overflow-y-auto h-[calc(100dvh-56px)]">{body}</div>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/src/components/expenses/dialogs/EditExpenseDialog.tsx
+++ b/src/components/expenses/dialogs/EditExpenseDialog.tsx
@@ -51,6 +51,7 @@ export function EditExpenseDialog({
 }: EditExpenseDialogProps) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const [state, formAction] = useActionState(updateExpenseAction, initialState);
+  // 호출자는 매 expense 마다 unmount/remount 패턴 — 동일 인스턴스 prop 교체 시 초기값 미반영. 키 재사용 시 버그 가능
   const [amount, setAmount] = useState(Number(expense.amount));
   const [categoryUuid, setCategoryUuid] = useState<string | null>(expense.categoryUuid);
   const [date, setDate] = useState(toLocalDateInput(expense.date));

--- a/src/components/expenses/dialogs/EditExpenseDialog.tsx
+++ b/src/components/expenses/dialogs/EditExpenseDialog.tsx
@@ -1,7 +1,3 @@
-/**
- * 지출 수정 다이얼로그
- */
-
 "use client";
 
 import { updateExpenseAction } from "@/actions/expense/update-expense-action";
@@ -13,14 +9,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { ExpenseFormFields } from "@/components/expenses/forms/ExpenseFormFields";
 import type { UpdateExpenseFormState } from "@/types/expense";
 import type { CategoryResponse } from "@/types/category";
 import { toLocalDateInput } from "@/lib/utils/format";
-import { Loader2 } from "lucide-react";
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 interface EditExpenseDialogProps {
@@ -53,11 +47,11 @@ export function EditExpenseDialog({
   isLoadingCategories = false,
 }: EditExpenseDialogProps) {
   const [state, formAction] = useActionState(updateExpenseAction, initialState);
+  const [amount, setAmount] = useState(Number(expense.amount));
+  const [categoryUuid, setCategoryUuid] = useState<string | null>(expense.categoryUuid);
+  const [date, setDate] = useState(toLocalDateInput(expense.date));
+  const [description, setDescription] = useState(expense.description ?? "");
 
-  // 날짜를 YYYY-MM-DD 형식으로 변환 (로컬 시간 기준, UTC 오프셋 문제 방지)
-  const formattedDate = toLocalDateInput(expense.date);
-
-  // 성공 시 처리
   useEffect(() => {
     if (state.success) {
       toast.success(state.message || "지출이 수정되었습니다");
@@ -75,102 +69,24 @@ export function EditExpenseDialog({
           <DialogDescription>지출 내역을 수정합니다</DialogDescription>
         </DialogHeader>
 
-        <form action={formAction} className="space-y-4">
-          {/* Hidden fields */}
+        <form action={formAction} className="space-y-5">
           <input type="hidden" name="expenseUuid" value={expense.uuid} />
           <input type="hidden" name="familyUuid" value={familyUuid} />
-
-          {/* 금액 입력 */}
-          <div className="space-y-2">
-            <Label htmlFor="amount">금액 *</Label>
-            <div className="relative">
-              <Input
-                id="amount"
-                name="amount"
-                type="number"
-                placeholder="0"
-                defaultValue={expense.amount}
-                className="text-right pr-8"
-                required
-              />
-              <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                원
-              </span>
-            </div>
-            {state.errors?.amount && (
-              <p className="text-sm text-destructive">{state.errors.amount[0]}</p>
-            )}
-          </div>
-
-          {/* 카테고리 선택 */}
-          <div className="space-y-2">
-            <Label htmlFor="categoryId">카테고리 *</Label>
-            {isLoadingCategories ? (
-              <div className="flex items-center justify-center py-2">
-                <Loader2 className="w-4 h-4 animate-spin" />
-              </div>
-            ) : (
-              <select
-                id="categoryId"
-                name="categoryId"
-                defaultValue={expense.categoryUuid}
-                className="w-full rounded-md border border-input bg-card px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                required
-              >
-                <option value="">카테고리를 선택하세요</option>
-                {categories.map((category) => (
-                  <option key={category.uuid} value={category.uuid}>
-                    {category.icon} {category.name}
-                  </option>
-                ))}
-              </select>
-            )}
-            {state.errors?.categoryId && (
-              <p className="text-sm text-destructive">
-                {state.errors.categoryId[0]}
-              </p>
-            )}
-          </div>
-
-          {/* 날짜 선택 */}
-          <div className="space-y-2">
-            <Label htmlFor="date">날짜 *</Label>
-            <Input
-              id="date"
-              name="date"
-              type="date"
-              defaultValue={formattedDate}
-              required
-            />
-            {state.errors?.date && (
-              <p className="text-sm text-destructive">{state.errors.date[0]}</p>
-            )}
-          </div>
-
-          {/* 메모 입력 */}
-          <div className="space-y-2">
-            <Label htmlFor="description">메모</Label>
-            <Input
-              id="description"
-              name="description"
-              placeholder="간단한 메모를 입력하세요 (선택사항)"
-              defaultValue={expense.description || ""}
-            />
-            {state.errors?.description && (
-              <p className="text-sm text-destructive">
-                {state.errors.description[0]}
-              </p>
-            )}
-          </div>
-
-          {/* 버튼들 */}
-          <div className="flex gap-2 pt-4">
-            <Button
-              type="button"
-              variant="outline"
-              className="flex-1"
-              onClick={() => onOpenChange(false)}
-            >
+          <ExpenseFormFields
+            categories={categories}
+            amount={amount}
+            onAmountChange={setAmount}
+            categoryUuid={categoryUuid}
+            onCategoryChange={setCategoryUuid}
+            date={date}
+            onDateChange={setDate}
+            description={description}
+            onDescriptionChange={setDescription}
+            isLoadingCategories={isLoadingCategories}
+            errors={state.errors}
+          />
+          <div className="flex gap-2 pt-2">
+            <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
               취소
             </Button>
             <SubmitButton className="flex-1" pendingText="수정 중...">

--- a/src/components/expenses/forms/AddExpenseForm.tsx
+++ b/src/components/expenses/forms/AddExpenseForm.tsx
@@ -2,15 +2,13 @@
 
 import { createExpenseAction } from "@/actions/expense/create-expense-action";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { SubmitButton } from "@/components/ui/submit-button";
 import type { CreateExpenseFormState } from "@/types/expense";
 import type { CategoryResponse } from "@/types/category";
 import { toLocalDateInput } from "@/lib/utils/format";
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { ExpenseFormFields } from "./ExpenseFormFields";
 
 interface AddExpenseFormProps {
   categories: CategoryResponse[];
@@ -32,122 +30,45 @@ export function AddExpenseForm({
   onCancel,
 }: AddExpenseFormProps) {
   const [state, formAction] = useActionState(createExpenseAction, initialState);
+  const [amount, setAmount] = useState(0);
+  const [categoryUuid, setCategoryUuid] = useState<string | null>(null);
+  const [date, setDate] = useState(toLocalDateInput());
+  const [description, setDescription] = useState("");
 
-  // 성공 시 처리
   useEffect(() => {
     if (state.success) {
-      toast.success("지출이 추가되었습니다", {
-        description: state.message,
-      });
+      toast.success("지출이 추가되었습니다", { description: state.message });
       onSuccess?.();
     } else if (state.message && !state.success) {
-      toast.error("오류가 발생했습니다", {
-        description: state.message,
-      });
+      toast.error("오류가 발생했습니다", { description: state.message });
     }
   }, [state, onSuccess]);
 
   return (
-    <Card className="w-full max-w-md mx-auto">
-      <CardHeader>
-        <CardTitle className="text-center">지출 추가</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form action={formAction} className="space-y-4">
-          {/* familyUuid hidden input */}
-          <input type="hidden" name="familyUuid" value={familyUuid} />
-          {/* 금액 입력 */}
-          <div className="space-y-2">
-            <Label htmlFor="amount">금액 *</Label>
-            <div className="relative">
-              <Input
-                id="amount"
-                name="amount"
-                type="number"
-                placeholder="0"
-                className="text-right pr-8"
-                required
-              />
-              <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-sm text-gray-500">
-                원
-              </span>
-            </div>
-            {state.errors?.amount && (
-              <p className="text-sm text-red-500">{state.errors.amount[0]}</p>
-            )}
-          </div>
-
-          {/* 카테고리 선택 */}
-          <div className="space-y-2">
-            <Label htmlFor="categoryId">카테고리 *</Label>
-            <select
-              id="categoryId"
-              name="categoryId"
-              className="w-full rounded-md border border-input bg-white px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              required
-            >
-              <option value="">카테고리를 선택하세요</option>
-              {categories.map((category) => (
-                <option key={category.uuid} value={category.uuid}>
-                  {category.icon} {category.name}
-                </option>
-              ))}
-            </select>
-            {state.errors?.categoryId && (
-              <p className="text-sm text-red-500">
-                {state.errors.categoryId[0]}
-              </p>
-            )}
-          </div>
-
-          {/* 날짜 선택 */}
-          <div className="space-y-2">
-            <Label htmlFor="date">날짜 *</Label>
-            <Input
-              id="date"
-              name="date"
-              type="date"
-              defaultValue={toLocalDateInput()}
-              required
-            />
-            {state.errors?.date && (
-              <p className="text-sm text-red-500">{state.errors.date[0]}</p>
-            )}
-          </div>
-
-          {/* 메모 입력 */}
-          <div className="space-y-2">
-            <Label htmlFor="description">메모</Label>
-            <Input
-              id="description"
-              name="description"
-              placeholder="간단한 메모를 입력하세요 (선택사항)"
-            />
-            {state.errors?.description && (
-              <p className="text-sm text-red-500">
-                {state.errors.description[0]}
-              </p>
-            )}
-          </div>
-
-          {/* 버튼들 */}
-          <div className="flex gap-2 pt-4">
-            {onCancel && (
-              <Button
-                type="button"
-                variant="outline"
-                className="flex-1"
-                onClick={onCancel}
-              >
-                취소
-              </Button>
-            )}
-            <SubmitButton className="flex-1" pendingText="추가 중...">
-              지출 추가
-            </SubmitButton>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+    <form action={formAction} className="space-y-5">
+      <input type="hidden" name="familyUuid" value={familyUuid} />
+      <ExpenseFormFields
+        categories={categories}
+        amount={amount}
+        onAmountChange={setAmount}
+        categoryUuid={categoryUuid}
+        onCategoryChange={setCategoryUuid}
+        date={date}
+        onDateChange={setDate}
+        description={description}
+        onDescriptionChange={setDescription}
+        errors={state.errors}
+      />
+      <div className="flex gap-2 pt-2">
+        {onCancel && (
+          <Button type="button" variant="outline" className="flex-1" onClick={onCancel}>
+            취소
+          </Button>
+        )}
+        <SubmitButton className="flex-1" pendingText="추가 중...">
+          지출 추가
+        </SubmitButton>
+      </div>
+    </form>
   );
 }

--- a/src/components/expenses/forms/AmountInput.tsx
+++ b/src/components/expenses/forms/AmountInput.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { cn } from "@/lib/client/utils";
 
 interface AmountInputProps {
+  id?: string;
   value: number;
   onChange: (next: number) => void;
   disabled?: boolean;
@@ -12,7 +13,7 @@ interface AmountInputProps {
 const MOBILE_CHIPS = [1000, 5000, 10000] as const;
 const DESKTOP_ONLY_CHIP = 50000;
 
-export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
+export function AmountInput({ id, value, onChange, disabled }: AmountInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleChipClick = (delta: number) => {
@@ -62,6 +63,7 @@ export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
 
         {/* 직접 입력 hidden input */}
         <input
+          id={id}
           ref={inputRef}
           type="number"
           inputMode="numeric"

--- a/src/components/expenses/forms/AmountInput.tsx
+++ b/src/components/expenses/forms/AmountInput.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRef } from "react";
+import { cn } from "@/lib/client/utils";
+
+interface AmountInputProps {
+  value: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+}
+
+const MOBILE_CHIPS = [1000, 5000, 10000] as const;
+const DESKTOP_ONLY_CHIP = 50000;
+
+export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChipClick = (delta: number) => {
+    onChange(Math.max(0, value + delta));
+  };
+
+  const handleDisplayClick = () => {
+    inputRef.current?.focus();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    const parsed = parseInt(raw, 10);
+    onChange(Math.max(0, isNaN(parsed) ? 0 : parsed));
+  };
+
+  const displayValue = value.toLocaleString("ko-KR");
+
+  return (
+    <div className="space-y-3">
+      {/* 라벨 */}
+      <p className="text-[12px] text-[var(--color-fg-muted)]">얼마를 썼나요?</p>
+
+      {/* 금액 디스플레이 영역 */}
+      <div
+        className="flex items-baseline gap-1 cursor-text"
+        onClick={handleDisplayClick}
+      >
+        {/* ₩ prefix */}
+        <span className="text-[28px] md:text-[32px] font-bold text-[var(--color-fg-muted)] leading-none">
+          ₩
+        </span>
+
+        {/* 금액 표시 */}
+        <span
+          className={cn(
+            "num",
+            "text-[56px] md:text-[64px] font-bold leading-none",
+            "overflow-hidden text-ellipsis whitespace-nowrap max-w-[280px] md:max-w-[360px]",
+            "[letter-spacing:-0.035em]"
+          )}
+          style={{ letterSpacing: "-0.035em" }}
+          aria-live="polite"
+          aria-label={`금액 ${displayValue}원`}
+        >
+          {displayValue}
+        </span>
+
+        {/* 직접 입력 hidden input */}
+        <input
+          ref={inputRef}
+          type="number"
+          inputMode="numeric"
+          value={value === 0 ? "" : value}
+          onChange={handleInputChange}
+          disabled={disabled}
+          className="sr-only"
+          aria-label="금액 직접 입력"
+          min={0}
+        />
+      </div>
+
+      {/* 빠른 추가 칩 row */}
+      <div className="flex gap-2">
+        {MOBILE_CHIPS.map((delta) => (
+          <button
+            key={delta}
+            type="button"
+            onClick={() => handleChipClick(delta)}
+            disabled={disabled}
+            className={cn(
+              "inline-flex items-center justify-center",
+              "rounded-full border border-[var(--color-border)] bg-[var(--color-bg-elev)]",
+              "px-3 py-1.5 text-sm font-medium text-[var(--color-fg)]",
+              "transition-transform active:scale-95",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            +{delta.toLocaleString("ko-KR")}
+          </button>
+        ))}
+
+        {/* 데스크톱 전용 칩 (+50,000) */}
+        <button
+          type="button"
+          onClick={() => handleChipClick(DESKTOP_ONLY_CHIP)}
+          disabled={disabled}
+          className={cn(
+            "hidden md:inline-flex items-center justify-center",
+            "rounded-full border border-[var(--color-border)] bg-[var(--color-bg-elev)]",
+            "px-3 py-1.5 text-sm font-medium text-[var(--color-fg)]",
+            "transition-transform active:scale-95",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          +{DESKTOP_ONLY_CHIP.toLocaleString("ko-KR")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/expenses/forms/AmountInput.tsx
+++ b/src/components/expenses/forms/AmountInput.tsx
@@ -54,7 +54,6 @@ export function AmountInput({ value, onChange, disabled }: AmountInputProps) {
             "overflow-hidden text-ellipsis whitespace-nowrap max-w-[280px] md:max-w-[360px]",
             "[letter-spacing:-0.035em]"
           )}
-          style={{ letterSpacing: "-0.035em" }}
           aria-live="polite"
           aria-label={`금액 ${displayValue}원`}
         >

--- a/src/components/expenses/forms/CategoryGrid.tsx
+++ b/src/components/expenses/forms/CategoryGrid.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { cn } from "@/lib/client/utils";
+import { getCategoryToneKey, type CategoryToneKey } from "@/lib/utils/category-tone";
+import type { CategoryResponse } from "@/types/category";
+
+interface CategoryGridProps {
+  categories: CategoryResponse[];
+  selectedUuid: string | null;
+  onSelect: (uuid: string) => void;
+  disabled?: boolean;
+}
+
+const TONE_CLASS: Record<CategoryToneKey, { bg: string; border: string; text: string }> = {
+  food:      { bg: "bg-[var(--color-cat-food-bg)]",      border: "border-[var(--color-cat-food-fg)]",      text: "text-[var(--color-cat-food-fg)]" },
+  cafe:      { bg: "bg-[var(--color-cat-cafe-bg)]",      border: "border-[var(--color-cat-cafe-fg)]",      text: "text-[var(--color-cat-cafe-fg)]" },
+  transit:   { bg: "bg-[var(--color-cat-transit-bg)]",   border: "border-[var(--color-cat-transit-fg)]",   text: "text-[var(--color-cat-transit-fg)]" },
+  telecom:   { bg: "bg-[var(--color-cat-telecom-bg)]",   border: "border-[var(--color-cat-telecom-fg)]",   text: "text-[var(--color-cat-telecom-fg)]" },
+  home:      { bg: "bg-[var(--color-cat-home-bg)]",      border: "border-[var(--color-cat-home-fg)]",      text: "text-[var(--color-cat-home-fg)]" },
+  shopping:  { bg: "bg-[var(--color-cat-shopping-bg)]",  border: "border-[var(--color-cat-shopping-fg)]",  text: "text-[var(--color-cat-shopping-fg)]" },
+  health:    { bg: "bg-[var(--color-cat-health-bg)]",    border: "border-[var(--color-cat-health-fg)]",    text: "text-[var(--color-cat-health-fg)]" },
+  leisure:   { bg: "bg-[var(--color-cat-leisure-bg)]",   border: "border-[var(--color-cat-leisure-fg)]",   text: "text-[var(--color-cat-leisure-fg)]" },
+  education: { bg: "bg-[var(--color-cat-education-bg)]", border: "border-[var(--color-cat-education-fg)]", text: "text-[var(--color-cat-education-fg)]" },
+  etc:       { bg: "bg-[var(--color-cat-etc-bg)]",       border: "border-[var(--color-cat-etc-fg)]",       text: "text-[var(--color-cat-etc-fg)]" },
+};
+
+export function CategoryGrid({
+  categories,
+  selectedUuid,
+  onSelect,
+  disabled,
+}: CategoryGridProps) {
+  return (
+    <div className="grid gap-2 grid-cols-5 md:grid-cols-10" role="radiogroup" aria-label="카테고리 선택">
+      {categories.map((category) => {
+        const toneKey = getCategoryToneKey(category.name);
+        const tone = TONE_CLASS[toneKey];
+        const isSelected = selectedUuid === category.uuid;
+        return (
+          <button
+            key={category.uuid}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            disabled={disabled}
+            onClick={() => onSelect(category.uuid)}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 rounded-xl border-[1.5px] px-1 py-2 transition-colors disabled:opacity-50 disabled:pointer-events-none",
+              isSelected
+                ? cn(tone.bg, tone.border)
+                : "bg-bg border-border hover:bg-bg-muted",
+            )}
+          >
+            <span className="text-[32px] leading-none md:text-[28px]" aria-hidden="true">
+              {category.icon ?? "📦"}
+            </span>
+            <span
+              className={cn(
+                "text-[11px] leading-tight truncate max-w-full",
+                isSelected ? cn(tone.text, "font-bold") : "text-fg-muted font-medium",
+              )}
+            >
+              {category.name}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/expenses/forms/ExpenseFormFields.tsx
+++ b/src/components/expenses/forms/ExpenseFormFields.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AmountInput } from "./AmountInput";
+import { CategoryGrid } from "./CategoryGrid";
+import type { CategoryResponse } from "@/types/category";
+
+interface ExpenseFormFieldsProps {
+  categories: CategoryResponse[];
+  amount: number;
+  onAmountChange: (next: number) => void;
+  categoryUuid: string | null;
+  onCategoryChange: (uuid: string) => void;
+  date: string;
+  onDateChange: (next: string) => void;
+  description: string;
+  onDescriptionChange: (next: string) => void;
+  isLoadingCategories?: boolean;
+  errors?: {
+    amount?: string[];
+    categoryId?: string[];
+    date?: string[];
+    description?: string[];
+  };
+  disabled?: boolean;
+}
+
+export function ExpenseFormFields({
+  categories,
+  amount,
+  onAmountChange,
+  categoryUuid,
+  onCategoryChange,
+  date,
+  onDateChange,
+  description,
+  onDescriptionChange,
+  isLoadingCategories,
+  errors,
+  disabled,
+}: ExpenseFormFieldsProps) {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <Label htmlFor="amount">금액 *</Label>
+        <AmountInput value={amount} onChange={onAmountChange} disabled={disabled} />
+        <input type="hidden" name="amount" value={amount} />
+        {errors?.amount && <p className="text-sm text-expense">{errors.amount[0]}</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label>카테고리 *</Label>
+        {isLoadingCategories ? (
+          <div className="h-20 flex items-center justify-center text-sm text-fg-muted">
+            카테고리를 불러오는 중...
+          </div>
+        ) : (
+          <CategoryGrid
+            categories={categories}
+            selectedUuid={categoryUuid}
+            onSelect={onCategoryChange}
+            disabled={disabled}
+          />
+        )}
+        <input type="hidden" name="categoryId" value={categoryUuid ?? ""} />
+        {errors?.categoryId && <p className="text-sm text-expense">{errors.categoryId[0]}</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="date">날짜 *</Label>
+        <Input
+          id="date"
+          name="date"
+          type="date"
+          value={date}
+          onChange={(e) => onDateChange(e.target.value)}
+          disabled={disabled}
+          required
+        />
+        {errors?.date && <p className="text-sm text-expense">{errors.date[0]}</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="description">메모</Label>
+        <Input
+          id="description"
+          name="description"
+          placeholder="간단한 메모 (선택사항)"
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+          disabled={disabled}
+        />
+        {errors?.description && <p className="text-sm text-expense">{errors.description[0]}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/expenses/forms/ExpenseFormFields.tsx
+++ b/src/components/expenses/forms/ExpenseFormFields.tsx
@@ -44,7 +44,7 @@ export function ExpenseFormFields({
     <div className="space-y-5">
       <div className="space-y-2">
         <Label htmlFor="amount">금액 *</Label>
-        <AmountInput value={amount} onChange={onAmountChange} disabled={disabled} />
+        <AmountInput id="amount" value={amount} onChange={onAmountChange} disabled={disabled} />
         <input type="hidden" name="amount" value={amount} />
         {errors?.amount && <p className="text-sm text-expense">{errors.amount[0]}</p>}
       </div>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (callback) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    },
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -2,14 +2,33 @@
 
 import { useSyncExternalStore } from "react";
 
-export function useMediaQuery(query: string): boolean {
-  return useSyncExternalStore(
-    (callback) => {
+const subscribeCache = new Map<string, (callback: () => void) => () => void>();
+const getSnapshotCache = new Map<string, () => boolean>();
+
+function getSubscribe(query: string): (callback: () => void) => () => void {
+  let subscribe = subscribeCache.get(query);
+  if (!subscribe) {
+    subscribe = (callback) => {
       const mql = window.matchMedia(query);
       mql.addEventListener("change", callback);
       return () => mql.removeEventListener("change", callback);
-    },
-    () => window.matchMedia(query).matches,
-    () => false,
-  );
+    };
+    subscribeCache.set(query, subscribe);
+  }
+  return subscribe;
+}
+
+function getSnapshotFn(query: string): () => boolean {
+  let fn = getSnapshotCache.get(query);
+  if (!fn) {
+    fn = () => window.matchMedia(query).matches;
+    getSnapshotCache.set(query, fn);
+  }
+  return fn;
+}
+
+const ssrFallback = () => false;
+
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(getSubscribe(query), getSnapshotFn(query), ssrFallback);
 }

--- a/src/lib/utils/category-tone.ts
+++ b/src/lib/utils/category-tone.ts
@@ -51,9 +51,12 @@ const NAME_TO_KEY: Record<string, CategoryToneKey> = {
   기타: "etc",
 };
 
+export function getCategoryToneKey(name: string): CategoryToneKey {
+  return NAME_TO_KEY[name.trim()] ?? "etc";
+}
+
 export function getCategoryTone(name: string): CategoryTone {
-  const key = NAME_TO_KEY[name.trim()] ?? "etc";
-  return TONE_MAP[key];
+  return TONE_MAP[getCategoryToneKey(name)];
 }
 
 export function getCategoryToneStyle(name: string): { background: string; color: string } {

--- a/tasks/plan005-add-expense-redesign/index.json
+++ b/tasks/plan005-add-expense-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan005-add-expense-redesign",
   "description": "지출 추가/편집 폼 Teal fintech 리디자인 — 큰 금액 input(56px num) + 빠른 추가 칩(+1k/+5k/+10k) + 카테고리 grid(plan002 톤 토큰) + Mobile bottom Sheet/Desktop 720px Dialog responsive. Edit 폼도 같이 통일.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-10",
   "total_phases": 5,
   "related_docs": [
@@ -23,35 +23,35 @@
       "file": "phase-01.md",
       "title": "AmountInput 신규 — 56px num input + 빠른 추가 칩 (+1k/+5k/+10k)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "CategoryGrid 신규 — 5×2 mobile / 10×1 desktop + 톤 ring (plan002 헬퍼 재사용)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "ExpenseFormFields 통합 + AddExpenseForm/EditExpenseDialog 마이그레이션",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "AddExpenseSheet (mobile) / AddExpenseDialog (desktop) responsive wrapper + 진입점 분기",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 5,
       "file": "phase-05.md",
       "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan005-add-expense-redesign/phase-02.md
+++ b/tasks/plan005-add-expense-redesign/phase-02.md
@@ -17,6 +17,20 @@
 
 ## 작업 항목
 
+### 0. `category-tone.ts` 에 `getCategoryToneKey` export 추가 (선행 — 필수)
+
+현재 `src/lib/utils/category-tone.ts` 는 `getCategoryTone(name): CategoryTone`, `getCategoryToneStyle(name)`, `CategoryToneKey` 타입만 export. **키 추출 헬퍼 부재** — 본 phase 의 `CategoryGrid` 가 정적 클래스 record 를 키로 lookup 하려면 키 자체가 필요.
+
+추가:
+
+```ts
+export function getCategoryToneKey(name: string): CategoryToneKey {
+  return NAME_TO_KEY[name.trim()] ?? "etc";
+}
+```
+
+(기존 `getCategoryTone` 내부 로직과 동일 — 한 줄 export 만 추가)
+
 ### 1. `CategoryGrid` 신규 컴포넌트
 
 `src/components/expenses/forms/CategoryGrid.tsx`. Props:
@@ -33,10 +47,31 @@ interface CategoryGridProps {
 Layout:
 - container `grid gap-2 grid-cols-5 md:grid-cols-10`
 - cell: 32px (mobile) / 28px (desktop) icon + 11px label
-- 선택 시: `bg-[var(--color-cat-{key}-bg)]` + `border-[var(--color-cat-{key}-fg)]` (1.5px) + label `text-[var(--color-cat-{key}-fg)]` `font-bold`
+- 선택 시: 정적 record 의 톤 className 적용
 - 비선택: `bg-bg` + `border-border` + label `text-fg-muted` `font-medium`
 
-`category-tone.ts` 의 `getCategoryToneKey(category.name)` 으로 톤 키 추출. 매칭 실패 시 `etc` 톤 (plan002 기본 동작).
+`category-tone.ts` 의 `getCategoryToneKey(category.name)` 으로 톤 키 추출 (위 §0 에서 추가됨). 매칭 실패 시 `etc` 톤.
+
+**Tailwind v4 dynamic class 회피 — 정적 record 필수**:
+
+```ts
+import type { CategoryToneKey } from "@/lib/utils/category-tone";
+
+const TONE_CLASS: Record<CategoryToneKey, { bg: string; border: string; text: string }> = {
+  food:      { bg: "bg-[var(--color-cat-food-bg)]",      border: "border-[var(--color-cat-food-fg)]",      text: "text-[var(--color-cat-food-fg)]" },
+  cafe:      { bg: "bg-[var(--color-cat-cafe-bg)]",      border: "border-[var(--color-cat-cafe-fg)]",      text: "text-[var(--color-cat-cafe-fg)]" },
+  transit:   { bg: "bg-[var(--color-cat-transit-bg)]",   border: "border-[var(--color-cat-transit-fg)]",   text: "text-[var(--color-cat-transit-fg)]" },
+  telecom:   { bg: "bg-[var(--color-cat-telecom-bg)]",   border: "border-[var(--color-cat-telecom-fg)]",   text: "text-[var(--color-cat-telecom-fg)]" },
+  home:      { bg: "bg-[var(--color-cat-home-bg)]",      border: "border-[var(--color-cat-home-fg)]",      text: "text-[var(--color-cat-home-fg)]" },
+  shopping:  { bg: "bg-[var(--color-cat-shopping-bg)]",  border: "border-[var(--color-cat-shopping-fg)]",  text: "text-[var(--color-cat-shopping-fg)]" },
+  health:    { bg: "bg-[var(--color-cat-health-bg)]",    border: "border-[var(--color-cat-health-fg)]",    text: "text-[var(--color-cat-health-fg)]" },
+  leisure:   { bg: "bg-[var(--color-cat-leisure-bg)]",   border: "border-[var(--color-cat-leisure-fg)]",   text: "text-[var(--color-cat-leisure-fg)]" },
+  education: { bg: "bg-[var(--color-cat-education-bg)]", border: "border-[var(--color-cat-education-fg)]", text: "text-[var(--color-cat-education-fg)]" },
+  etc:       { bg: "bg-[var(--color-cat-etc-bg)]",       border: "border-[var(--color-cat-etc-fg)]",       text: "text-[var(--color-cat-etc-fg)]" },
+};
+```
+
+동적 보간 (`bg-[var(--color-cat-${key}-bg)]`) 절대 금지 — Tailwind 빌드 시 누락. **사전 정의된 10 키만 사용**.
 
 ### 2. 아이콘 매핑
 

--- a/tasks/plan005-add-expense-redesign/phase-03.md
+++ b/tasks/plan005-add-expense-redesign/phase-03.md
@@ -29,18 +29,24 @@ interface ExpenseFormFieldsProps {
   onCategoryChange: (uuid: string) => void;
   date: string;             // ISO YYYY-MM-DD
   onDateChange: (next: string) => void;
-  memo: string;
-  onMemoChange: (next: string) => void;
+  description: string;             // FormData key 보존 — 기존 AddExpenseForm/EditExpenseDialog 가 name="description" 사용
+  onDescriptionChange: (next: string) => void;
   disabled?: boolean;
 }
 ```
+
+**FormData key 보존 — 결정**: handoff UI 라벨이 "메모" 로 표시되더라도 **prop 이름과 hidden input `name=` 은 `description` 으로 통일**. 이유:
+- 기존 `createExpenseAction` / `updateExpenseAction` 의 FormData key 가 `description`
+- `CreateExpenseFormState.errors.description` 도 동일 key 사용
+- action 시그니처 변경 시 backend dto / Zod schema 동시 변경 발생 → plan005 scope 외
+- UI 라벨은 `FieldLabel` 텍스트로 "메모" 표시, prop 만 description
 
 Layout (top → bottom):
 1. AmountInput (phase 1)
 2. divider (border-bottom)
 3. FieldLabel "카테고리" + CategoryGrid (phase 2)
 4. FieldLabel "날짜" + DateField (calendar Popover trigger)
-5. FieldLabel "메모" + Input (memo)
+5. FieldLabel "메모" + Input (name="description", value=description prop)
 
 `FieldLabel` / `FieldRow` 헬퍼는 컴포넌트 안 사적 정의 (handoff mockup line 277~285 참조).
 
@@ -49,8 +55,10 @@ Layout (top → bottom):
 `src/components/expenses/forms/AddExpenseForm.tsx` 재작성:
 - `useActionState` + `createExpenseAction` 흐름 그대로
 - form 본문을 `<ExpenseFormFields />` 로 교체
-- 4개 필드 state (amount/categoryUuid/date/memo) 는 `useState` 로 유지
-- form submit 시 hidden input 또는 FormData 로 action 에 전달 (기존 패턴 그대로)
+- 4개 필드 state (amount/categoryUuid/date/description) 는 `useState` 로 유지
+- form submit 시 hidden input 또는 FormData 로 action 에 전달 (기존 패턴 그대로 — `name="description"` 등)
+
+**Props 시그니처 변동**: 기존 `AddExpenseFormProps` 는 `categories`/`familyUuid`/`onSuccess?`/`onCancel?` 로 변경 없음 (호출자 `AddExpenseDialog` 무영향). form 내부 구조만 변경.
 
 ### 3. `EditExpenseDialog` 마이그레이션
 
@@ -61,7 +69,7 @@ Layout (top → bottom):
   categories={categories}
   amount={Number(expense.amount)}
   onAmountChange={setAmount}
-  categoryUuid={expense.category.uuid}
+  categoryUuid={expense.categoryUuid}
   // ...
 />
 ```

--- a/tasks/plan005-add-expense-redesign/phase-04.md
+++ b/tasks/plan005-add-expense-redesign/phase-04.md
@@ -13,10 +13,9 @@
 - shadcn 컴포넌트:
   - `src/components/ui/sheet.tsx` (이미 사용 중)
   - `src/components/ui/dialog.tsx` (이미 사용 중)
-- 진입점:
-  - `src/components/layout/BottomNavigation.tsx:97` — FAB → AddExpenseDialog
-  - `src/components/dashboard/QuickActions.tsx:47` — 버튼 → AddExpenseDialog
-  - `src/app/(authenticated)/transactions/_components/ExpenseTabContent.tsx` — 페이지 내 추가
+- 진입점 (실측 — 2곳):
+  - `src/components/layout/BottomNavigation.tsx:98` — FAB → AddExpenseDialog
+  - `src/components/dashboard/QuickActions.tsx:122` — 버튼 → AddExpenseDialog
 - 모든 진입점이 `AddExpenseDialog` 호출 → wrapper 한 곳만 고치면 전파.
 
 ## 작업 항목
@@ -73,17 +72,17 @@ grep -rn "useMediaQuery\|useBreakpoint\|matchMedia" src/hooks src/lib 2>/dev/nul
 
 또는 CSS-only 분기 (`md:hidden` / `hidden md:block` 두 wrapper 모두 렌더) 가능하나 — 두 트리 모두 mount 되면 form state 가 둘로 나뉨. JS hook 분기가 단순.
 
-### 3. 진입점 검증 (변경 0)
+### 3. 진입점 검증 (변경 0 — 2곳 실측)
 
 ```bash
 # cwd: /Users/nhn/personal/fos-accountbook
 # branch: plan/005-add-expense-redesign
 
-# 진입점 3곳에서 AddExpenseDialog 호출 그대로
-grep -rn 'AddExpenseDialog' src/components/layout/ src/components/dashboard/QuickActions.tsx src/app/\(authenticated\)/transactions/ 2>/dev/null
+# 진입점 2곳에서 AddExpenseDialog 호출 그대로
+grep -rn 'AddExpenseDialog' src/components/layout/BottomNavigation.tsx src/components/dashboard/QuickActions.tsx 2>/dev/null | wc -l   # >= 2 (각 파일 import + 사용)
 ```
 
-각 호출 site 변경 0. props (open/onOpenChange/categories) 시그니처 동일.
+각 호출 site 변경 0. props (open/onOpenChange/categories/familyUuid) 시그니처 동일.
 
 ### 4. EditExpenseDialog 도 동일 패턴
 
@@ -128,11 +127,12 @@ grep -nE 'from ["\x27]@/components/ui/sheet|from ["\x27]@/components/ui/dialog' 
 - BottomNavigation FAB 디자인 변경 — 별도 plan
 - /add 전용 라우트 신설 (사용자 결정으로 X)
 - ExpenseFilters / Recurring sheet 의 responsive 패턴 — 별도 plan
+- viewport 회전 중 form state 보존 — 빈도 낮음, lift state 비용 큰 변경. 사용자 보고 빈도 따라 차후 plan 분리
 
 ## Risks
 
 | 리스크 | 완화 |
 |---|---|
-| viewport 전환 시 폼 state 손실 (Dialog → Sheet 또는 반대) | 부모 컴포넌트에서 form state 관리 + AddExpenseDialog 는 단순 wrapper. open prop 만 부모가 통제. 단 phase 03 의 form state 위치 점검 — 폼 컴포넌트 내부면 wrapper 교체 시 unmount 됨 |
+| viewport 전환 시 폼 state 손실 (Dialog → Sheet 또는 반대) | **Out of Scope 결정** — viewport 회전 중 폼 reset 은 허용 (실사용 빈도 낮음, lift state 시 prop drill 4개 + AddExpenseDialog API 복잡화). 모바일 회전 / 데스크톱 resize 가 768px breakpoint 를 넘는 경우만 발생. 차후 사용자 보고 빈도 보고 plan 분리 검토 |
 | `useMediaQuery` SSR hydration mismatch | 초기값 false (모바일 가정) + `useEffect` 로 mount 후 갱신. 첫 렌더 mismatch 가능성 있으면 `suppressHydrationWarning` 명시 또는 `useSyncExternalStore` 패턴 |
 | Sheet `h-[100dvh]` 가 iOS Safari 의 동적 viewport 와 충돌 | `100dvh` 가 표준. 폴백 `100vh` 하드코딩 회피 — 표준 단위 사용 |

--- a/tasks/plan005-add-expense-redesign/phase-05.md
+++ b/tasks/plan005-add-expense-redesign/phase-05.md
@@ -1,7 +1,7 @@
 # Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
 
 **Model**: haiku
-**Status**: pending
+**Status**: completed
 **Goal**: phase 01~04 산출물 통합 검증, 신규 컴포넌트 등록 확인, `index.json` status `completed` 마킹.
 
 ## Context (자기완결)


### PR DESCRIPTION
## Summary

plan005 — 지출/수입 추가·수정 폼 Teal fintech 리디자인. 큰 금액 input + 빠른 추가 칩 + 카테고리 grid + 모바일 Sheet / 데스크톱 720px Dialog 분기.

### 변경 사항

**phase 1** (`98e123a`)
- `AmountInput` 신규 — 56/64px num display + ₩ prefix + 빠른 추가 칩 (+1k/+5k/+10k, md+ +50k)
- 단위 테스트 8 케이스

**phase 2** (`7151723`)
- `category-tone.ts` 에 `getCategoryToneKey` 신규 export
- `CategoryGrid` 신규 — 5×2 mobile / 10×1 desktop responsive, `TONE_CLASS` 정적 record (Tailwind v4 dynamic 회피)
- 단위 테스트 6 케이스

**phase 3** (`fc5cfdc`)
- `ExpenseFormFields` 신규 (Amount + Category + Date + Description)
- `AddExpenseForm` / `EditExpenseDialog` 마이그레이션
- prop 이름 `description` 통일 (FormData key 보존, action 무변경)

**phase 4** (`b0fe188`)
- `useMediaQuery` 신규 (useSyncExternalStore, SSR-safe)
- `AddExpenseDialog` / `EditExpenseDialog` 모바일 Sheet / 데스크톱 Dialog 분기
- `activeTypeDraft` derived 패턴 (ADR-F17)

**phase 5 + docs** (`98ba844` + `b200788`)
- 통합 검증 + status=completed
- flow.md §3 갱신, ADR-F17 set-state-in-effect 예외 보론

### Test plan

- [x] pnpm lint
- [x] pnpm tsc --noEmit
- [x] pnpm test (205 / 29 suites)
- [ ] 모바일 viewport — Sheet 풀화면 + 빠른 추가 칩 동작
- [ ] 데스크톱 viewport — 720px Dialog + +50k 칩 노출
- [ ] CategoryGrid 톤 색 (식비/카페/교통 등) 적용 확인
- [ ] Edit 다이얼로그 initial values + 저장 동작
- [ ] 지출/수입 토글 segmented 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)