### PR TITLE
docs(plan007): react-day-picker v10 + @daypicker/react migration plan

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -283,3 +283,20 @@
 
 - **적용 범위**: URL searchParams 기반 client 필터 컴포넌트 전반. 첫 적용 사례 — `AmountRangeFilter.tsx` (plan003).
 
+---
+
+## ADR-F18: react-day-picker → @daypicker/react 패키지 이전 (2026-05-11)
+
+- **결정**: `react-day-picker` v9 → v10 메이저 업그레이드 + 패키지명을 공식 권장 신 namespace 인 `@daypicker/react` 로 이전. v10 의 폐기 props/event handler 일괄 교체.
+- **맥락**: PR #222 (Dependabot) 가 단순 dep bump 만 제안 — 폐기 API 제거된 v10 에서 코드 마이그레이션 누락 시 빌드/런타임 회귀. 또 v10 공식 권장이 신 namespace `@daypicker/react` 로 이동 (장기 수명 + non-Gregorian calendar 들도 `@daypicker/*` 스코프). frontend 사용처는 단 2 파일 (`src/components/ui/calendar.tsx` shadcn wrapper + `src/components/dashboard/CalendarView.tsx`) 로 작아 한 PR 에 dep+코드 통합 적합.
+- **대안 기각**:
+  - `react-day-picker` 패키지명 유지: v10 호환 OK 이지만 신 namespace 가 공식 표준. 후속 add-on 패키지 (`@daypicker/persian` 등) 와 일관성.
+  - v9 stick: 보안/유지보수 리스크 누적. 메이저 upgrade 가 작아 미루지 않는 게 합리적.
+- **트레이드오프**: import 경로 + `style.css` 경로 갱신 필요. `DayPicker` API 자체는 동일 export. peer dep 충돌 점검 필요 (구 이름 의존 다른 dep 가 있으면).
+- **폐기 prop 교체 매핑**:
+  - `fromMonth/toMonth` → `startMonth/endMonth`
+  - `fromDate/toDate` → `hidden={{ before/after }}`
+  - `initialFocus` → `autoFocus`
+  - `onWeekNumberClick/onDayKey*/onDayPointer*/onDayTouch*` → 커스텀 `WeekNumber`/`DayButton` 컴포넌트
+- **적용 범위**: `package.json`, `src/components/ui/calendar.tsx`, `src/components/dashboard/CalendarView.tsx`.
+

--- a/tasks/plan007-react-day-picker-v10/index.json
+++ b/tasks/plan007-react-day-picker-v10/index.json
@@ -1,0 +1,44 @@
+{
+  "name": "plan007-react-day-picker-v10",
+  "description": "react-day-picker 9.14 → 10.0 메이저 + @daypicker/react 신 namespace 이전. 폐기 props (fromMonth/toMonth/initialFocus 등) 일괄 교체. PR #222 (Dependabot dep bump only) 대체.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 4,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "prerequisites": [
+    "ADR-F18 갱신 commit (이 PR 포함) — react-day-picker v10 + 신 패키지명 결정 docs 동기화",
+    "PR #222 (Dependabot react-day-picker bump) 은 본 plan PR 머지 후 close — 사용자 결정"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "@daypicker/react 패키지 추가 + react-day-picker 제거 + 폐기 prop 사용처 grep",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "shadcn calendar.tsx 마이그레이션 (import 경로 + style.css + 폐기 prop 교체)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "CalendarView.tsx DayButton 마이그레이션 (DayButtonProps 시그니처 점검)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan007-react-day-picker-v10/phase-01.md
+++ b/tasks/plan007-react-day-picker-v10/phase-01.md
@@ -1,0 +1,88 @@
+# Phase 01 — @daypicker/react 패키지 이전 + 폐기 prop 사용처 grep
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `react-day-picker` → `@daypicker/react` 패키지 이전 + v10 폐기 prop 사용처 식별 (사후 phase 2~3 에서 교체).
+
+## Context (자기완결)
+
+- 사용처 단일 grep 결과 (2 파일):
+  - `src/components/ui/calendar.tsx` (68줄) — `import { DayPicker } from "react-day-picker"`
+  - `src/components/dashboard/CalendarView.tsx` — `import { DayButtonProps } from "react-day-picker"`
+- v10 공식 권장: 신 namespace `@daypicker/react`. 구 `react-day-picker` 패키지도 v10 호환 유지하지만 ADR-F18 결정으로 신 namespace 채택.
+- 폐기 props (ADR-F18 매핑 표): `fromMonth/toMonth/fromYear/toYear/fromDate/toDate/initialFocus` + `onDayKey*/onDayPointer*/onDayTouch*`.
+
+## 작업 항목
+
+### 1. dep 교체
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/007-react-day-picker-v10
+pnpm remove react-day-picker
+pnpm add @daypicker/react@^10.0.0
+```
+
+`package.json` 의 `react-day-picker` 제거 + `@daypicker/react` 추가. `pnpm-lock.yaml` 자동 갱신.
+
+### 2. 폐기 prop 사용처 grep
+
+```bash
+# 우리 코드에서 폐기 prop 사용 여부
+grep -rnE 'fromMonth|toMonth|fromYear|toYear|fromDate|toDate|initialFocus|onWeekNumberClick|onDayKeyUp|onDayKeyPress|onDayPointerEnter|onDayPointerLeave|onDayTouchCancel|onDayTouchEnd|onDayTouchMove|onDayTouchStart' \
+  src/components/ui/calendar.tsx src/components/dashboard/CalendarView.tsx 2>/dev/null
+
+# 폐기 type alias 사용처
+grep -rnE 'formatMonthCaption|formatYearCaption|labelDay|labelCaption|isMatch|isDateInRange|DateLib\.Date|FormatOptions|LabelOptions' \
+  src/ 2>/dev/null
+```
+
+각 결과를 phase commit message 본문에 기록 — phase 2/3 에서 교체할 위치 명확화.
+
+### 3. peer dep 점검
+
+```bash
+# react-day-picker 구 이름에 의존하는 다른 dep 가 있는지
+grep -rnE '"react-day-picker"' node_modules/*/package.json 2>/dev/null | head
+```
+
+shadcn 의존성 외 (이미 우리가 ui/calendar.tsx 로 wrap) 충돌 없을 것으로 추정. 충돌 발견 시 phase 본문 commit 에 보고 + 대안 검토.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/007-react-day-picker-v10
+
+pnpm install
+pnpm tsc --noEmit
+pnpm lint
+
+# package.json 신 / 구
+grep '"@daypicker/react"' package.json   # = "^10.0.0"
+! grep '"react-day-picker"' package.json   # exit 1 — 구 패키지 제거
+
+# 단 import 경로 갱신은 phase 2~3 에서. 지금은 type 에러 예상됨 — package 만 교체 후 phase 종료
+```
+
+phase 1 종료 시점에서는 `pnpm tsc --noEmit` 가 import 에러 (react-day-picker 미존재) 발생할 수 있음 — **정상**. phase 2/3 에서 해소.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `package.json` / `pnpm-lock.yaml` | dep 교체 |
+
+## Out of Scope
+
+- `import` 경로 갱신 (phase 2/3)
+- 폐기 prop 실제 교체 (phase 2/3)
+- 신 add-on 패키지 (`@daypicker/persian` 등) — 비 그레고리안 캘린더 미사용
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| peer dep 충돌 (다른 라이브러리가 구 이름 의존) | 점검 grep 으로 사전 발견. 발견 시 v10 호환 `react-day-picker` 도 alias 로 추가 검토 (별도 plan) |
+| pnpm install 시 lockfile 다른 dep peer 경고 | 경고만 있고 install 자체 성공이면 OK. error 면 보고 |
+| 폐기 prop 사용 발견 0건이면 phase 2/3 일부 작업 불필요 | grep 결과에 따라 phase 2/3 범위 자동 축소 — phase 시작 시 점검 |

--- a/tasks/plan007-react-day-picker-v10/phase-02.md
+++ b/tasks/plan007-react-day-picker-v10/phase-02.md
@@ -1,0 +1,100 @@
+# Phase 02 — shadcn calendar.tsx 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `src/components/ui/calendar.tsx` 의 import 경로를 `@daypicker/react` 로 교체 + style.css 경로 갱신 + 폐기 prop 사용 시 v10 동등 prop 으로 교체.
+
+## Context (자기완결)
+
+- 파일: `src/components/ui/calendar.tsx` (68줄). shadcn 표준 wrapper:
+  ```ts
+  import { DayPicker } from "react-day-picker";
+  export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+  function Calendar({ className, classNames, showOutsideDays, ...props }) {
+    return <DayPicker .../>;
+  }
+  ```
+- phase-01 의 grep 결과에 따라 폐기 prop 사용 위치 식별됨. 본 phase 에서 교체.
+- ADR-F18 매핑 표:
+  - `fromMonth/toMonth` → `startMonth/endMonth`
+  - `fromDate/toDate` → `hidden={{ before/after }}`
+  - `initialFocus` → `autoFocus`
+
+## 작업 항목
+
+### 1. import 경로 갱신
+
+```ts
+// 변경 전
+import { DayPicker } from "react-day-picker";
+// 변경 후
+import { DayPicker } from "@daypicker/react";
+```
+
+style.css import 가 있으면 함께 교체 (`react-day-picker/dist/style.css` → `@daypicker/react/style.css`).
+
+### 2. 폐기 prop 직접 사용 점검 + 교체
+
+shadcn calendar.tsx 가 props 를 `...props` 로 forward 만 하므로 직접 폐기 prop 사용은 보통 없음. 단 `classNames` override 안에 폐기 키 (`day_outside` → `day` variant 등) 가 있는지 확인:
+
+```bash
+# 폐기 classNames key (release note 의 classNames diff 확인)
+grep -nE 'day_outside|day_selected|day_disabled|day_today|day_hidden|day_range_start|day_range_middle|day_range_end' src/components/ui/calendar.tsx
+```
+
+v10 의 classNames 구조 변경 시 동등 키로 교체. release note 또는 d.ts 참조.
+
+### 3. type re-export 점검
+
+```ts
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+```
+
+이건 그대로 — DayPicker 의 v10 시그니처가 자동 추론. 호출자 (Calendar 사용처) 의 폐기 prop 사용은 phase 시작 시 grep:
+
+```bash
+grep -rnE 'fromMonth|toMonth|fromYear|toYear|fromDate|toDate|initialFocus' src/ \
+  --include='*.tsx' --include='*.ts' | grep -v calendar.tsx
+```
+
+발견 시 호출자 측에서 동등 prop 으로 교체.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/007-react-day-picker-v10
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+
+# import 경로
+grep -n 'from "@daypicker/react"' src/components/ui/calendar.tsx | wc -l   # = 1
+! grep -n 'from "react-day-picker"' src/components/ui/calendar.tsx
+
+# 폐기 prop 0건 (전 코드베이스)
+! grep -rnE 'fromMonth|toMonth|fromYear|toYear|fromDate=|toDate=|initialFocus=' src/
+```
+
+수동 smoke: dashboard `/dashboard` → CalendarView 표시 + 날짜 클릭 정상.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/ui/calendar.tsx` | import 경로 + 폐기 키 교체 (있을 시) |
+
+## Out of Scope
+
+- CalendarView.tsx 의 DayButton 마이그레이션 (phase 3)
+- 신 styling (v10 의 default 스타일 변경 가능성) — 시각 회귀 시 별도 plan
+- 다른 add-on 패키지 도입
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| v10 의 classNames 키 이름 변경으로 우리 override 가 무시됨 | phase 시작 grep 으로 사전 식별 + d.ts 참조 |
+| `@daypicker/react/style.css` 가 dist 경로 다름 | release note + node_modules/@daypicker/react/package.json `exports` 필드 확인 |
+| Calendar wrapper 의 ariaLabel 등 폐기 i18n props | release note 의 label 변경 점검 — `labelDay/labelCaption` → 동등 키 |

--- a/tasks/plan007-react-day-picker-v10/phase-03.md
+++ b/tasks/plan007-react-day-picker-v10/phase-03.md
@@ -1,0 +1,87 @@
+# Phase 03 — CalendarView.tsx DayButton 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `src/components/dashboard/CalendarView.tsx` 의 `DayButtonProps` import + 사용 시그니처를 v10 기준으로 갱신.
+
+## Context (자기완결)
+
+- 파일: `src/components/dashboard/CalendarView.tsx`. line 15 `import { DayButtonProps } from "react-day-picker"`. line 101 `<Calendar ... />`.
+- v10 release note: `DayButton` 커스텀 컴포넌트 등록 방식 변경 가능 (`onDayKey*` 등 폐기 event 가 DayButton 으로 이동).
+- phase-01 grep 결과로 CalendarView 의 폐기 prop / 시그니처 변경 점 식별됨.
+
+## 작업 항목
+
+### 1. import 경로 갱신
+
+```ts
+import { DayButtonProps } from "@daypicker/react";
+```
+
+### 2. DayButton 컴포넌트 시그니처 점검
+
+v10 의 `DayButtonProps` 가 v9 와 다른 필드 있는지 d.ts 또는 release note 확인:
+
+```bash
+# node_modules 의 v10 d.ts 직접 확인
+grep -rn 'DayButtonProps' node_modules/@daypicker/react/dist/ 2>/dev/null | head -5
+```
+
+기존 CalendarView 의 custom DayButton 구현 (있다면) 의 props 사용처를 v10 시그니처에 맞춰 조정.
+
+### 3. 폐기 event prop 교체
+
+`onDayKey*` / `onDayPointer*` / `onDayTouch*` 등을 Calendar 호출처에서 사용 중이면, 커스텀 `DayButton` 컴포넌트로 이동:
+
+```tsx
+<Calendar
+  components={{
+    DayButton: (props: DayButtonProps) => {
+      // 기존 onDayPointerEnter 등 핸들러를 여기서 직접 처리
+      return <button {...props} onPointerEnter={...} />;
+    },
+  }}
+/>
+```
+
+phase-01 grep 결과에 따라 실제 변경 범위 결정.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/007-react-day-picker-v10
+
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+pnpm test --run
+
+# import 경로
+grep -n 'from "@daypicker/react"' src/components/dashboard/CalendarView.tsx | wc -l   # >= 1
+! grep -n 'from "react-day-picker"' src/components/dashboard/CalendarView.tsx
+
+# 폐기 event prop 0건
+! grep -nE 'onDayKey|onDayPointer|onDayTouch|onWeekNumberClick' src/components/dashboard/CalendarView.tsx
+```
+
+수동 smoke: `/dashboard` → CalendarView 의 날짜 hover / 클릭 / 키보드 탐색 모두 정상.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/dashboard/CalendarView.tsx` | import 경로 + DayButton 시그니처 갱신 |
+
+## Out of Scope
+
+- 신 calendar 디자인 (v10 기본 스타일이 다르면) — 시각 회귀 시 plan008+
+- v10 의 신규 기능 (`hidden`, `before`, `after` 등) 활용 — 본 plan 은 호환만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| DayButtonProps 가 v10 에서 `day: Date` 등 새 필드 추가 | d.ts 참조 + tsc 가 에러 잡음. 명시 destructuring 사용처면 보고 |
+| 키보드 접근성 (Tab/Enter) 회귀 | v10 의 autoFocus 등 신 옵션 활용. 수동 smoke 로 점검 |
+| 커스텀 DayButton 구현이 v10 의 내부 hook 의존성 (예: `useDay`) 변경에 영향 | release note 의 internal API breakage 확인. 우리 CalendarView 가 직접 DayButton 커스터마이즈 안 하면 영향 0 |

--- a/tasks/plan007-react-day-picker-v10/phase-04.md
+++ b/tasks/plan007-react-day-picker-v10/phase-04.md
@@ -1,0 +1,93 @@
+# Phase 04 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~03 산출물 통합 검증, react-day-picker v9 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: dep 교체 (1) + ui/calendar.tsx (2) + CalendarView.tsx (3).
+- legacy 잔재 후보: `from "react-day-picker"` import 경로, 폐기 prop, 폐기 type alias.
+- `_shared/common-pitfalls.md § 1-8` 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/007-react-day-picker-v10
+
+pnpm install
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` + 어느 phase 가 회귀를 만들었는지 식별.
+
+### 2. v9 잔재 grep — 0건 증명
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+
+# package.json v10 lock
+grep '"@daypicker/react"' package.json   # = "^10.0.0"
+! grep '"react-day-picker"' package.json   # exit 1
+
+# import 경로 잔재
+! grep -rnE 'from ["\x27]react-day-picker' src/
+
+# 폐기 prop 잔재
+! grep -rnE 'fromMonth=|toMonth=|fromYear=|toYear=|fromDate=|toDate=|initialFocus=' src/
+
+# 폐기 event prop 잔재
+! grep -rnE 'onDayKey|onDayPointer|onDayTouch|onWeekNumberClick' src/
+
+# 폐기 type alias / format helper
+! grep -rnE 'formatMonthCaption|formatYearCaption|labelDay|labelCaption' src/
+! grep -rnE 'DateLib\.Date|FormatOptions[^a-zA-Z]|LabelOptions' src/
+```
+
+### 3. 신 패키지 사용 등록 확인
+
+```bash
+grep -rn 'from "@daypicker/react"' src/ | wc -l   # >= 2 (ui/calendar.tsx + CalendarView.tsx)
+
+# v10 신 prop 사용 (해당 시)
+# - startMonth/endMonth, hidden, autoFocus 등은 우리 코드가 옵션 명시 안 하면 0 건 — 검증 불필요
+```
+
+### 4. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan007-react-day-picker-v10/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan007-react-day-picker-v10/index.json
+grep -c '"status": "completed"' tasks/plan007-react-day-picker-v10/index.json   # = 5 (top + 4 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan007-react-day-picker-v10/phase-04.md
+grep '^\*\*Status\*\*:' tasks/plan007-react-day-picker-v10/phase-04.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan007-react-day-picker-v10/index.json` | 모든 status `completed` |
+| `tasks/plan007-react-day-picker-v10/phase-04.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- PR #222 close — 본 plan PR 머지 후 사용자가 GitHub UI 에서 직접 close (또는 plan PR 의 `Closes #222` 마커로 자동)
+- v10 신규 기능 도입 (hidden, autoFocus 등) — 본 plan 은 호환만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 안 문자열) | 라인 시작 앵커 + 정확한 토큰 매치 |
+| macOS BSD `sed -i ''` vs Linux GNU `sed -i` | 본 plan macOS 환경 가정 |
+| 수동 smoke 누락 시 시각 회귀 미발견 | dashboard `/dashboard` 의 CalendarView 화면 검증 항목 phase 2/3 본문에 명시 |


### PR DESCRIPTION
## Summary

react-day-picker 9.14.0 → 10.0.0 메이저 + 패키지명 `@daypicker/react` 로 이전. Dependabot PR #222 (단순 dep bump only) 대체.

## ADR

- ADR-F18 신규 — `react-day-picker` → `@daypicker/react` 패키지 이전 + 폐기 prop 매핑 표

## 사용자 결정 (confirmed)

- `@daypicker/react` 신 패키지 (장기 수명)
- ADR-F18 신규
- PR #222 close — 본 PR 이 dep+코드 한 PR 로 대체

## Phase 구조 (4 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | @daypicker/react 추가 + 구 패키지 제거 + 폐기 prop grep | sonnet |
| 02 | shadcn ui/calendar.tsx 마이그레이션 | sonnet |
| 03 | CalendarView.tsx DayButton 시그니처 | sonnet |
| 04 | 통합 검증 + completed | haiku |

## 영향 면적 (작음)

- `src/components/ui/calendar.tsx` (68줄)
- `src/components/dashboard/CalendarView.tsx`

## 다음 단계

\`/build-with-teams plan007-react-day-picker-v10\` 호출 시 같은 브랜치에서 phase 실행.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)