### PR TITLE
docs(plan008): TypeScript 5.9 → 6.0 major migration plan

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -302,3 +302,18 @@
   - `onWeekNumberClick/onDayKey*/onDayPointer*/onDayTouch*` → 커스텀 `WeekNumber`/`DayButton` 컴포넌트
 - **적용 범위**: `package.json`, `src/components/ui/calendar.tsx`, `src/components/dashboard/CalendarView.tsx`.
 
+---
+
+## ADR-F19: TypeScript 5.9 → 6.0 메이저 이전 + breaking 대응 패턴 (2026-05-11)
+
+- **결정**: TypeScript 컴파일러를 `^5` 에서 `^6` 메이저로 이전. release note 의 stricter inference / lib.d.ts 변경 / decorator 표준 채택 등으로 발생하는 type 에러를 plan008 의 각 phase 에서 카테고리별 패턴 적용으로 일괄 수정.
+- **맥락**: PR #179 (Dependabot) 가 단순 dep bump 만 제안 — typescript 메이저는 전체 `.ts/.tsx` 컴파일에 영향이라 tsc 실측 후 에러 카테고리 식별 필수. ky/react-day-picker (단일 파일) 대비 영향 면적 큼. 미루면 보안/성능 개선 누적 손실 + msw·jest·eslint-config-next 등 peer dep 가 ts6 로 먼저 옮겨가면 빌드 분리 위험.
+- **대안 기각**:
+  - ts5 stick: 보안/유지보수 + 신 inference 혜택 미수용. peer dep 호환 점진 분리 위험.
+  - Dependabot PR #179 그대로 머지: tsc 에러 무대응으로 빌드 회귀.
+- **트레이드오프**: 메이저 dep bump 의 첫 번째 적용. 발견 에러를 단순 fix 로 처리 못 하는 케이스 (예: inference 변경으로 라이브러리 측 타입 깨짐) 는 별도 plan 으로 분리.
+- **breaking 대응 패턴 (실측 후 채움)**:
+  - plan008 phase-01 의 release note fetch + tsc 실측 결과를 본 ADR 본문에 카테고리별 1~2줄로 추가 (lib.d.ts 변경 / inference 변경 / decorator / 기타).
+  - 향후 ts7+ 이전 시 본 ADR 참조점.
+- **적용 범위**: `package.json`, `tsconfig.json`, src/ 전체 (해당 파일만 fix).
+

--- a/tasks/plan008-typescript-v6/index.json
+++ b/tasks/plan008-typescript-v6/index.json
@@ -1,0 +1,51 @@
+{
+  "name": "plan008-typescript-v6",
+  "description": "TypeScript 5.9 → 6.0 메이저 + @types/node patch. release note fetch + tsc 실측 후 발견 에러 카테고리별 패턴 수정. PR #179 (Dependabot dep bump only) 대체.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "prerequisites": [
+    "ADR-F19 갱신 commit (이 PR 포함) — typescript v6 이전 + breaking 대응 결정 docs 동기화",
+    "PR #179 (Dependabot typescript group bump) 은 본 plan PR 머지 후 close — 사용자 결정"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "dep 교체 + release note WebFetch + tsc 실측 + 에러 카테고리 분류 + peer dep 점검",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "lib.d.ts / inference 변경으로 인한 에러 일괄 수정",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "peer dep (msw / jest / eslint-config-next / typescript-eslint) 호환 정렬",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "ADR-F19 breaking 대응 패턴 본문 채우기 + tsconfig.json 신 옵션 검토",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan008-typescript-v6/phase-01.md
+++ b/tasks/plan008-typescript-v6/phase-01.md
@@ -1,0 +1,109 @@
+# Phase 01 — dep 교체 + release note 수집 + tsc 실측 + 에러 카테고리 분류
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: TypeScript 6.0 release note 의 정확한 breaking 매핑 수집 + 우리 코드 영향 tsc 실측 + 발견 에러를 카테고리별로 분류 (phase 2~3 에서 카테고리별 fix).
+
+## Context (자기완결)
+
+- 현재: typescript `^5` (5.9.3), @types/node `^22` (22.19.7)
+- 목표: typescript `^6` (6.0.3), @types/node `^22` (22.19.18)
+- tsconfig.json: `target: ES2017`, `strict: true`, `moduleResolution: bundler`, `noEmit: true`
+- PR #179 의 lock diff 참조: `@typescript-eslint/parser` 8.48.1 + `eslint-config-next` 16.0.7 + `msw` 2.14.5 + `jest` 30.3.0 모두 ts6 호환 점검 필요.
+
+## 작업 항목
+
+### 1. release note WebFetch (정확한 breaking 매핑 수집)
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+```
+
+WebFetch 로 TypeScript 6.0 release blog post 수집:
+
+- 1차: `https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/`
+- 2차 (실패 시): GitHub release `https://github.com/microsoft/TypeScript/releases/tag/v6.0.0` 의 fixed issues query
+
+수집 후 breaking changes 를 **카테고리별** 로 정리한 본문을 phase commit message 또는 PR description 에 1단락으로 기록:
+
+- lib.d.ts 추가/변경 (예: 신 표준 메서드)
+- inference 변경 (예: contextual typing)
+- 폐기 compiler 옵션 / 신 기본값
+- decorator / class field 처리
+- 기타
+
+### 2. dep 교체
+
+```bash
+pnpm add -D typescript@^6 @types/node@^22
+```
+
+`package.json` 의 `"typescript": "^5"` → `"^6"`. @types/node 는 minor 패치만 (^22 그대로).
+
+### 3. 1차 tsc 실측
+
+```bash
+pnpm tsc --noEmit 2>&1 | tee /tmp/tsc-errors.txt | tail -40
+```
+
+에러 line 수 / 파일 수 / 카테고리 식별. `/tmp/tsc-errors.txt` 는 후속 phase 참조용 (PR commit 에는 포함 X).
+
+### 4. 에러 카테고리 분류 (phase 2~3 입력)
+
+`/tmp/tsc-errors.txt` 의 에러 메시지를 다음 카테고리로 분류:
+
+- **lib.d.ts 변경**: `Property 'X' does not exist on type 'Array<...>'` 등 표준 라이브러리 type 변화
+- **inference 변경**: `Type 'X' is not assignable to type 'Y'` — 5.9 에서 통과하던 코드가 fail
+- **strict 옵션 신 기본**: `Object is possibly 'null'` 같은 새 strict 발동
+- **peer dep 타입 충돌**: `node_modules/...` 안의 라이브러리 type — msw/jest/next 등
+- **deprecated API**: 우리 코드가 ts compiler API 직접 사용 (보통 0)
+
+카테고리별 에러 수 + 대표 파일 1~2개를 phase 본문 commit message 에 기록.
+
+### 5. peer dep 호환 점검
+
+```bash
+pnpm install 2>&1 | grep -iE 'peer|warning' | head -20
+```
+
+- `@typescript-eslint/parser` 8.48.1 가 ts6 지원? (보통 8.x 는 ts5 가정, 9.x 가 ts6)
+- `eslint-config-next` 16.0.7 의 type plugin 이 ts6 호환?
+- `msw` 2.14.5 의 d.ts 가 ts6 inference 와 충돌?
+- `jest-environment-jsdom` 30.x 가 ts6 호환?
+
+peer 경고 발견 시 phase-03 (peer 정렬) 의 입력. install 자체 실패면 `PHASE_BLOCKED: peer resolution failed` 출력 후 보고.
+
+### 6. 자동 verification
+
+```bash
+# package.json 신 / 구
+grep '"typescript"' package.json   # = "^6"
+
+# tsc 실측 결과 존재
+test -f /tmp/tsc-errors.txt && wc -l /tmp/tsc-errors.txt
+
+# phase 1 시점에는 tsc 통과 안 함 — 정상. phase 2~3 에서 해소
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `package.json` / `pnpm-lock.yaml` | dep 교체 |
+| (`/tmp/tsc-errors.txt`) | phase 산출물 — repo 에 commit X |
+
+## Out of Scope
+
+- 에러 fix 자체 (phase 2)
+- peer dep 실제 교체 (phase 3)
+- tsconfig.json 옵션 변경 (phase 4)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| WebFetch 가 release blog 차단/형식 변화 | 2차 fallback (GitHub release tag). 모두 실패 시 phase commit message 에 "release note 미수집, ts6 release blog 부재" 명시 + tsc 에러만으로 분류 |
+| tsc 에러 200+ — 단일 phase 처리 부담 | 카테고리별 분할이 phase 2 의 분기 기반. 1000+ 면 plan008 자체 분할 검토 + 보고 |
+| peer dep 가 ts6 거부 → install 실패 | install 실패 = PHASE_BLOCKED. msw/jest 업그레이드 의존성 plan 분리 가능성 |
+| @types/node 22.19.18 가 신 type 추가로 별도 에러 | minor patch — 영향 작을 것. tsc 결과에 포함되면 함께 fix |

--- a/tasks/plan008-typescript-v6/phase-02.md
+++ b/tasks/plan008-typescript-v6/phase-02.md
@@ -1,0 +1,98 @@
+# Phase 02 — lib.d.ts / inference 변경 일괄 수정
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: phase-01 에서 분류한 에러 카테고리 중 **우리 코드 측 fix 만으로 해결 가능한 항목** (lib.d.ts 변경 / inference 변경 / 신 strict 기본값) 일괄 수정.
+
+## Context (자기완결)
+
+- phase-01 commit message 의 카테고리 분류표 + `/tmp/tsc-errors.txt` (생존 시) 참조.
+- 본 phase 대상: **우리 src/ 코드 수정으로 해결되는 에러**. peer dep 측 에러는 phase-03.
+- 일반적 fix 패턴:
+  - `Object is possibly 'null'` → optional chaining `?.` 또는 명시 가드
+  - `Property 'X' does not exist` → 타입 좁히기 또는 type assertion (최소 사용)
+  - `Type 'X' is not assignable to 'Y'` → 명시 타입 annotation 추가
+  - 신 표준 메서드 (`Array.prototype.findLast` 등) 가 우리 코드 호출 시 — 신 lib 가 정상 제공
+
+## 작업 항목
+
+### 1. phase-01 카테고리표 + tsc 에러 재실행
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+
+pnpm tsc --noEmit 2>&1 | tee /tmp/tsc-errors-v2.txt | tail -40
+```
+
+phase-01 의 카테고리 분류표를 본 phase 작업 분할 기준으로 사용.
+
+### 2. lib.d.ts 변경 에러 fix
+
+신 표준 메서드 호출 / 변경된 type 시그니처 (예: `Array.findLast` 반환 타입 narrowing) 영향을 받는 위치를 식별 + fix.
+
+```bash
+# 예시 — 우리 코드에서 사용 빈도 grep
+grep -rnE 'findLast|toReversed|toSorted|toSpliced' src/ 2>/dev/null
+```
+
+발견 시 ts6 의 신 시그니처에 맞춰 호출자 type 조정.
+
+### 3. inference 변경 에러 fix
+
+가장 흔한 패턴 — 5.9 에서 통과하던 inference 가 6.0 에서 strict 해지는 경우. 명시 type annotation 추가:
+
+```ts
+// Before (5.9 통과):
+const result = items.reduce((acc, x) => ({ ...acc, [x.key]: x.value }), {});
+// After (6.0 stricter — 명시):
+const result = items.reduce<Record<string, T>>((acc, x) => ({ ...acc, [x.key]: x.value }), {});
+```
+
+각 위치는 phase-01 의 카테고리표에서 식별. 위 패턴 외에 `any` 의존 / type assertion 회피 우선.
+
+### 4. 신 strict 기본값 fix
+
+ts6 의 신 strict 옵션 (있다면) 가 tsconfig 의 `strict: true` 로 자동 발동. 발생 에러를 일반 가드 패턴으로:
+
+```ts
+// Object is possibly 'null'
+- session.user.name
++ session?.user?.name
+```
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+
+pnpm tsc --noEmit 2>&1 | tail -20
+# 에러 수가 phase-01 시점 대비 감소 — 단 peer dep 측 에러 (phase-03) 는 남을 수 있음
+
+# any 신규 도입 0건
+! grep -rnE ': any\b|<any>|as any\b' src/ \
+  | grep -v ".test.tsx?:" | grep -v "// eslint-disable"
+```
+
+수동 smoke: `pnpm build` → 컴파일 통과 (peer dep 측 잔여 에러 1~5 건 정도 허용). 잔여 에러는 phase-03 에서 해소.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/` 의 영향 받은 파일 다수 | type annotation 추가 / 가드 추가 |
+
+## Out of Scope
+
+- peer dep (msw / jest / next type plugin) 측 에러 (phase-03)
+- tsconfig.json 옵션 변경 (phase-04)
+- 신 ts6 기능 적극 도입 (예: 신 Standard Decorator) — 본 plan 은 호환만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 에러 수가 100+ 면 phase 작업 양 초과 (CLAUDE.md "5개 이하" 위반) | phase-01 카테고리표를 5 카테고리 이하로 압축. 그래도 초과면 본 phase 를 phase-02a/02b 분할 + index.json 갱신 보고 |
+| inference 변경 fix 시 `any` 도입 유혹 | grep 으로 검출 + lint 통과 강제. 정 안 되면 `// @ts-expect-error` 한 줄 + 이유 주석 (재발 추적용) |
+| 우리 fix 가 의도치 않은 타입 강화로 호출자 깨짐 | tsc + jest --run 으로 회귀 1차 검출. PR 검증 단계에서 추가 점검 |

--- a/tasks/plan008-typescript-v6/phase-03.md
+++ b/tasks/plan008-typescript-v6/phase-03.md
@@ -1,0 +1,107 @@
+# Phase 03 — peer dep 호환 정렬
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: typescript 6 가 요구하는 peer dep 업그레이드 — `@typescript-eslint/parser`, `eslint-config-next`, `msw`, `jest-environment-jsdom` 등.
+
+## Context (자기완결)
+
+- phase-01 의 `pnpm install` 경고 + tsc 에러 중 `node_modules/...` 경로의 type 에러를 본 phase 에서 처리.
+- 주요 peer 후보 (현재 버전 → ts6 호환 목표):
+  - `@typescript-eslint/parser` 8.48.1 → 9.x (ts6 지원 명시 시)
+  - `eslint-config-next` 16.0.7 → next 측 type plugin 호환 점검
+  - `msw` 2.14.5 → ts6 지원 버전
+  - `jest` 30.3.0 + `jest-environment-jsdom` 30.3.0 → 30.x 가 ts6 지원
+- 본 phase 가 dep 한 두 개 bump 면 PR 사이즈 증가. 단 typescript 메이저 의존성 안정화에 필수.
+
+## 작업 항목
+
+### 1. 각 peer 의 ts6 지원 매트릭스 확인
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+
+# typescript-eslint v9 의 peer dep
+pnpm view typescript-eslint@latest peerDependencies
+pnpm view @typescript-eslint/parser@latest peerDependencies
+
+# msw 신 버전 peer
+pnpm view msw@latest peerDependencies
+
+# jest peer
+pnpm view jest@latest peerDependencies
+```
+
+각 결과를 표로 정리 (commit message 본문):
+
+| Package | 현재 | ts6 호환 최소 | 업그레이드? |
+|---|---|---|---|
+| @typescript-eslint/parser | 8.48.1 | (확인 후 채움) | 필요 시 9.x |
+| eslint-config-next | 16.0.7 | (next docs) | next 16 그대로 추정 |
+| msw | 2.14.5 | (확인 후 채움) | 필요 시 patch+ |
+| jest | 30.3.0 | (확인 후 채움) | 30.x 그대로 추정 |
+
+### 2. 필요한 peer 업그레이드 일괄
+
+```bash
+# 예 — typescript-eslint v9 가 ts6 강제 요구 시
+pnpm add -D @typescript-eslint/parser@^9 @typescript-eslint/eslint-plugin@^9
+```
+
+각 업그레이드 후 `pnpm install` 경고 0 + `pnpm tsc --noEmit` 의 peer 측 에러 0.
+
+### 3. ESLint config 점검
+
+`eslint.config.mjs` (또는 `.eslintrc.*`) 가 typescript-eslint plugin 의 신 API 사용 — 신 버전 import 경로 / rule 이름 변경 점검:
+
+```bash
+grep -rnE 'typescript-eslint|@typescript-eslint' eslint.config.mjs 2>/dev/null
+```
+
+신 v9 가 ESM-only 또는 새 preset 명 (`recommendedTypeChecked` 등) 요구 시 config 갱신.
+
+### 4. 신 dep 충돌 cross-check
+
+```bash
+pnpm install
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --run
+```
+
+각 통과 확인. peer dep 측 에러 0 + 우리 코드 측 에러 0 = phase 4 진입 가능.
+
+### 5. 자동 verification
+
+```bash
+# typescript-eslint 버전 (ts6 호환)
+grep '"@typescript-eslint/parser"' package.json
+
+# msw / jest 버전
+grep -E '"msw"|"jest"' package.json
+
+# pnpm install 경고 0 (peer 측)
+pnpm install 2>&1 | grep -iE 'peer.*WARN' | wc -l   # = 0 (또는 최소)
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `package.json` / `pnpm-lock.yaml` | peer dep 업그레이드 |
+| `eslint.config.mjs` (해당 시) | typescript-eslint v9 신 preset 적용 |
+
+## Out of Scope
+
+- msw / jest 의 신규 기능 도입 (mock signature 변경 등) — 호환만
+- ESLint rule 정책 변경 — 본 plan 은 ts6 통과만
+- next.js 자체 메이저 업그레이드 — 별도 plan
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| typescript-eslint v9 가 ESM-only 라 우리 config 호환 안 됨 | eslint.config.mjs 가 이미 ESM. config 갱신만 필요. issue 발생 시 보고 |
+| eslint-config-next 16 이 ts6 미지원 → next.js 측 업그레이드 의존 | next 측 release 점검 필요. 미지원 확정 시 plan008 일부 차단 + next 메이저 plan 분리 |
+| msw 측 d.ts 가 ts6 inference 와 충돌 | 신 버전 bump 후에도 에러 잔재 시 임시 `skipLibCheck: true` (이미 설정됨) 가 한계 — 다른 옵션 검토 |

--- a/tasks/plan008-typescript-v6/phase-04.md
+++ b/tasks/plan008-typescript-v6/phase-04.md
@@ -1,0 +1,95 @@
+# Phase 04 — ADR-F19 본문 갱신 + tsconfig.json 신 옵션 검토
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: phase 1~3 의 실측 결과를 docs/adr.md ADR-F19 본문에 카테고리별로 기록 + ts6 신 옵션이 우리 프로젝트에 가치 있는지 검토 (도입은 본 plan 범위 외, 검토 결과만 ADR 또는 후속 plan 으로).
+
+## Context (자기완결)
+
+- ADR-F19 는 본 plan 시작 시 작성됐으나 "breaking 대응 패턴" 본문이 placeholder — phase 1 의 카테고리 분류표 + phase 2~3 의 fix 적용 패턴을 1~2줄씩 기록.
+- ts6 신 옵션 후보 (가치 검토):
+  - `verbatimModuleSyntax` 강화
+  - `noUncheckedIndexedAccess` (기존 5.x 도 있지만 6.0 기본값 변경 검토)
+  - `exactOptionalPropertyTypes` 강화
+  - 신 module 옵션 (`module: "preserve"` 등)
+- 본 phase 는 신 옵션 **도입 자체는 안 함** — 검토 결과만 ADR 또는 후속 plan 메모.
+
+## 작업 항목
+
+### 1. ADR-F19 본문 채우기
+
+phase 1~3 의 실측 결과를 `docs/adr.md` 의 ADR-F19 안 "breaking 대응 패턴" 섹션에 추가. 카테고리별 1~2줄:
+
+```markdown
+- **breaking 대응 패턴**:
+  - lib.d.ts 변경: {N}건 — 주로 {예시 카테고리}. {적용 패턴 1줄}.
+  - inference 변경: {N}건 — 주로 {예시 카테고리}. 명시 type annotation 으로 fix.
+  - 신 strict 기본값: {N}건 또는 0건.
+  - peer dep 충돌: {N}건 — {업그레이드한 패키지명}.
+  - tsconfig.json 변경: {있음/없음 + 사유}.
+```
+
+placeholder 항목 (현재 ADR-F19 의 "phase-01 의 tsc 실측 결과를 본 ADR 본문에 카테고리별 1~2줄로 기록") 을 실측 데이터로 교체.
+
+### 2. tsconfig.json 신 옵션 검토
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+
+# 현재 tsconfig.json
+cat tsconfig.json
+```
+
+ts6 release note 의 신 옵션을 우리 프로젝트에 적용 가능성 평가:
+
+- `verbatimModuleSyntax`: ESM 명확화. import/export type 명시 의무화 — 코드 변경 폭 큼 → **본 plan OOS, plan009 검토**
+- `noUncheckedIndexedAccess`: 배열 indexing 후 undefined 반환 — `arr[0]?.x` 패턴 강제. 안전성↑ but 변경 폭 큼 → **OOS**
+- `exactOptionalPropertyTypes`: 우리 코드의 optional prop 에 영향 → **OOS**
+
+검토 결과를 ADR-F19 또는 별도 `plan008-followup.md` (commit 안 함, 인라인 메모) 에 1줄씩. 본 plan 은 tsconfig.json **변경 없음** 이 기본.
+
+### 3. CLAUDE.md 의 typescript 메모 점검
+
+`CLAUDE.md` 에 typescript 버전 관련 메모가 있으면 ts6 으로 갱신:
+
+```bash
+grep -nE 'TypeScript|typescript' CLAUDE.md | head
+```
+
+"TypeScript 5" 같은 stale 문자열이 있으면 갱신.
+
+### 4. 자동 verification
+
+```bash
+# ADR-F19 본문에 카테고리 항목 채워짐
+grep -E 'lib\.d\.ts 변경:|inference 변경:|peer dep 충돌:' docs/adr.md | wc -l   # >= 3
+
+# tsconfig.json 변경 없음 확인 (본 plan OOS)
+git diff origin/main -- tsconfig.json | wc -l   # = 0 (또는 최소)
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `docs/adr.md` | ADR-F19 본문 placeholder → 실측 데이터 |
+| `CLAUDE.md` | ts 버전 stale 메모 갱신 (해당 시) |
+
+## Out of Scope
+
+- 신 tsconfig 옵션 도입 (`verbatimModuleSyntax` 등) — plan009 후속
+- 신 ts6 기능 (Decorator 표준 등) 적극 채택
+- next.js / msw / jest 자체 메이저 업그레이드
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| ADR 본문이 단순 "0건" 만 가득 (breaking 영향 미미) | 본 ADR 자체 가치 약화 — 그러나 ts6 이전 사실 + 패턴 메모 자체로 미래 ts7 참조점. 본문 작아도 보존 |
+| tsconfig 신 옵션이 단순 적용 가능 (변경 폭 작음) 하면 본 plan 안에서 처리 유혹 | scope 보호 — 작아도 별도 plan. PR 검토 단위 명확. 메모만 phase 본문에 |

--- a/tasks/plan008-typescript-v6/phase-05.md
+++ b/tasks/plan008-typescript-v6/phase-05.md
@@ -1,0 +1,102 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, typescript 5.x 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: dep 교체 (1) + lib.d.ts/inference fix (2) + peer dep 정렬 (3) + ADR/tsconfig 검토 (4).
+- legacy 잔재 후보: package.json 의 `^5` 잔재, 우리 코드의 ts5 회피 패턴 (`as any`, `// @ts-ignore`).
+- `_shared/common-pitfalls.md § 1-8` 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/008-typescript-v6
+
+pnpm install
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` + 어느 phase 가 회귀를 만들었는지 식별.
+
+### 2. ts 버전 lock 확인
+
+```bash
+grep '"typescript"' package.json   # = "^6"
+grep -E 'typescript@6\.' pnpm-lock.yaml | head -3   # 6.x 버전 lock 됨
+```
+
+### 3. ts5 잔재 grep — 0건
+
+```bash
+# package.json 의 ^5 잔재
+! grep -E '"typescript":\s*"\^5' package.json
+
+# 우리 코드의 ts5 회피 패턴 — 본 plan 신규 도입 0건
+NEW_ANY=$(git diff origin/main -- 'src/**/*.ts' 'src/**/*.tsx' | grep -E '^\+.*\bas any\b|^\+.*: any\b' | grep -v ".test.")
+if [ -n "$NEW_ANY" ]; then
+  echo "⚠️ 본 plan 에서 신규 도입된 any 사용:"
+  echo "$NEW_ANY"
+  exit 1
+fi
+
+# @ts-ignore / @ts-expect-error 신규 도입 — 정당 사유 없으면 0
+git diff origin/main | grep -E '^\+.*@ts-ignore|^\+.*@ts-expect-error' | head
+```
+
+### 4. ADR-F19 본문 갱신 확인 (phase 04 산출물)
+
+```bash
+# placeholder 항목 사라짐
+! grep -nE 'phase-01.*실측 결과를.*카테고리별 1~2줄로 기록\|breaking 대응 패턴.*실측 후 채움' docs/adr.md
+
+# 실측 카테고리 항목 채워짐
+grep -E 'lib\.d\.ts 변경:|inference 변경:|peer dep 충돌:' docs/adr.md | wc -l   # >= 3
+```
+
+### 5. tsconfig.json 미변경 (본 plan OOS)
+
+```bash
+git diff origin/main -- tsconfig.json | wc -l   # = 0
+```
+
+### 6. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan008-typescript-v6/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan008-typescript-v6/index.json
+grep -c '"status": "completed"' tasks/plan008-typescript-v6/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan008-typescript-v6/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan008-typescript-v6/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan008-typescript-v6/index.json` | 모든 status `completed` |
+| `tasks/plan008-typescript-v6/phase-05.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- PR #179 close — 본 plan PR 머지 후 사용자가 직접 close (또는 PR 의 `Closes #179` 마커)
+- tsconfig.json 신 옵션 도입 — plan009 후속
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `as any` / `@ts-ignore` 가 phase 2 에서 정당 사유로 신규 도입됐다면 검증 step 3 가 false positive | 정당 사유 grep 시 주석에 "// ts6 호환 — 이유" 명시 + 본 step 3 의 grep 패턴 정교화 |
+| 검증 step 3 의 `git diff origin/main` 가 plan branch base 변경으로 출력 폭증 | grep 결과를 카테고리별로 분류 + 사용자 확인 후 진행. 폭증 시 phase BLOCK |
+| macOS BSD `sed -i ''` vs Linux GNU `sed -i` | 본 plan macOS 환경 가정 |


### PR DESCRIPTION
## Summary

TypeScript 5.9.3 → 6.0.3 메이저 + @types/node patch. Dependabot PR #179 (DIRTY, 단순 dep bump only) 대체.

## ADR

- ADR-F19 신규 — typescript v6 이전 + breaking 대응 패턴
  - 본문의 카테고리별 매핑은 phase-04 에서 phase-01 의 tsc 실측 결과로 채움
  - 향후 ts7+ 이전 시 참조점

## 사용자 결정 (confirmed)

- **적극적 scope** — release note 정확 매핑 + 우리 코드 grep + 카테고리별 fix
- ADR-F19 신규 (자명한 dep bump 가 아닌 메이저 결정 기록)
- PR #179 close — 본 PR 이 dep+코드 한 PR 로 대체

## Phase 구조 (5 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | dep 교체 + release note + tsc 실측 + 카테고리 분류 | sonnet |
| 02 | lib.d.ts / inference fix (src/ 측) | sonnet |
| 03 | peer dep 호환 정렬 (typescript-eslint, msw, jest 등) | sonnet |
| 04 | ADR-F19 본문 갱신 + tsconfig 신 옵션 검토 (도입 OOS) | sonnet |
| 05 | 통합 검증 + completed | haiku |

## 영향 면적

- **전체 src/** — 컴파일러 자체 메이저
- 의존성: @typescript-eslint, eslint-config-next, msw, jest peer 호환 필요

## 다음 단계

\`/build-with-teams plan008-typescript-v6\` 호출 시 같은 브랜치에서 phase 실행.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)