### PR TITLE
feat(deps): react-day-picker v9 → v10 + @daypicker/react 신 namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:unit": "jest --testPathPatterns=auth|api|components"
   },
   "dependencies": {
+    "@daypicker/react": "^10.0.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -45,7 +46,6 @@
     "next-themes": "^0.4.6",
     "pretendard": "^1.3.9",
     "react": "19.2.6",
-    "react-day-picker": "^9.14.0",
     "react-dom": "19.2.6",
     "react-hook-form": "^7.75.0",
     "recharts": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@daypicker/react':
+        specifier: ^10.0.0
+        version: 10.0.0(react@19.2.6)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.6))
@@ -86,9 +89,6 @@ importers:
       react:
         specifier: 19.2.6
         version: 19.2.6
-      react-day-picker:
-        specifier: ^9.14.0
-        version: 9.14.0(react@19.2.6)
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
@@ -447,6 +447,12 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@daypicker/react@10.0.0':
+    resolution: {integrity: sha512-17bV4OhWrBcPipWH7ecqw3qJTdseKCl+5DBviG2McWL64LfhzYEe79sCzxsDZjfhnIWTOX2LKOxE6FptWr+llw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -1478,10 +1484,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
-
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -2202,9 +2204,6 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
-
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
@@ -3609,8 +3608,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+  react-day-picker@10.0.0:
+    resolution: {integrity: sha512-lrEXo5wFPsq5LTcayelM3BPueD00v7zbdipAY+EIdPcseVykYwkOWx4Ujn/EtbBvpnp8ZPUHol17HXH6kVbZoA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: '>=16.8.0'
@@ -4597,6 +4596,11 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@daypicker/react@10.0.0(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      react-day-picker: 10.0.0(react@19.2.6)
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -5680,8 +5684,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
-
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6427,8 +6429,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-
-  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
 
@@ -8141,12 +8141,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-day-picker@9.14.0(react@19.2.6):
+  react-day-picker@10.0.0(react@19.2.6):
     dependencies:
       '@date-fns/tz': 1.4.1
-      '@tabby_ai/hijri-converter': 1.0.5
       date-fns: 4.1.0
-      date-fns-jalali: 4.1.0-0
       react: 19.2.6
 
   react-dom@19.2.6(react@19.2.6):

--- a/src/components/dashboard/CalendarView.tsx
+++ b/src/components/dashboard/CalendarView.tsx
@@ -12,7 +12,7 @@ import { addMonths, format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
-import { DayButtonProps } from "react-day-picker";
+import { DayButtonProps } from "@daypicker/react";
 import { toast } from "sonner";
 
 export function CalendarView() {
@@ -106,7 +106,7 @@ export function CalendarView() {
             classNames={{
               months: "w-full",
               month: "w-full space-y-4",
-              caption: "hidden", // 기본 헤더 숨김
+              month_caption: "hidden", // 기본 헤더 숨김
               nav: "hidden", // 기본 네비게이션 숨김
               month_grid: "w-full border-collapse", // table
               weekdays: "grid grid-cols-7 mb-2", // head_row

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import * as React from "react";
-import { DayPicker } from "@daypicker/react";
+import { DayPicker, type ChevronProps } from "@daypicker/react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/client/utils";
@@ -56,7 +56,7 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Chevron: ({ orientation, className }) => {
+        Chevron: ({ orientation, className }: ChevronProps) => {
           const Icon = orientation === "left" ? ChevronLeft : ChevronRight;
           return <Icon className={cn("h-4 w-4", className)} />;
         },

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import * as React from "react";
-import { DayPicker } from "react-day-picker";
+import { DayPicker } from "@daypicker/react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/client/utils";
@@ -22,15 +22,17 @@ function Calendar({
       classNames={{
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
-        caption: "flex justify-center pt-1 relative items-center",
+        month_caption: "flex justify-center pt-1 relative items-center",
         caption_label: "text-sm font-medium",
         nav: "space-x-1 flex items-center",
-        nav_button: cn(
+        button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1",
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1",
+        ),
         month_grid: "w-full border-collapse space-y-1",
         weekdays: "flex",
         weekday:
@@ -54,9 +56,9 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Chevron: ({ orientation, className, ...props }) => {
+        Chevron: ({ orientation, className }) => {
           const Icon = orientation === "left" ? ChevronLeft : ChevronRight;
-          return <Icon className={cn("h-4 w-4", className)} {...props} />;
+          return <Icon className={cn("h-4 w-4", className)} />;
         },
       }}
       {...props}

--- a/tasks/plan007-react-day-picker-v10/index.json
+++ b/tasks/plan007-react-day-picker-v10/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan007-react-day-picker-v10",
   "description": "react-day-picker 9.14 → 10.0 메이저 + @daypicker/react 신 namespace 이전. 폐기 props (fromMonth/toMonth/initialFocus 등) 일괄 교체. PR #222 (Dependabot dep bump only) 대체.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
   "total_phases": 4,
   "related_docs": [
@@ -17,28 +17,28 @@
       "file": "phase-01.md",
       "title": "@daypicker/react 패키지 추가 + react-day-picker 제거 + 폐기 prop 사용처 grep",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "shadcn calendar.tsx 마이그레이션 (import 경로 + style.css + 폐기 prop 교체)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "CalendarView.tsx DayButton 마이그레이션 (DayButtonProps 시그니처 점검)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan007-react-day-picker-v10/phase-01.md
+++ b/tasks/plan007-react-day-picker-v10/phase-01.md
@@ -42,11 +42,11 @@ grep -rnE 'formatMonthCaption|formatYearCaption|labelDay|labelCaption|isMatch|is
 ### 3. peer dep 점검
 
 ```bash
-# react-day-picker 구 이름에 의존하는 다른 dep 가 있는지
-grep -rnE '"react-day-picker"' node_modules/*/package.json 2>/dev/null | head
+# react-day-picker 구 이름에 의존하는 다른 dep 가 있는지 (transitive 포함)
+pnpm why react-day-picker 2>&1 | head -30
 ```
 
-shadcn 의존성 외 (이미 우리가 ui/calendar.tsx 로 wrap) 충돌 없을 것으로 추정. 충돌 발견 시 phase 본문 commit 에 보고 + 대안 검토.
+shadcn 의존성 외 (이미 우리가 ui/calendar.tsx 로 wrap) 충돌 없을 것으로 추정. transitive 의존이 발견되면 phase 본문 commit 에 보고 + 대안 검토.
 
 ### 4. 자동 verification
 

--- a/tasks/plan007-react-day-picker-v10/phase-02.md
+++ b/tasks/plan007-react-day-picker-v10/phase-02.md
@@ -33,31 +33,52 @@ import { DayPicker } from "@daypicker/react";
 
 style.css import 가 있으면 함께 교체 (`react-day-picker/dist/style.css` → `@daypicker/react/style.css`).
 
-### 2. 폐기 prop 직접 사용 점검 + 교체
+### 2. classNames 키 v10 ClassNames 타입과 1:1 매핑 검증 + 변경 키 교체 (CRITICAL)
 
-shadcn calendar.tsx 가 props 를 `...props` 로 forward 만 하므로 직접 폐기 prop 사용은 보통 없음. 단 `classNames` override 안에 폐기 키 (`day_outside` → `day` variant 등) 가 있는지 확인:
+현 calendar.tsx 가 사용하는 22개 키를 v10 `ClassNames` 타입과 대조. 단순 grep 으로는 silent regression 차단 불가 — **type-driven 검증** 사용.
 
 ```bash
-# 폐기 classNames key (release note 의 classNames diff 확인)
-grep -nE 'day_outside|day_selected|day_disabled|day_today|day_hidden|day_range_start|day_range_middle|day_range_end' src/components/ui/calendar.tsx
+# v10 ClassNames 타입의 키 목록 추출 (phase-01 의 dep 교체 후 node_modules 에 신 패키지 존재)
+grep -rnE 'type ClassNames|interface ClassNames|ClassNames =' node_modules/@daypicker/react/dist/ 2>/dev/null | head
+# d.ts 위치 확인 후 직접 열어서 ClassNames 의 모든 키 나열
 ```
 
-v10 의 classNames 구조 변경 시 동등 키로 교체. release note 또는 d.ts 참조.
+현 calendar.tsx 키 (v9 후반 shadcn 표준 기준):
+```
+months, month, caption, caption_label, nav, nav_button,
+nav_button_previous, nav_button_next, month_grid, weekdays,
+weekday, week, day, day_button, range_end, selected, today,
+outside, disabled, range_middle, hidden
+```
 
-### 3. type re-export 점검
+v9 → v10 가능한 rename 후보 (release note + d.ts 참조 필수):
+- `caption` / `caption_label` → `month_caption` / `caption_label` 가능성
+- `nav_button` / `nav_button_previous` / `nav_button_next` → `button_previous` / `button_next` 가능성
+- 기타 d.ts 가 권위
 
+검증 방법 — 타입 강제:
 ```ts
-export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+import type { ClassNames } from "@daypicker/react";
+const classNames: Partial<ClassNames> = { /* 현 키 22개 */ };
 ```
 
-이건 그대로 — DayPicker 의 v10 시그니처가 자동 추론. 호출자 (Calendar 사용처) 의 폐기 prop 사용은 phase 시작 시 grep:
+`pnpm tsc --noEmit` 가 잘못된 키 (v10 에서 제거/이름 변경된 키) 를 모두 잡음. 발견 시 d.ts 의 신 키로 교체.
 
+### 3. Chevron component prop 시그니처 v10 호환 검증 (CRITICAL)
+
+`calendar.tsx:56-61` 의 `components.Chevron` 시그니처 (`orientation, className, ...props`) 가 v10 d.ts 와 일치하는지 확인:
+
+```bash
+grep -rnE 'ChevronProps|Chevron:' node_modules/@daypicker/react/dist/ 2>/dev/null | head
+```
+
+`orientation` 값 enum / 추가 props (`disabled`, `size` 등) 가 v10 에서 추가됐는지 d.ts 확인. 시그니처 차이 발견 시 destructuring 갱신.
+
+호출자 측 폐기 prop 점검 (phase-01 에서 0건 확인됨, 회귀 방지용 재확인):
 ```bash
 grep -rnE 'fromMonth|toMonth|fromYear|toYear|fromDate|toDate|initialFocus' src/ \
   --include='*.tsx' --include='*.ts' | grep -v calendar.tsx
 ```
-
-발견 시 호출자 측에서 동등 prop 으로 교체.
 
 ### 4. 자동 verification
 
@@ -77,7 +98,7 @@ grep -n 'from "@daypicker/react"' src/components/ui/calendar.tsx | wc -l   # = 1
 ! grep -rnE 'fromMonth|toMonth|fromYear|toYear|fromDate=|toDate=|initialFocus=' src/
 ```
 
-수동 smoke: dashboard `/dashboard` → CalendarView 표시 + 날짜 클릭 정상.
+수동 smoke (선택, human review): dashboard `/dashboard` → CalendarView 표시 + 날짜 클릭 정상. headless executor 는 skip — `tsc --noEmit` + `pnpm build` + step 2 type-driven 검증 통과로 갈음.
 
 ## Critical Files
 

--- a/tasks/plan007-react-day-picker-v10/phase-03.md
+++ b/tasks/plan007-react-day-picker-v10/phase-03.md
@@ -65,7 +65,7 @@ grep -n 'from "@daypicker/react"' src/components/dashboard/CalendarView.tsx | wc
 ! grep -nE 'onDayKey|onDayPointer|onDayTouch|onWeekNumberClick' src/components/dashboard/CalendarView.tsx
 ```
 
-수동 smoke: `/dashboard` → CalendarView 의 날짜 hover / 클릭 / 키보드 탐색 모두 정상.
+수동 smoke (선택, human review): `/dashboard` → CalendarView 의 날짜 hover / 클릭 / 키보드 탐색. headless executor 는 `pnpm test --run` + tsc + build 로 갈음.
 
 ## Critical Files
 

--- a/tasks/plan007-react-day-picker-v10/phase-04.md
+++ b/tasks/plan007-react-day-picker-v10/phase-04.md
@@ -79,9 +79,12 @@ grep '^\*\*Status\*\*:' tasks/plan007-react-day-picker-v10/phase-04.md   # = "**
 | `tasks/plan007-react-day-picker-v10/index.json` | 모든 status `completed` |
 | `tasks/plan007-react-day-picker-v10/phase-04.md` | 본 파일 status `completed` |
 
+### 5. PR body 에 `Closes #222` 마커 (team-lead 가 PR 생성 시)
+
+PR description body 에 `Closes #222` 한 줄 포함 — Dependabot PR (`chore(deps): bump react-day-picker`) 이 본 plan PR 머지 시 자동 close 되도록.
+
 ## Out of Scope
 
-- PR #222 close — 본 plan PR 머지 후 사용자가 GitHub UI 에서 직접 close (또는 plan PR 의 `Closes #222` 마커로 자동)
 - v10 신규 기능 도입 (hidden, autoFocus 등) — 본 plan 은 호환만
 
 ## Risks

--- a/tasks/plan007-react-day-picker-v10/phase-04.md
+++ b/tasks/plan007-react-day-picker-v10/phase-04.md
@@ -1,7 +1,7 @@
 # Phase 04 — 통합 검증 + legacy 잔재 grep + completed 마킹
 
 **Model**: haiku
-**Status**: pending
+**Status**: completed
 **Goal**: phase 01~03 산출물 통합 검증, react-day-picker v9 잔재 0건 증명, `index.json` status `completed` 마킹.
 
 ## Context (자기완결)


### PR DESCRIPTION
## Summary

ADR-F18 결정 반영. `react-day-picker` v9 → v10 메이저 + `@daypicker/react` 신 namespace 로 이전.

PR #222 (Dependabot dep bump only) 를 대체. `Closes #222`.

## 변경 사항

### dep 교체
- `react-day-picker@^9.14.0` 제거
- `@daypicker/react@^10.0.0` 추가
- v10 호환 동시에 신 namespace 채택 (ADR-F18 결정)

### `src/components/ui/calendar.tsx`
- import 경로 → `@daypicker/react`
- classNames 키 v10 rename:
  - `caption` → `month_caption`
  - `nav_button` (단일) → `button_previous` / `button_next` 분리 (위치 클래스 통합)
- Chevron destructuring 으로 v10 신규 props (`size?`, `disabled?`) 가 `lucide` Icon 으로 누출되지 않도록 차단

### `src/components/dashboard/CalendarView.tsx`
- `DayButtonProps` import 경로 → `@daypicker/react`
- `caption` → `month_caption`

## Test plan

- [x] `pnpm tsc --noEmit`: 0 errors
- [x] `pnpm lint`: 통과
- [x] `pnpm test`: 211 passed
- [x] `pnpm build`: 통과
- [x] v9 잔재 grep 0건 (`from "react-day-picker"`, 폐기 prop, 폐기 event prop, 폐기 type alias)
- [ ] 머지 후 `/dashboard` 의 CalendarView 시각 회귀 확인 (수동 smoke)

## 검증 게이트 (build-with-teams)

- critic: APPROVE (REVISE 1회 — classNames 키 type-driven 검증으로 전환)
- code-reviewer: PASS
- docs-verifier: PASS (ADR-F18 준수 + dead reference 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)