### PR TITLE
docs(plan009): BottomNavigation Teal fintech 리디자인 plan

### DIFF
--- a/tasks/plan009-bottom-navigation-redesign/index.json
+++ b/tasks/plan009-bottom-navigation-redesign/index.json
@@ -1,0 +1,42 @@
+{
+  "name": "plan009-bottom-navigation-redesign",
+  "description": "BottomNavigation Teal fintech 리디자인 — handoff MobileShell TabBar (5 메뉴: 홈/내역/추가/분석/설정) + FAB (brand-500 + white ring + custom shadow) 적용. 현 blue-600 → brand-600 토큰 + 활성 상태 sw=2.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/code-architecture.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan005-add-expense-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 완료 (OKLCH 토큰 / brand-500/600)",
+    "plan005 머지 완료 (AddExpenseDialog Sheet/Dialog responsive — FAB 진입점)",
+    "handoff mockup: /tmp/handoff_fos/fos-accountbook/project/screens/mobile.jsx line 9~103 (MobileShell + TabBar + FAB)"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "BottomNavigation TabBar 디자인 — brand 토큰 + 활성 sw 강화 + 5 메뉴 일관",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "FAB 신 디자인 — brand-500 단색 + 4px white ring + custom shadow + 위치 정밀화",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan009-bottom-navigation-redesign/phase-01.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-01.md
@@ -1,0 +1,103 @@
+# Phase 01 — TabBar 디자인 갱신 (brand 토큰 + 활성 sw 강화)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: BottomNavigation 의 5 탭 (홈/내역/추가/분석/설정) 시각을 handoff MobileShell TabBar 패턴에 맞춰 갱신. blue-600 하드코딩 → brand-600 토큰, 활성 상태 typography 강화.
+
+## Context (자기완결)
+
+- 현재 파일: `src/components/layout/BottomNavigation.tsx` (104줄). `<NavButton>` 서브 컴포넌트 + `<BottomNavigation>` wrapper.
+- 현재 활성 색: `text-blue-600` (line 25) — 하드코딩, plan001 토큰 미적용.
+- 현재 비활성 색: `text-gray-500` — surface 토큰 미적용.
+- handoff TabBar (mobile.jsx line 54~87):
+  - container: 88px height + 8px paddingTop + 24px paddingBottom + `border-t border-border bg-bg-elev`
+  - tab item: `flex-1 flex flex-col items-center gap-[3px]`
+  - 활성: `text-brand-600` + `font-semibold` + icon stroke `sw=2` (Lucide `strokeWidth`)
+  - 비활성: `text-fg-subtle` + `font-medium` + icon `sw=1.6`
+  - center slot (add): 빈 `<div flex-1 />` (FAB 가 absolute 로 그 위 떠 있음 — phase 02 책임)
+
+## 작업 항목
+
+### 1. NavButton 스타일 토큰 교체
+
+`src/components/layout/BottomNavigation.tsx:25~26`:
+
+```tsx
+// 변경 전
+isActive ? "text-blue-600" : "text-gray-500"
+
+// 변경 후
+isActive ? "text-brand-600" : "text-fg-subtle"
+```
+
+활성 라벨도 `font-semibold` (현재 `font-medium`):
+
+```tsx
+<span className={cn("text-[10px] md:text-xs", isActive && "font-semibold")}>
+```
+
+### 2. icon strokeWidth 분기
+
+Lucide icon 은 `strokeWidth` prop 으로 stroke 두께 조절. NavButton 시그니처에 `isActive` 기반 분기:
+
+```tsx
+<Icon className="w-4.5 h-4.5 md:w-5 md:h-5" strokeWidth={isActive ? 2 : 1.6} />
+```
+
+### 3. container 시각 토큰 정렬
+
+`<div className="fixed bottom-0 ... bg-white/90 backdrop-blur-xl border-t border-gray-200/50 ...">` 의 하드코딩 색:
+
+```tsx
+// 변경 전
+className="fixed bottom-0 left-0 right-0 z-50 bg-white/90 backdrop-blur-xl border-t border-gray-200/50 safe-area-pb"
+
+// 변경 후 (light/dark 자동 전환)
+className="fixed bottom-0 left-0 right-0 z-50 bg-bg-elev/95 backdrop-blur-xl border-t border-border safe-area-pb"
+```
+
+`bg-white/90` → `bg-bg-elev/95` (handoff 의 `bg-bg-elev` 토큰 + 약간 transparency 유지로 glass 효과).
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/009-bottom-navigation-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+
+# 하드코딩 색 잔재 0
+! grep -nE 'text-blue-600|text-gray-500|bg-white/|border-gray-' src/components/layout/BottomNavigation.tsx
+
+# brand 토큰 사용
+grep -nE 'text-brand-600|text-fg-subtle|bg-bg-elev|border-border' src/components/layout/BottomNavigation.tsx | wc -l   # >= 4
+
+# strokeWidth 분기 도입
+grep -n 'strokeWidth=' src/components/layout/BottomNavigation.tsx | wc -l   # >= 1
+```
+
+수동 smoke: 모바일 viewport → 각 탭 클릭 시 활성 색 brand-600 표시 + icon 두꺼워짐. light/dark 토글 시 surface 토큰 자동 전환.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/layout/BottomNavigation.tsx` | NavButton + container 색/typography 토큰 교체 |
+
+## Out of Scope
+
+- FAB 디자인 (phase 02)
+- 메뉴 구성 변경 — 5 메뉴 도메인 유지
+- 탭 안 신 아이콘 추가 — Lucide 그대로 (Home/CreditCard/Plus/BarChart3/Settings)
+- safe-area 처리 변경 — 기존 `safe-area-pb` 유틸 유지
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| Tailwind v4 가 `text-brand-600` 클래스 미인식 (theme 정의 누락) | plan001 의 `@theme --color-brand-600` 등록됨. `pnpm build` 가 unused class warning 안 띄우는지 확인 |
+| dark mode 에서 `bg-bg-elev/95` 가 충분히 대비 안 됨 | plan001 의 dark theme 토큰이 이미 정의 — light/dark 둘 다 테스트 |
+| `safe-area-pb` 유틸이 globals.css 에 정의됐는지 | grep 으로 확인. 없으면 본 phase OOS — 별도 plan |

--- a/tasks/plan009-bottom-navigation-redesign/phase-02.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-02.md
@@ -1,0 +1,129 @@
+# Phase 02 — FAB 신 디자인 (brand 단색 + white ring + custom shadow)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 현 BottomNavigation 의 FAB 를 handoff `<FAB />` 디자인으로 교체 — `gradient-primary` 단색 → `bg-brand-500` + 4px white ring + Teal-toned soft shadow.
+
+## Context (자기완결)
+
+- 현재 FAB (`BottomNavigation.tsx:62~70`):
+  - 위치: TabBar 안 인라인 (`-mt-4 md:-mt-6` 으로 위로 빠짐)
+  - 색: `gradient-primary` (gradient — 단색 X)
+  - 크기: 48~56px
+  - shape: `rounded-xl md:rounded-2xl` (정사각형 모서리 둥근)
+  - shadow: `shadow-lg hover:shadow-xl`
+  - icon: `<Plus />` white
+- handoff FAB (mobile.jsx line 89~103):
+  - 위치: `position: absolute, bottom: 32px, left: 50%, translateX(-50%)` — TabBar 위에 떠 있음
+  - 색: `bg-brand-500` 단색 (Teal `oklch(0.640 0.140 188)`)
+  - 크기: 56px
+  - shape: `rounded-full` (완전 원형)
+  - border: `border-4 border-bg-elev` (4px white ring — light mode 기준. dark 도 `bg-bg-elev` 토큰 자동)
+  - shadow: `0 6px 20px -4px oklch(0.640 0.140 188 / 0.45), 0 2px 6px -2px rgb(0 0 0 / 0.12)` — Teal-toned soft shadow
+  - icon: `<Plus />` size=24 strokeWidth=2.4 white
+
+## 작업 항목
+
+### 1. FAB 컴포넌트 분리
+
+`src/components/layout/BottomNavigation.tsx` 안에 inline 으로 있던 FAB 를 별도 `<FAB />` 컴포넌트로 추출 (코드 가독성 + 향후 다른 위치 재사용 가능):
+
+```tsx
+function FAB({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="지출 추가"
+      className="absolute bottom-[28px] left-1/2 -translate-x-1/2 w-14 h-14 rounded-full bg-brand-500 text-white border-4 border-bg-elev shadow-[var(--shadow-fab)] flex items-center justify-center transition-all hover:bg-brand-600"
+    >
+      <Plus className="w-6 h-6" strokeWidth={2.4} />
+    </button>
+  );
+}
+```
+
+### 2. globals.css 에 FAB shadow 토큰 추가
+
+`src/app/globals.css` 의 `@theme` 블록 또는 `:root` 에 Teal-toned soft shadow:
+
+```css
+--shadow-fab: 0 6px 20px -4px oklch(0.640 0.140 188 / 0.45),
+              0 2px 6px -2px rgb(0 0 0 / 0.12);
+```
+
+이 토큰은 FAB 전용. 다른 컴포넌트가 같은 brand-tone shadow 필요시 재사용 (예: dashboard hero card).
+
+### 3. BottomNavigation 본문에서 FAB 위치 조정
+
+기존:
+```tsx
+{/* 지출 추가 */}
+<div className="relative -mt-4 md:-mt-6">
+  <Button ... className="gradient-primary ...">
+    <Plus ... />
+  </Button>
+</div>
+```
+
+신규: TabBar 안의 5개 NavButton 중 가운데 (index=2) 는 빈 공간으로 두고, 별도 `<FAB />` 를 wrapper 의 `relative` 컨테이너에 absolute 로 배치:
+
+```tsx
+<div className="fixed bottom-0 left-0 right-0 z-50 ...">
+  <div className="relative max-w-7xl mx-auto px-2 md:px-4">
+    <div className="flex justify-around items-center h-14 md:h-16">
+      <NavButton /* 홈 */ />
+      <NavButton /* 내역 */ />
+      <div className="flex-1" />  {/* center slot — FAB 위치 */}
+      <NavButton /* 분석 */ />
+      <NavButton /* 설정 */ />
+    </div>
+    <FAB onClick={() => setIsExpenseDialogOpen(true)} />
+  </div>
+</div>
+```
+
+`<FAB />` 의 `absolute bottom-[28px] left-1/2` 가 wrapper 의 relative 컨테이너 기준으로 배치 — TabBar 위로 떠오름.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/009-bottom-navigation-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# gradient-primary 잔재 0 (BottomNav 한정)
+! grep -nE 'gradient-primary' src/components/layout/BottomNavigation.tsx
+
+# FAB shadow 토큰 등록
+grep -n '\-\-shadow-fab' src/app/globals.css | wc -l   # >= 1
+
+# brand-500 + border-bg-elev 사용
+grep -nE 'bg-brand-500|border-bg-elev|shadow-fab' src/components/layout/BottomNavigation.tsx | wc -l   # >= 2
+```
+
+수동 smoke: 모바일 → FAB 가 TabBar 위에 떠 있음 + Teal 원형 + 4px white ring + soft shadow. 클릭 시 AddExpenseDialog Sheet 진입 (plan005 효과).
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/layout/BottomNavigation.tsx` | FAB 별도 컴포넌트 추출 + 신 디자인 |
+| `src/app/globals.css` | `--shadow-fab` 토큰 추가 |
+
+## Out of Scope
+
+- FAB tap animation (scale 등) — 추후 plan 검토
+- 다른 페이지의 floating button (없음 — FAB 는 BottomNav 전용)
+- AddExpenseDialog 호출 시그니처 — 그대로 (plan005 가 이미 처리)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `--shadow-fab` 토큰을 arbitrary class `shadow-[var(--shadow-fab)]` 로 적용 시 Tailwind v4 가 못 잡음 | plan001 패턴 확인 (`shadow-[var(--shadow-default)]` 사용 사례) — 작동함 확인 |
+| FAB absolute 위치가 safe-area 와 겹침 (iOS notch) | `bottom-[calc(28px+env(safe-area-inset-bottom))]` 패턴 필요 시 적용. 본 phase 1차는 단순 28px |
+| 4px white ring (border-bg-elev) 이 dark mode 에서 어색 (검정 ring) | `border-bg-elev` 가 light=#FFF, dark=elevated bg — 자연스러운 ring. plan001 토큰 효과 |

--- a/tasks/plan009-bottom-navigation-redesign/phase-03.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-03.md
@@ -1,0 +1,93 @@
+# Phase 03 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~02 산출물 통합 검증, hardcoded 색 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: TabBar 토큰 (1) + FAB 신 디자인 + shadow 토큰 (2).
+- legacy 잔재 후보: `text-blue-600`, `text-gray-500`, `gradient-primary` (BottomNav 한정), `bg-white/`, `border-gray-`.
+- `_shared/common-pitfalls.md § 1-8` 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/009-bottom-navigation-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` + 회귀 phase 식별.
+
+### 2. legacy 잔재 grep — 0건 증명
+
+```bash
+# BottomNavigation 의 하드코딩 색 + 구 gradient 잔재
+! grep -nE 'text-blue-600|text-gray-500|gradient-primary|bg-white/[0-9]|border-gray-' src/components/layout/BottomNavigation.tsx
+
+# hex/rgb 직접 (FAB shadow 토큰의 oklch alpha 는 globals.css 한정 — 컴포넌트 측 0건)
+! grep -nE '#[0-9a-fA-F]{6}\b|hsl\(' src/components/layout/BottomNavigation.tsx
+```
+
+### 3. 신 디자인 등록 확인
+
+```bash
+# brand 토큰 사용
+grep -nE 'text-brand-600|text-fg-subtle|bg-bg-elev|border-border|bg-brand-500|border-bg-elev' src/components/layout/BottomNavigation.tsx | wc -l   # >= 5
+
+# FAB shadow 토큰
+grep -n '\-\-shadow-fab' src/app/globals.css | wc -l   # >= 1
+grep -n 'shadow-fab' src/components/layout/BottomNavigation.tsx | wc -l   # >= 1
+
+# icon strokeWidth 분기 (활성/비활성)
+grep -n 'strokeWidth' src/components/layout/BottomNavigation.tsx | wc -l   # >= 2 (NavButton + FAB)
+```
+
+### 4. AddExpenseDialog 진입점 보존
+
+```bash
+# FAB 클릭 → setIsExpenseDialogOpen(true) 흐름 유지
+grep -n 'setIsExpenseDialogOpen' src/components/layout/BottomNavigation.tsx | wc -l   # >= 1
+grep -n 'AddExpenseDialog' src/components/layout/BottomNavigation.tsx | wc -l   # >= 2 (import + 사용)
+```
+
+### 5. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan009-bottom-navigation-redesign/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan009-bottom-navigation-redesign/index.json
+grep -c '"status": "completed"' tasks/plan009-bottom-navigation-redesign/index.json   # = 4 (top + 3 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan009-bottom-navigation-redesign/phase-03.md
+grep '^\*\*Status\*\*:' tasks/plan009-bottom-navigation-redesign/phase-03.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan009-bottom-navigation-redesign/index.json` | 모든 status `completed` |
+| `tasks/plan009-bottom-navigation-redesign/phase-03.md` | 본 파일 status `completed` |
+
+## Out of Scope
+
+- FAB tap animation / haptic feedback — 후속 plan
+- 데스크톱 네비게이션 (현재 BottomNav 는 모든 viewport 공통 — handoff 데스크톱은 별도 `DesktopShell` 사이드바. plan010+ 검토)
+- 신 메뉴 추가 (가족 초대 등) — 별도 plan
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 내 문자열) | 라인 시작 앵커 + 정확한 토큰 |
+| macOS BSD `sed -i ''` vs Linux | macOS 환경 가정 |
+| 데스크톱 viewport 에서 BottomNav 가 어색 (handoff 는 sidebar 권장) | plan009 범위 외 — 데스크톱 sidebar 도입은 plan010+ 별도 검토 |


### PR DESCRIPTION
## Summary

BottomNavigation (5 메뉴 + FAB) 의 handoff MobileShell 디자인 일관 적용. 모바일 진입점 마무리.

## 사용자 결정 (confirmed)

- plan009 = BottomNavigation 통일 (다음 디자인 작업 우선순위 1순위)

## Phase 구조 (3 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | TabBar 디자인 (brand 토큰 + 활성 sw + surface 토큰) | sonnet |
| 02 | FAB 신 디자인 (bg-brand-500 + 4px white ring + Teal-toned shadow) | sonnet |
| 03 | 통합 검증 + completed | haiku |

## 변경 핵심

| 영역 | Before | After |
|---|---|---|
| 활성 탭 색 | \`text-blue-600\` (하드코딩) | \`text-brand-600\` (토큰) |
| 비활성 탭 색 | \`text-gray-500\` | \`text-fg-subtle\` |
| icon stroke | 일정 | 활성=2 / 비활성=1.6 |
| FAB 색 | \`gradient-primary\` (gradient) | \`bg-brand-500\` 단색 |
| FAB shape | \`rounded-xl/2xl\` (정사각형) | \`rounded-full\` 원형 |
| FAB border | 없음 | 4px \`border-bg-elev\` (white ring) |
| FAB shadow | \`shadow-lg\` | \`shadow-[var(--shadow-fab)]\` Teal-toned soft |

## 의존성

- plan001 머지 완료 ✅ (brand-500/600, surface 토큰)
- plan005 머지 완료 ✅ (AddExpenseDialog Sheet/Dialog responsive — FAB 진입점 그대로 보존)

## 다음 단계

\`/build-with-teams plan009-bottom-navigation-redesign\` 호출 시 같은 브랜치에서 phase 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)