### PR TITLE
docs(plan010): 도메인 외곽 4 페이지 Teal 리디자인 plan

### DIFF
--- a/tasks/plan010-domain-pages-redesign/index.json
+++ b/tasks/plan010-domain-pages-redesign/index.json
@@ -1,0 +1,57 @@
+{
+  "name": "plan010-domain-pages-redesign",
+  "description": "도메인 외곽 4 페이지 Teal 리디자인 — Settings (3 카드) + Categories (list + Add/Edit/Delete dialog + plan002 톤 8 팔레트) + FamiliesSelect (카드 행 + 멤버 avatar) + FamiliesCreate (glass 제거 + gradient-family 채널). AddCategoryDialog/EditCategoryDialog 의 stale state fix 동시 적용.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/code-architecture.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 완료 (OKLCH 토큰 + Pretendard + data-theme)",
+    "plan002 머지 완료 (--color-cat-* 22 토큰 + window.tokens.color.category 매핑)",
+    "fix PR #233 머지 권장 (AddExpense/EditExpense/AddIncome/EditIncome 의 stale state inner body 패턴 — 본 plan 의 Category dialog 에 동일 적용)",
+    "handoff mockup: /tmp/handoff_plan010/fos-accountbook/project/screens/{mobile,desktop}-extra.jsx Screens 5~8"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "Settings — SettingsCard helper 추출 + 3 카드 (기본 가족 / 예산 / 알림) 토큰 적용",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "Categories — CategoryList row + Add/Edit/Delete Dialog stale state fix + plan002 톤 8 팔레트 매핑",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "FamiliesSelect — 카드 행 토큰 교체 + plan002 멤버 avatar 재사용",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "FamiliesCreate — glass 제거 + bg-bg-elev card + gradient-family 채널 + segmented type 토글",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan010-domain-pages-redesign/phase-01.md
+++ b/tasks/plan010-domain-pages-redesign/phase-01.md
@@ -1,0 +1,125 @@
+# Phase 01 — Settings 페이지 + SettingsCard helper
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Mobile/Desktop Settings (Screen 5) 디자인 적용 — 3 카드 구조 (기본 가족 / 가족별 예산 / 알림) + `SettingsCard` 공용 헬퍼 추출.
+
+## Context (자기완결)
+
+- 현재: `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` (302줄). 3 Card (line 119, 183, 267) 구조 이미 존재 — 토큰 교체만.
+- handoff 참조:
+  - 모바일: `/tmp/handoff_plan010/fos-accountbook/project/screens/mobile-extra.jsx` line 136~277
+  - 데스크톱: 동일 디렉터리 `desktop-extra.jsx` line 22~194 (2-col grid)
+- 사용자 결정: 3 카드 구조 유지 + 토큰 교체.
+- 활성 라디오 시각: handoff 패턴 `bg-brand-50 text-brand-700` + brand-500 check icon (sw=2.6).
+
+## 작업 항목
+
+### 1. `SettingsCard` 공용 헬퍼 추출
+
+`src/components/layout/SettingsCard.tsx` 신규. Props:
+
+```ts
+interface SettingsCardProps {
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}
+```
+
+Layout: `bg-bg-elev rounded-lg border-border` + header (icon 24px + title 16px font-bold + subtitle 12.5px text-fg-muted) + content.
+
+shadcn `Card` 위에 wrapper — 기존 Card 활용 + 헤더 패턴 일관.
+
+### 2. SettingsPageClient 마이그레이션
+
+3 Card 본문을 `<SettingsCard>` 호출로 교체. 텍스트 색/배경 하드코딩 grep + 토큰 교체:
+
+```bash
+grep -nE 'text-gray-|text-green-|hover:bg-gray-|bg-blue-|border-gray-' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | head
+```
+
+교체 매핑:
+- `text-gray-900` → `text-fg`
+- `text-gray-600` → `text-fg-muted`
+- `text-gray-500` → `text-fg-subtle`
+- `text-green-600` → `text-brand-600` (현재 기본 표시 — handoff 가 brand 톤)
+- `hover:bg-gray-50` → `hover:bg-bg-muted`
+
+### 3. 활성 라디오 시각 (handoff 패턴)
+
+기존 shadcn `RadioGroup` + `RadioGroupItem` 유지하되, 선택 시 행 전체에 `bg-brand-50` 배경 + 가족명 text `text-brand-700` 적용. 현재 기본 표시 ✓ 아이콘은 `text-brand-500`.
+
+```tsx
+<div className={cn(
+  "flex items-center gap-3 p-3 rounded-md cursor-pointer transition",
+  isSelected ? "bg-brand-50" : "hover:bg-bg-muted"
+)}>
+  <RadioGroupItem value={family.uuid} id={family.uuid} />
+  <Label htmlFor={family.uuid} className={cn("flex-1", isSelected && "text-brand-700")}>
+    {family.name}
+    ...
+  </Label>
+</div>
+```
+
+### 4. 데스크톱 2-col grid 적용
+
+handoff `DesktopSettings` (desktop-extra.jsx line 24~) 가 2-col grid 로 카드 배치. 모바일은 단일 column.
+
+```tsx
+<div className="grid gap-4 md:grid-cols-2">
+  <SettingsCard ... />  {/* 기본 가족 */}
+  <SettingsCard ... />  {/* 예산 */}
+  <SettingsCard ... className="md:col-span-2" />  {/* 알림 — full width */}
+</div>
+```
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/010-domain-pages-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/layout/SettingsCard.tsx
+
+# 하드코딩 색 잔재 0
+! grep -nE 'text-gray-[3-9]|text-green-[5-9]|hover:bg-gray-|bg-blue-50' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx
+
+# 신 토큰 사용
+grep -nE 'text-fg|text-fg-muted|text-brand-|bg-brand-50' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 5
+
+# md:grid-cols-2 (데스크톱)
+grep -n 'md:grid-cols-2' src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/settings` → 3 카드 표시. 기본 가족 라디오 선택 시 brand 톤 활성. 데스크톱 viewport 2-col.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/layout/SettingsCard.tsx` | 신규 |
+| `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` | 수정 (토큰 교체 + SettingsCard 사용) |
+
+## Out of Scope
+
+- Categories / Families 페이지 (phase 2~4)
+- 신 Settings 섹션 추가 (프로필 / 로그아웃 등 — handoff 미제공)
+- 알림 설정 데이터 모델 변경 (UI 만)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 알림 설정 데이터 (`notifs`) 가 실제 backend 미연동 | UI 만 — `useState` 로직 유지. 실제 저장은 별도 plan |
+| SettingsCard 헬퍼가 Card shadcn 과 prop 충돌 | wrapper 로 명확 분리. 내부에서 `<Card>` 호출 |
+| 2-col grid 가 알림 카드 길이 다르면 어색 | 알림 카드 `md:col-span-2` 로 full-width. 또는 grid auto-rows 자연 흐름 |

--- a/tasks/plan010-domain-pages-redesign/phase-02.md
+++ b/tasks/plan010-domain-pages-redesign/phase-02.md
@@ -1,0 +1,133 @@
+# Phase 02 — Categories list + Dialog stale fix + plan002 톤 팔레트
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Categories (Screen 6) 적용 — 카테고리 list row 토큰 교체 + Add/Edit/Delete Dialog 의 stale state fix (PR #233 패턴) + 색 팔레트 8개를 plan002 톤 fg 값으로 매핑.
+
+## Context (자기완결)
+
+- 영향 파일 (`src/app/(authenticated)/categories/_components/`):
+  - `page.tsx` (42줄) — 헤더
+  - `CategoryPageClient.tsx` (96줄)
+  - `CategoryList.tsx` (90줄)
+  - `CategoryItem.tsx` (85줄)
+  - `AddCategoryDialog.tsx` (240줄) — useState 5개 (name/color/icon/excludeFromBudget/isSubmitting) + hex 팔레트
+  - `EditCategoryDialog.tsx` (240줄) — 동일 + useEffect 의존성
+  - `DeleteCategoryDialog.tsx` (53줄) — useActionState 0 (fix 불필요)
+- handoff 참조: `mobile-extra.jsx` line 281~466 + `desktop-extra.jsx` line 198~365
+- handoff 의 색 팔레트: `window.tokens.color.category[pickedHue]` — 8개 도메인 키 (food/cafe/transit/telecom/home/shopping/health/leisure).
+
+## 작업 항목
+
+### 1. AddCategoryDialog / EditCategoryDialog stale state fix
+
+PR #233 의 inner body 패턴 동일 적용. 양 파일에:
+
+```tsx
+export function AddCategoryDialog({ open, onOpenChange, ... }) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="...">
+        ...
+        {open ? <AddCategoryDialogBody ... /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddCategoryDialogBody({ onOpenChange, ... }) {
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(PALETTE[0]);  // 8 hex 중 첫 번째
+  // ...
+}
+```
+
+EditCategoryDialog 의 `useEffect(() => setColor(category.color), [category.color])` 패턴은 inner body 안의 initial state 로 흡수 — open 변경 시 자동 reset, prop 변경은 key 또는 자체 동기화로.
+
+### 2. 색 팔레트 8개 → plan002 톤 fg 매핑
+
+`PALETTE` 상수 (현재 EditCategoryDialog line 61~68 의 8 hex):
+
+```ts
+// 변경 전 (Tailwind 기본 색)
+const PALETTE = ["#ef4444", "#f59e0b", "#ec4899", "#10b981", "#3b82f6", "#8b5cf6", "#06b6d4", "#f43f5e"];
+
+// 변경 후 (plan002 카테고리 톤 fg — OKLCH)
+const PALETTE = [
+  "oklch(0.560 0.140 35)",   // food coral
+  "oklch(0.520 0.110 60)",   // cafe bronze
+  "oklch(0.540 0.130 230)",  // transit blue
+  "oklch(0.540 0.130 280)",  // telecom violet
+  "oklch(0.510 0.110 188)",  // home teal
+  "oklch(0.560 0.140 330)",  // shopping pink
+  "oklch(0.520 0.120 152)",  // health green
+  "oklch(0.520 0.120 105)",  // leisure olive
+];
+```
+
+DB 의 `category.color` 는 여전히 string — hex 또는 OKLCH 둘 다 수용. 단 OKLCH 문자열을 backend 가 그대로 저장 (validation 없음 가정 — backend 점검 필요. 가드 추가).
+
+backend 가 hex 만 수용한다면 plan 본문에 보고 + plan011 로 backend 변경 분리.
+
+### 3. CategoryList row 토큰 교체
+
+`CategoryList.tsx` + `CategoryItem.tsx`:
+- 카테고리 icon cell: `bg-[${color}]/15 text-[${color}]` 패턴 → `style={{ background: color + "26", color }}` (16% alpha hex `26`) 또는 inline OKLCH alpha
+- row hover: `hover:bg-bg-muted`
+- 텍스트: `text-fg` / `text-fg-muted` 토큰
+
+### 4. CategoryPageClient + page.tsx 헤더 토큰
+
+`page.tsx` line 29~32 의 `text-gray-900` / `text-gray-600` → `text-fg` / `text-fg-muted`. "추가" 버튼이 있으면 `bg-brand-500 text-white` 토큰 적용.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/010-domain-pages-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+
+# Dialog stale fix 패턴 적용 (open ? <Body /> 분리)
+grep -n 'CategoryDialogBody\|open\s*?\s*<' src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx | wc -l   # >= 1
+grep -n 'CategoryDialogBody\|open\s*?\s*<' src/app/\(authenticated\)/categories/_components/EditCategoryDialog.tsx | wc -l   # >= 1
+
+# 8 hex 팔레트 잔재 0 (Tailwind 기본 색)
+! grep -nE '#ef4444|#f59e0b|#ec4899|#10b981|#3b82f6|#8b5cf6|#06b6d4|#f43f5e' src/app/\(authenticated\)/categories/
+
+# OKLCH 톤 8개 등록
+grep -cE 'oklch\([0-9.]+ [0-9.]+ [0-9]+\)' src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx   # >= 8
+
+# 하드코딩 gray 색 잔재 0
+! grep -nE 'text-gray-[3-9]|hover:bg-gray-' src/app/\(authenticated\)/categories/
+```
+
+수동 smoke: `/categories` → 카테고리 row + 추가 → 다이얼로그 → 색 팔레트 8 동그라미 (plan002 톤). 다이얼로그 두 번 열기 시 stale state 없음. Edit 도 동일.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx` | inner body 분리 + 팔레트 교체 |
+| `src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx` | 동일 |
+| `src/app/(authenticated)/categories/_components/CategoryList.tsx` | 토큰 교체 |
+| `src/app/(authenticated)/categories/_components/CategoryItem.tsx` | 토큰 교체 |
+| `src/app/(authenticated)/categories/_components/CategoryPageClient.tsx` | 토큰 |
+| `src/app/(authenticated)/categories/page.tsx` | 헤더 토큰 |
+
+## Out of Scope
+
+- backend `category.color` schema 변경 — OKLCH 문자열 수용 확인 후 별도 plan
+- 카테고리 row 의 통계 (이번 달 N건) 추가 — 데이터 의존 별도 plan
+- DeleteCategoryDialog 디자인 — 토큰만 (간단), 본 phase 안 포함하되 별도 작업항목 X
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| backend 가 OKLCH 문자열 거부 (validation) | dev 환경 fetch 로 확인 — 거부 시 phase 본문에 보고 + 일단 hex 유지 |
+| Tailwind v4 가 OKLCH inline `style={{ color: "oklch(...)" }}` 인식 못 함 | inline style 은 CSS color value 그대로 전달 — Tailwind 무관. 브라우저가 처리. 안전 |
+| EditCategoryDialog 의 prop 변경 시 inner body remount 자연 동기화 | 동일 row 반복 수정 시 같은 expense prop → Body 가 unmount/remount = initial value 새로. PR #233 패턴과 일관 |

--- a/tasks/plan010-domain-pages-redesign/phase-03.md
+++ b/tasks/plan010-domain-pages-redesign/phase-03.md
@@ -1,0 +1,122 @@
+# Phase 03 — FamiliesSelect 카드 행 + plan002 멤버 avatar
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff FamiliesSelect (Screen 7) 디자인 적용 — 카드 행 구조 유지 + 토큰 교체 + plan002 RecentActivity 의 멤버 avatar 겹침 패턴 재사용.
+
+## Context (자기완결)
+
+- 영향 파일:
+  - `src/app/(authenticated)/families/select/page.tsx` (29줄) — Server Component, 직접 렌더 X
+  - `src/components/families/FamilySelectorPage.tsx` — wrapper (확인)
+  - `src/components/families/FamilySelector.tsx` (~228줄) — 실제 카드 list. 하드코딩 색 다수 (`hover:border-blue-200`, `text-gray-*`, `bg-gray-300` avatar).
+- handoff 참조: `mobile-extra.jsx` line 470~575 + `desktop-extra.jsx` line 369~487
+- plan002 의 `CoupleAvatars` 헬퍼 또는 RecentActivity 의 avatar 겹침 (`-ml-2 ring-2 ring-bg-elev`) 패턴 재사용.
+
+## 작업 항목
+
+### 1. FamilySelector 카드 토큰 교체
+
+기존 (FamilySelector.tsx line 155~):
+```tsx
+className="cursor-pointer hover:shadow-lg ... border-2 hover:border-blue-200"
+```
+
+신규:
+```tsx
+className="cursor-pointer transition border-border hover:border-brand-300 hover:shadow-default bg-bg-elev"
+```
+
+card 안 텍스트:
+- `text-gray-900` → `text-fg`
+- `text-gray-600` → `text-fg-muted`
+- `text-gray-500` → `text-fg-subtle`
+- `text-gray-400` (ChevronRight) → `text-fg-subtle`
+
+### 2. 멤버 avatar 겹침 패턴 (plan002 재사용)
+
+기존 (line 188~):
+```tsx
+<div className="w-8 h-8 rounded-full bg-gray-300 ...">
+```
+
+신규: plan002 `CoupleAvatars` 또는 동일 패턴:
+
+```tsx
+<div className="flex">
+  {family.members.slice(0, 3).map((m, i) => (
+    <div key={m.uuid} className={cn(
+      "w-8 h-8 rounded-full ring-2 ring-bg-elev overflow-hidden",
+      i > 0 && "-ml-2"
+    )}>
+      {m.userImage ? (
+        <Image src={m.userImage} alt={m.userName ?? ""} width={32} height={32} className="object-cover w-full h-full" />
+      ) : (
+        <div className="w-full h-full bg-bg-muted text-fg-muted text-xs font-semibold flex items-center justify-center">
+          {m.userName?.charAt(0) ?? "U"}
+        </div>
+      )}
+    </div>
+  ))}
+  {family.members.length > 3 && (
+    <div className="-ml-2 w-8 h-8 rounded-full ring-2 ring-bg-elev bg-bg-muted text-fg-muted text-xs font-semibold flex items-center justify-center">
+      +{family.members.length - 3}
+    </div>
+  )}
+</div>
+```
+
+기존 `text-xs text-gray-500` "+{N}" 패턴 → `+N` cell 자체로 (handoff 스타일).
+
+### 3. 구분선 + 신 가족 만들기 영역
+
+FamilySelector 하단 구분선 (line 220~ "또는"):
+- `border-gray-300` → `border-border`
+- `bg-gray-50 text-gray-500` → `bg-bg text-fg-muted`
+
+### 4. 에러 / 빈 상태 토큰
+
+`text-red-500` (line 112 error) → `text-expense` (semantic 의미색).
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/010-domain-pages-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# 하드코딩 잔재 0
+! grep -nE 'text-gray-[3-9]|bg-gray-[3-9]|hover:border-blue-|text-red-' src/components/families/FamilySelector.tsx
+
+# 신 토큰 사용
+grep -nE 'text-fg|hover:border-brand-300|ring-bg-elev|bg-bg-elev' src/components/families/FamilySelector.tsx | wc -l   # >= 4
+
+# 멤버 avatar 겹침 패턴 (-ml-2 ring)
+grep -n '\-ml-2.*ring-' src/components/families/FamilySelector.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/families/select` (다수 가족 보유 시) → 카드 row 표시 + hover brand-300 border + 멤버 avatar 3개 겹침 + "+N" 자연.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/families/FamilySelector.tsx` | 토큰 교체 + avatar 겹침 패턴 |
+| `src/components/families/FamilySelectorPage.tsx` (해당 시) | wrapper 토큰 점검 |
+
+## Out of Scope
+
+- FamilySelectorDropdown (drawer 안 가족 전환 UI — 별도 컴포넌트, 본 plan 본문 OOS)
+- 가족 row 클릭 → 상세 페이지 (현재 selection only)
+- 4명 이상 가족 "+N" 외 cell — 본 plan 은 3 + 1 cell 유지
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `family.members` API 응답에 `userImage` 부재 | 첫 글자 fallback 이미 있음 (line 198) — 토큰만 적용 |
+| plan002 `CoupleAvatars` helper 가 export 되지 않을 경우 inline | 인라인 구현으로 충분. 재사용은 추후 plan 에서 helper 추출 검토 |
+| ring `ring-bg-elev` 가 dark mode 에서 어색 | plan001 `--color-bg-elev` 가 dark 에서 자연 변환. 시각 점검만 |

--- a/tasks/plan010-domain-pages-redesign/phase-04.md
+++ b/tasks/plan010-domain-pages-redesign/phase-04.md
@@ -1,0 +1,157 @@
+# Phase 04 — FamiliesCreate glass 제거 + gradient-family 채널
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff FamiliesCreate (Screen 8) 디자인 적용 — `app-background + glass-card` 폐기 + `bg-bg-elev` 카드 + gradient-family 채널 (상단 아이콘 원형) + 가계부 타입 segmented 토글.
+
+## Context (자기완결)
+
+- 영향 파일: `src/app/(authenticated)/families/create/page.tsx` (164줄). 신규 사용자 첫 진입점.
+- 현재 (line 66~67):
+  - 배경: `min-h-screen app-background p-4`
+  - Card: `<Card className="glass-card">`
+  - 안내 박스 (line 147~): `bg-blue-50` + `text-blue-900/700` 하드코딩
+- handoff 참조: `mobile-extra.jsx` line 579~720 + `desktop-extra.jsx` line 491~628
+- 사용자 결정: glass 제거 + bg-bg-elev card + gradient-family 채널만 상단.
+
+## 작업 항목
+
+### 1. 배경 / 카드 클래스 교체
+
+```tsx
+// 변경 전
+<div className="min-h-screen app-background p-4">
+  <div className="max-w-md mx-auto pt-20">
+    <Card className="glass-card">
+
+// 변경 후
+<div className="min-h-screen bg-bg p-4">
+  <div className="max-w-md mx-auto pt-20">
+    <Card className="bg-bg-elev border-border shadow-default">
+```
+
+`app-background` 클래스는 다른 페이지에서 쓰이는지 grep 확인:
+
+```bash
+grep -rn 'app-background\|glass-card' src/ 2>/dev/null
+```
+
+`app-background` 가 본 페이지 외 사용처 0 이면 globals.css 에서도 제거 (별도 작업항목). 0 아니면 본 페이지 className 만 교체.
+
+### 2. 상단 gradient-family 채널 (아이콘 원형)
+
+handoff 패턴: 카드 상단에 96px round + `gradient-family` 배경 + `<Users />` 아이콘 white inside. 시각 강조 + 도메인 정체성.
+
+```tsx
+<CardHeader className="text-center pt-8 pb-4">
+  <div className="mx-auto mb-3 w-24 h-24 rounded-full gradient-family flex items-center justify-center">
+    <Users className="w-10 h-10 text-white" strokeWidth={2.2} />
+  </div>
+  <CardTitle className="text-2xl font-bold tracking-tight text-fg">
+    우리집 가계부 시작하기
+  </CardTitle>
+  <CardDescription className="text-fg-muted">
+    가족 가계부를 만들어 보세요
+  </CardDescription>
+</CardHeader>
+```
+
+기존 `text-primary` (line 70 `<CardTitle className="text-2xl font-bold text-primary">`) → `text-fg`. brand 강조는 상단 아이콘 채널이 담당.
+
+### 3. 가계부 타입 segmented 토글 (plan003 패턴 재사용)
+
+현재 `personal` vs `family` 선택 UI 점검 후 plan003 의 `SegmentedToggle` 또는 동일 패턴 적용 (plan006 가 SegmentedToggle generic 추출 가능성 — 점검).
+
+```bash
+# SegmentedToggle generic helper 위치
+grep -rn 'SegmentedToggle\|segmented-toggle' src/components/ui/ src/components/ 2>/dev/null
+```
+
+없으면 inline 구현 (handoff 패턴 그대로):
+```tsx
+<div className="flex gap-1 bg-bg-muted p-1 rounded-md">
+  <button
+    type="button"
+    onClick={() => setFamilyType("family")}
+    className={cn(
+      "flex-1 py-2 px-3 rounded text-sm font-semibold transition",
+      familyType === "family" ? "bg-bg-elev text-fg shadow-subtle" : "text-fg-muted"
+    )}
+  >
+    가족
+  </button>
+  <button ... >개인</button>
+</div>
+```
+
+### 4. 안내 박스 토큰 교체
+
+기존 (line 147~153):
+```tsx
+<div className="mt-6 p-4 bg-blue-50 rounded-lg">
+  <h4 className="font-medium text-sm text-blue-900 mb-2">...</h4>
+  <p className="text-xs text-blue-700">...</p>
+</div>
+```
+
+신규 — brand-50/700 톤으로 안내:
+```tsx
+<div className="mt-6 p-4 bg-brand-50 rounded-md border border-brand-100">
+  <h4 className="font-semibold text-sm text-brand-700 mb-1">...</h4>
+  <p className="text-xs text-brand-700/80">...</p>
+</div>
+```
+
+`brand-100` 등록 — plan001 `@theme` 에 이미 있음 (brand 50~900 전 스케일).
+
+### 5. 저장 버튼 brand 토큰
+
+기존 (확인 필요 — 본 phase 시작 시 점검):
+```bash
+grep -n 'gradient-primary\|bg-primary\|bg-blue-' src/app/\(authenticated\)/families/create/page.tsx
+```
+
+저장 버튼: `bg-brand-500 hover:bg-brand-600 text-white w-full` 토큰.
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/010-domain-pages-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# glass-card / app-background 잔재 0 (본 페이지 한정)
+! grep -nE 'glass-card|app-background' src/app/\(authenticated\)/families/create/page.tsx
+
+# 하드코딩 색 잔재 0
+! grep -nE 'bg-blue-|text-blue-|text-primary' src/app/\(authenticated\)/families/create/page.tsx
+
+# gradient-family + brand 토큰
+grep -nE 'gradient-family|bg-brand-500|bg-brand-50|text-brand-' src/app/\(authenticated\)/families/create/page.tsx | wc -l   # >= 3
+```
+
+수동 smoke: 새 가입 사용자 시뮬레이션 → `/families/create` → 상단 gradient-family 원형 + brand 톤 카드 + 가족/개인 segmented + 안내 박스 brand-50 톤. 저장 → /dashboard 진입.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/families/create/page.tsx` | 배경 + 카드 + 아이콘 + 안내 + 저장 버튼 토큰 |
+| `src/app/globals.css` | `app-background` / `glass-card` 클래스 — 다른 페이지에서 사용처 0 이면 제거 (작업항목 1 점검) |
+
+## Out of Scope
+
+- 가족 초대 (invite) 페이지 디자인 — handoff Screen 외, 별도 plan
+- 가입 흐름 신규 ("가족 코드 입력" 등) — 도메인 변경 필요
+- 다국어 — 본 plan 한국어만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `app-background` 가 다른 페이지에서 사용 중 | grep 결과로 식별. 사용처 있으면 본 페이지 className 만 교체 — globals.css 정의는 유지 |
+| `gradient-family` 그라디언트 색이 dark mode 에서 대비 약함 | plan001 의 gradient-family 정의 (brand 300→500) 가 dark/light 동일 hue — 명도 자동. 시각 점검 |
+| segmented toggle helper 가 plan006 에서 추출 안 됐을 경우 inline | 인라인으로 단순. helper 재사용은 후속 plan |

--- a/tasks/plan010-domain-pages-redesign/phase-05.md
+++ b/tasks/plan010-domain-pages-redesign/phase-05.md
@@ -1,0 +1,112 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase 01~04 산출물 통합 검증, 4 페이지 + 카테고리 다이얼로그 의 하드코딩 색 잔재 0건 증명, `index.json` status `completed` 마킹.
+
+## Context (자기완결)
+
+- 검증 대상: Settings (1) + Categories list/dialog stale fix (2) + FamiliesSelect (3) + FamiliesCreate (4).
+- legacy 잔재 후보: `text-gray-*`, `hover:bg-gray-*`, `bg-blue-*`, `text-blue-*`, `border-blue-*`, `glass-card`, `app-background` (본 페이지 외 사용처 0 시 globals.css 정리).
+- `_shared/common-pitfalls.md § 1-8` 준수 — 마지막 phase 본인 status 도 직접 갱신.
+
+## 작업 항목
+
+### 1. 빌드 / lint / type / test 통과
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/010-domain-pages-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test --run
+```
+
+각 exit 0. 실패 시 `PHASE_BLOCKED: build failed` + 어느 phase 가 회귀를 만들었는지 식별.
+
+### 2. 4 페이지 하드코딩 색 잔재 0건
+
+```bash
+# Settings / Categories / Families 의 하드코딩 잔재
+! grep -rnE 'text-gray-[3-9]|hover:bg-gray-[5-9]|bg-gray-[3-9]|text-blue-[3-9]|bg-blue-[3-9]|border-blue-' \
+  src/app/\(authenticated\)/settings/ \
+  src/app/\(authenticated\)/categories/ \
+  src/app/\(authenticated\)/families/ \
+  src/components/families/
+```
+
+`!` 가 exit 1 — 잔재 0 확인.
+
+### 3. 핵심 신 토큰 등록 확인
+
+```bash
+# SettingsCard helper
+test -f src/components/layout/SettingsCard.tsx
+
+# Settings 페이지의 신 토큰
+grep -nE 'text-fg|text-fg-muted|bg-brand-50|md:grid-cols-2' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 4
+
+# Category dialog stale fix 패턴 (open ? <Body /> 분리)
+grep -n 'CategoryDialogBody' src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx | wc -l   # >= 1
+grep -n 'CategoryDialogBody' src/app/\(authenticated\)/categories/_components/EditCategoryDialog.tsx | wc -l   # >= 1
+
+# 색 팔레트 OKLCH 8개
+grep -cE 'oklch\([0-9.]+ [0-9.]+ [0-9]+\)' \
+  src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx   # >= 8
+
+# FamilySelector 멤버 avatar 겹침
+grep -n '\-ml-2.*ring-' src/components/families/FamilySelector.tsx | wc -l   # >= 1
+
+# FamiliesCreate gradient-family + brand 토큰
+grep -nE 'gradient-family|bg-brand-500|bg-brand-50' \
+  src/app/\(authenticated\)/families/create/page.tsx | wc -l   # >= 3
+```
+
+### 4. glass-card / app-background 사용처 점검
+
+phase-04 에서 결정한 `app-background` / `glass-card` 클래스의 다른 페이지 사용 여부:
+
+```bash
+grep -rn 'app-background\|glass-card' src/ 2>/dev/null
+```
+
+- 본 plan 의 `families/create/page.tsx` 외 사용처 0 → globals.css 에서 두 클래스 정의 제거 (phase-04 작업항목 1 의 후속)
+- 사용처 있으면 본 plan 안에서 정의 유지, 별도 plan 으로 처리
+
+### 5. `index.json` + 본 phase status → `completed`
+
+```bash
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan010-domain-pages-redesign/index.json
+sed -i '' 's/"status": "in_progress"/"status": "completed"/g' tasks/plan010-domain-pages-redesign/index.json
+grep -c '"status": "completed"' tasks/plan010-domain-pages-redesign/index.json   # = 6 (top + 5 phases)
+
+sed -i '' 's/^\*\*Status\*\*: pending$/**Status**: completed/' tasks/plan010-domain-pages-redesign/phase-05.md
+grep '^\*\*Status\*\*:' tasks/plan010-domain-pages-redesign/phase-05.md   # = "**Status**: completed"
+```
+
+이 phase 의 모든 산출물 (status 변경 + 검증 grep 출력 + globals.css 정리 결정) 은 단일 commit 으로 묶음.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan010-domain-pages-redesign/index.json` | 모든 status `completed` |
+| `tasks/plan010-domain-pages-redesign/phase-05.md` | 본 파일 status `completed` |
+| `src/app/globals.css` | `app-background` / `glass-card` 정의 정리 (사용처 0 일 때) |
+
+## Out of Scope
+
+- /invite 페이지 디자인 — 별도 plan
+- Settings 의 신규 섹션 (프로필 / 로그아웃) — handoff 외
+- backend `category.color` schema 점검 결과에 따른 마이그레이션 — plan011+
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 검증 grep false positive (주석 내 문자열) | 라인 시작 앵커 + 정확한 토큰 |
+| macOS BSD `sed -i ''` vs Linux | macOS 환경 가정 |
+| globals.css 정리 시 다른 페이지 시각 회귀 | 작업항목 4 의 grep 결과 0 확인 후에만 제거. 의심 시 정의 유지 |


### PR DESCRIPTION
## Summary

handoff bundle 의 Screens 5~8 (Settings / Categories / FamiliesSelect / FamiliesCreate) 적용 plan. 도메인 외곽 페이지들의 plan001~009 토큰 일관 적용 + Add/Edit Category Dialog 의 stale state fix 동시 처리.

## 사용자 결정 (confirmed)

| 영역 | 결정 |
|---|---|
| Settings 카드 구조 | 현 3 카드 유지 + 토큰 교체만 |
| Category 색 팔레트 (8 hex) | plan002 톤 fg 8개 (food/cafe/transit/telecom/home/shopping/health/leisure) OKLCH 매핑 |
| FamilySelector 행 | 카드 행 유지 + plan002 멤버 avatar 겹침 패턴 재사용 |
| FamiliesCreate glass-card | 폐기 + bg-bg-elev card + gradient-family 채널만 상단 |
| Dialog stale state | plan010 안에 포함 (Add/Edit Category Dialog 적용) |

## Phase 구조 (5 phase)

| # | 영역 | 모델 |
|---|---|---|
| 01 | Settings — SettingsCard helper + 3 카드 | sonnet |
| 02 | Categories — list + Dialog stale fix + 팔레트 매핑 | sonnet |
| 03 | FamiliesSelect — 카드 행 + 멤버 avatar | sonnet |
| 04 | FamiliesCreate — glass 제거 + gradient-family | sonnet |
| 05 | 통합 검증 + completed | haiku |

## handoff bundle

\`/tmp/handoff_plan010/fos-accountbook/project/screens/{mobile,desktop}-extra.jsx\` — Screens 5~8 (총 16 아트보드).

## 의존성

- plan001 머지 ✅ (OKLCH/Pretendard/data-theme)
- plan002 머지 ✅ (--color-cat-* 22 토큰 + window.tokens.color.category)
- PR #233 fix(dialogs) 권장 머지 (Add/Edit Category Dialog 에 동일 패턴 적용)

## 다음 단계

\`/build-with-teams plan010-domain-pages-redesign\` 호출 시 같은 브랜치에서 phase 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)