### PR TITLE
feat(deps): TypeScript 5.9 → 6.0 major migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ next-env.d.ts
 .omc
 
 .claude/worktrees/
+
+# build-with-teams phase 산출물 (tsc 에러 dump 등)
+.scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Claude Code가 항상 따라야 할 규칙과 참조 문서 포인터.
 
 ## 기술 스택
 
-Next.js 16 (App Router) · TypeScript 5 (strict) · Tailwind CSS v4 · Radix UI + Shadcn · NextAuth v5 · pnpm 10 · Jest + Testing Library
+Next.js 16 (App Router) · TypeScript 6 (strict) · Tailwind CSS v4 · Radix UI + Shadcn · NextAuth v5 · pnpm 10 · Jest + Testing Library
 
 ---
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -312,8 +312,13 @@
   - ts5 stick: 보안/유지보수 + 신 inference 혜택 미수용. peer dep 호환 점진 분리 위험.
   - Dependabot PR #179 그대로 머지: tsc 에러 무대응으로 빌드 회귀.
 - **트레이드오프**: 메이저 dep bump 의 첫 번째 적용. 발견 에러를 단순 fix 로 처리 못 하는 케이스 (예: inference 변경으로 라이브러리 측 타입 깨짐) 는 별도 plan 으로 분리.
-- **breaking 대응 패턴 (실측 후 채움)**:
-  - plan008 phase-01 의 release note fetch + tsc 실측 결과를 본 ADR 본문에 카테고리별 1~2줄로 추가 (lib.d.ts 변경 / inference 변경 / decorator / 기타).
+- **breaking 대응 패턴 (plan008 실측)**:
+  - lib.d.ts 변경: 0건 — `target: ES2017` + `skipLibCheck: true` 조합으로 신규 Temporal/ES2025 type 노출 없음.
+  - inference 변경: 0건 — contextual typing 변화로 인한 에러 미발생.
+  - 신 기본값 (`noUncheckedSideEffectImports: true`): 1건 — `src/app/layout.tsx` 의 `import './globals.css'` TS2882. `src/types/css.d.ts` 에 `declare module '*.css'` 선언으로 fix.
+  - peer dep 충돌: `@typescript-eslint/*` 8.48.1 (`typescript <6.0.0` 제약) → 8.59.2 (`<6.1.0`) 직접 devDep 추가로 fix.
+  - tsconfig.json 변경: 없음 — 기존 `strict: true` / `moduleResolution: bundler` / `module: esnext` 가 ts6 기본값과 일치.
+  - 신 옵션 (`verbatimModuleSyntax` / `noUncheckedIndexedAccess` / `exactOptionalPropertyTypes`): 변경 폭 큼 → plan009 후속 검토로 분리.
   - 향후 ts7+ 이전 시 본 ADR 참조점.
 - **적용 범위**: `package.json`, `tsconfig.json`, src/ 전체 (해당 파일만 fix).
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@typescript-eslint/eslint-plugin": "^8.59.2",
+    "@typescript-eslint/parser": "^8.59.2",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",
     "jest": "^30.4.2",
@@ -71,6 +73,7 @@
     "postcss": "^8.5.14",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.59.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,12 +135,18 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.59.2
+        version: 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.0.7
-        version: 16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.0.7(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@22.19.7)
@@ -149,7 +155,7 @@ importers:
         version: 30.4.1
       msw:
         specifier: ^2.14.5
-        version: 2.14.5(@types/node@22.19.7)(typescript@5.9.3)
+        version: 2.14.5(@types/node@22.19.7)(typescript@6.0.3)
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
@@ -160,8 +166,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^5
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
 
 packages:
 
@@ -465,6 +474,12 @@ packages:
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -1702,63 +1717,63 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@typescript-eslint/eslint-plugin@8.48.1':
-    resolution: {integrity: sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==}
+  '@typescript-eslint/eslint-plugin@8.59.2':
+    resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.48.1
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      '@typescript-eslint/parser': ^8.59.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.48.1':
-    resolution: {integrity: sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==}
+  '@typescript-eslint/parser@8.59.2':
+    resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/project-service@8.48.1':
-    resolution: {integrity: sha512-HQWSicah4s9z2/HifRPQ6b6R7G+SBx64JlFQpgSSHWPKdvCZX57XCbszg/bapbRsOEv42q5tayTYcEFpACcX1w==}
+  '@typescript-eslint/project-service@8.59.2':
+    resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/scope-manager@8.48.1':
-    resolution: {integrity: sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==}
+  '@typescript-eslint/scope-manager@8.59.2':
+    resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/tsconfig-utils@8.48.1':
-    resolution: {integrity: sha512-k0Jhs4CpEffIBm6wPaCXBAD7jxBtrHjrSgtfCjUvPp9AZ78lXKdTR8fxyZO5y4vWNlOvYXRtngSZNSn+H53Jkw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.48.1':
-    resolution: {integrity: sha512-1jEop81a3LrJQLTf/1VfPQdhIY4PlGDBc/i67EVWObrtvcziysbLN3oReexHOM6N3jyXgCrkBsZpqwH0hiDOQg==}
+  '@typescript-eslint/tsconfig-utils@8.59.2':
+    resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.48.1':
-    resolution: {integrity: sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.48.1':
-    resolution: {integrity: sha512-/9wQ4PqaefTK6POVTjJaYS0bynCgzh6ClJHGSBj06XEHjkfylzB+A3qvyaXnErEZSaxhIo4YdyBgq6j4RysxDg==}
+  '@typescript-eslint/type-utils@8.59.2':
+    resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.48.1':
-    resolution: {integrity: sha512-fAnhLrDjiVfey5wwFRwrweyRlCmdz5ZxXz2G/4cLn0YDLjTapmN4gcCsTBR1N2rWnZSDeWpYtgLDsJt+FpmcwA==}
+  '@typescript-eslint/types@8.59.2':
+    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.2':
+    resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.48.1':
-    resolution: {integrity: sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==}
+  '@typescript-eslint/utils@8.59.2':
+    resolution: {integrity: sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -2000,6 +2015,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.10.29:
     resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
     engines: {node: '>=6.0.0'}
@@ -2015,11 +2034,12 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2446,6 +2466,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2660,9 +2684,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   graphql@16.14.0:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
@@ -3310,15 +3331,15 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -4036,8 +4057,8 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -4083,15 +4104,15 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript-eslint@8.48.1:
-    resolution: {integrity: sha512-FbOKN1fqNoXp1hIl5KYpObVrp0mCn+CLgn479nmu2IsRMrx2vyv74MmsBLVlhg8qVwNFGbXSp8fh1zp8pEoC2A==}
+  typescript-eslint@8.59.2:
+    resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4619,6 +4640,11 @@ snapshots:
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.7.0))':
+    dependencies:
+      eslint: 9.39.2(jiti@2.7.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
@@ -5896,97 +5922,96 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/type-utils': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.48.1
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
       eslint: 9.39.2(jiti@2.7.0)
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.48.1
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.48.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.2
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.48.1':
+  '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
 
-  '@typescript-eslint/tsconfig-utils@8.48.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.48.1': {}
+  '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/typescript-estree@8.48.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/visitor-keys': 8.48.1
+      '@typescript-eslint/project-service': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
+      minimatch: 10.2.5
+      semver: 7.8.0
       tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.48.1
-      '@typescript-eslint/types': 8.48.1
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.48.1':
+  '@typescript-eslint/visitor-keys@8.59.2':
     dependencies:
-      '@typescript-eslint/types': 8.48.1
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -6234,6 +6259,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.10.29: {}
 
   baseline-browser-mapping@2.8.8: {}
@@ -6248,13 +6275,13 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6616,20 +6643,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.0.7(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 16.0.7
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.7.0))
       globals: 16.4.0
-      typescript-eslint: 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      typescript-eslint: 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
@@ -6655,22 +6682,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6681,7 +6708,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6693,7 +6720,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -6759,6 +6786,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.2(jiti@2.7.0):
     dependencies:
@@ -7021,8 +7050,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   graphql@16.14.0: {}
 
@@ -7850,6 +7877,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -7857,10 +7888,6 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimatch@9.0.9:
     dependencies:
@@ -7872,7 +7899,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.5(@types/node@22.19.7)(typescript@5.9.3):
+  msw@2.14.5(@types/node@22.19.7)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.12(@types/node@22.19.7)
       '@mswjs/interceptors': 0.41.8
@@ -7893,7 +7920,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -8610,9 +8637,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  ts-api-utils@2.1.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -8670,18 +8697,18 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.48.1(@typescript-eslint/parser@8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.48.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.48.1(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,3 @@
+// TypeScript 6.0 noUncheckedSideEffectImports 기본값 true 대응
+// CSS 파일의 side-effect import (import './globals.css') 타입 선언
+declare module "*.css";

--- a/tasks/plan008-typescript-v6/index.json
+++ b/tasks/plan008-typescript-v6/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan008-typescript-v6",
   "description": "TypeScript 5.9 → 6.0 메이저 + @types/node patch. release note fetch + tsc 실측 후 발견 에러 카테고리별 패턴 수정. PR #179 (Dependabot dep bump only) 대체.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
   "total_phases": 5,
   "related_docs": [
@@ -17,35 +17,35 @@
       "file": "phase-01.md",
       "title": "dep 교체 + release note WebFetch + tsc 실측 + 에러 카테고리 분류 + peer dep 점검",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "lib.d.ts / inference 변경으로 인한 에러 일괄 수정",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "peer dep (msw / jest / eslint-config-next / typescript-eslint) 호환 정렬",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "ADR-F19 breaking 대응 패턴 본문 채우기 + tsconfig.json 신 옵션 검토",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 5,
       "file": "phase-05.md",
       "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan008-typescript-v6/phase-01.md
+++ b/tasks/plan008-typescript-v6/phase-01.md
@@ -44,14 +44,15 @@ pnpm add -D typescript@^6 @types/node@^22
 ### 3. 1차 tsc 실측
 
 ```bash
-pnpm tsc --noEmit 2>&1 | tee /tmp/tsc-errors.txt | tail -40
+mkdir -p .scratch   # .gitignore 등록됨, worktree-scoped 산출물 디렉터리
+pnpm tsc --noEmit 2>&1 | tee .scratch/tsc-errors-plan008.txt | tail -40
 ```
 
-에러 line 수 / 파일 수 / 카테고리 식별. `/tmp/tsc-errors.txt` 는 후속 phase 참조용 (PR commit 에는 포함 X).
+에러 line 수 / 파일 수 / 카테고리 식별. `.scratch/tsc-errors-plan008.txt` 는 후속 phase 참조용 (PR commit 에는 포함 X).
 
 ### 4. 에러 카테고리 분류 (phase 2~3 입력)
 
-`/tmp/tsc-errors.txt` 의 에러 메시지를 다음 카테고리로 분류:
+`.scratch/tsc-errors-plan008.txt` 의 에러 메시지를 다음 카테고리로 분류:
 
 - **lib.d.ts 변경**: `Property 'X' does not exist on type 'Array<...>'` 등 표준 라이브러리 type 변화
 - **inference 변경**: `Type 'X' is not assignable to type 'Y'` — 5.9 에서 통과하던 코드가 fail
@@ -72,7 +73,22 @@ pnpm install 2>&1 | grep -iE 'peer|warning' | head -20
 - `msw` 2.14.5 의 d.ts 가 ts6 inference 와 충돌?
 - `jest-environment-jsdom` 30.x 가 ts6 호환?
 
-peer 경고 발견 시 phase-03 (peer 정렬) 의 입력. install 자체 실패면 `PHASE_BLOCKED: peer resolution failed` 출력 후 보고.
+peer 경고 발견 시 phase-03 (peer 정렬) 의 입력.
+
+**peer 매트릭스 사전 채우기 (phase-03 작업 축소용)**:
+
+```bash
+# 각 peer 의 latest peerDependencies 사전 조회 — phase-03 진입 시 "결정 + 적용" 만 남도록
+pnpm view typescript-eslint@latest peerDependencies 2>&1 | head
+pnpm view @typescript-eslint/parser@latest peerDependencies 2>&1 | head
+pnpm view msw@latest peerDependencies 2>&1 | head
+pnpm view jest@latest peerDependencies 2>&1 | head
+pnpm view eslint-config-next@latest peerDependencies 2>&1 | head
+```
+
+결과를 phase-01 commit message 의 **peer 매트릭스 표**로 정리 (현재 버전 / ts6 호환 최소 / 업그레이드 필요 여부 5행). phase-03 은 이 표를 받아 결정 + 적용만 수행.
+
+install 자체 실패면 `PHASE_BLOCKED: peer resolution failed` 출력 후 보고.
 
 ### 6. 자동 verification
 
@@ -81,7 +97,7 @@ peer 경고 발견 시 phase-03 (peer 정렬) 의 입력. install 자체 실패�
 grep '"typescript"' package.json   # = "^6"
 
 # tsc 실측 결과 존재
-test -f /tmp/tsc-errors.txt && wc -l /tmp/tsc-errors.txt
+test -f .scratch/tsc-errors-plan008.txt && wc -l .scratch/tsc-errors-plan008.txt
 
 # phase 1 시점에는 tsc 통과 안 함 — 정상. phase 2~3 에서 해소
 ```
@@ -91,7 +107,7 @@ test -f /tmp/tsc-errors.txt && wc -l /tmp/tsc-errors.txt
 | 파일 | 상태 |
 |---|---|
 | `package.json` / `pnpm-lock.yaml` | dep 교체 |
-| (`/tmp/tsc-errors.txt`) | phase 산출물 — repo 에 commit X |
+| (`.scratch/tsc-errors-plan008.txt`) | phase 산출물 — repo 에 commit X |
 
 ## Out of Scope
 
@@ -104,6 +120,6 @@ test -f /tmp/tsc-errors.txt && wc -l /tmp/tsc-errors.txt
 | 리스크 | 완화 |
 |---|---|
 | WebFetch 가 release blog 차단/형식 변화 | 2차 fallback (GitHub release tag). 모두 실패 시 phase commit message 에 "release note 미수집, ts6 release blog 부재" 명시 + tsc 에러만으로 분류 |
-| tsc 에러 200+ — 단일 phase 처리 부담 | 카테고리별 분할이 phase 2 의 분기 기반. 1000+ 면 plan008 자체 분할 검토 + 보고 |
+| tsc 에러 임계 (phase-02 와 통일) | **50+ 또는 영향 파일 20+ → phase-02 를 02a/02b 분할 (phase-02 risks 참조)**. **1000+ → plan008 자체 분할 + PHASE_BLOCKED 보고**. 50~1000 구간은 단일 phase-02 유지 |
 | peer dep 가 ts6 거부 → install 실패 | install 실패 = PHASE_BLOCKED. msw/jest 업그레이드 의존성 plan 분리 가능성 |
 | @types/node 22.19.18 가 신 type 추가로 별도 에러 | minor patch — 영향 작을 것. tsc 결과에 포함되면 함께 fix |

--- a/tasks/plan008-typescript-v6/phase-02.md
+++ b/tasks/plan008-typescript-v6/phase-02.md
@@ -6,7 +6,7 @@
 
 ## Context (자기완결)
 
-- phase-01 commit message 의 카테고리 분류표 + `/tmp/tsc-errors.txt` (생존 시) 참조.
+- phase-01 commit message 의 카테고리 분류표 + `.scratch/tsc-errors-plan008.txt` (생존 시) 참조.
 - 본 phase 대상: **우리 src/ 코드 수정으로 해결되는 에러**. peer dep 측 에러는 phase-03.
 - 일반적 fix 패턴:
   - `Object is possibly 'null'` → optional chaining `?.` 또는 명시 가드
@@ -22,7 +22,7 @@
 # cwd: /Users/nhn/personal/fos-accountbook
 # branch: plan/008-typescript-v6
 
-pnpm tsc --noEmit 2>&1 | tee /tmp/tsc-errors-v2.txt | tail -40
+pnpm tsc --noEmit 2>&1 | tee .scratch/tsc-errors-plan008-v2.txt | tail -40
 ```
 
 phase-01 의 카테고리 분류표를 본 phase 작업 분할 기준으로 사용.
@@ -70,9 +70,9 @@ ts6 의 신 strict 옵션 (있다면) 가 tsconfig 의 `strict: true` 로 자동
 pnpm tsc --noEmit 2>&1 | tail -20
 # 에러 수가 phase-01 시점 대비 감소 — 단 peer dep 측 에러 (phase-03) 는 남을 수 있음
 
-# any 신규 도입 0건
+# any 신규 도입 0건 (\.test\.(ts|tsx): 양쪽 escape — BRE `?` 리터럴 회피)
 ! grep -rnE ': any\b|<any>|as any\b' src/ \
-  | grep -v ".test.tsx?:" | grep -v "// eslint-disable"
+  | grep -vE '\.test\.(ts|tsx):' | grep -v "// eslint-disable"
 ```
 
 수동 smoke: `pnpm build` → 컴파일 통과 (peer dep 측 잔여 에러 1~5 건 정도 허용). 잔여 에러는 phase-03 에서 해소.
@@ -93,6 +93,6 @@ pnpm tsc --noEmit 2>&1 | tail -20
 
 | 리스크 | 완화 |
 |---|---|
-| 에러 수가 100+ 면 phase 작업 양 초과 (CLAUDE.md "5개 이하" 위반) | phase-01 카테고리표를 5 카테고리 이하로 압축. 그래도 초과면 본 phase 를 phase-02a/02b 분할 + index.json 갱신 보고 |
+| 에러 분할 임계 — 통일 기준 | **에러 50+ 또는 영향 파일 20+ → phase-02 를 02a/02b 강제 분할 + index.json `total_phases` 갱신**. **1000+ → plan008 자체 분할 보고 + PHASE_BLOCKED**. 50~1000 구간은 분할 없이 단일 phase 처리 가능 (작업 항목은 5 카테고리로 압축) |
 | inference 변경 fix 시 `any` 도입 유혹 | grep 으로 검출 + lint 통과 강제. 정 안 되면 `// @ts-expect-error` 한 줄 + 이유 주석 (재발 추적용) |
 | 우리 fix 가 의도치 않은 타입 강화로 호출자 깨짐 | tsc + jest --run 으로 회귀 1차 검출. PR 검증 단계에서 추가 점검 |

--- a/tasks/plan008-typescript-v6/phase-04.md
+++ b/tasks/plan008-typescript-v6/phase-04.md
@@ -7,11 +7,11 @@
 ## Context (자기완결)
 
 - ADR-F19 는 본 plan 시작 시 작성됐으나 "breaking 대응 패턴" 본문이 placeholder — phase 1 의 카테고리 분류표 + phase 2~3 의 fix 적용 패턴을 1~2줄씩 기록.
-- ts6 신 옵션 후보 (가치 검토):
-  - `verbatimModuleSyntax` 강화
-  - `noUncheckedIndexedAccess` (기존 5.x 도 있지만 6.0 기본값 변경 검토)
-  - `exactOptionalPropertyTypes` 강화
-  - 신 module 옵션 (`module: "preserve"` 등)
+- tsconfig 옵션 ts6 컨텍스트 재검토 (기존 5.x 부터 존재하는 옵션이지만 ts6 기본값/권장값이 바뀐 가능성 점검):
+  - `verbatimModuleSyntax` (ts5 부터 존재 — ts6 권장값 재검토)
+  - `noUncheckedIndexedAccess` (ts5 부터 존재 — ts6 기본값/적용 효과 재검토)
+  - `exactOptionalPropertyTypes` (ts5 부터 존재 — ts6 기본값 재검토)
+  - 신 module 옵션 (`module: "preserve"` 등, ts5.4 부터 존재)
 - 본 phase 는 신 옵션 **도입 자체는 안 함** — 검토 결과만 ADR 또는 후속 plan 메모.
 
 ## 작업 항목

--- a/tasks/plan008-typescript-v6/phase-05.md
+++ b/tasks/plan008-typescript-v6/phase-05.md
@@ -41,7 +41,7 @@ grep -E 'typescript@6\.' pnpm-lock.yaml | head -3   # 6.x 버전 lock 됨
 ! grep -E '"typescript":\s*"\^5' package.json
 
 # 우리 코드의 ts5 회피 패턴 — 본 plan 신규 도입 0건
-NEW_ANY=$(git diff origin/main -- 'src/**/*.ts' 'src/**/*.tsx' | grep -E '^\+.*\bas any\b|^\+.*: any\b' | grep -v ".test.")
+NEW_ANY=$(git diff origin/main -- 'src/**/*.ts' 'src/**/*.tsx' | grep -E '^\+.*\bas any\b|^\+.*: any\b' | grep -vE '\.test\.(ts|tsx):')
 if [ -n "$NEW_ANY" ]; then
   echo "⚠️ 본 plan 에서 신규 도입된 any 사용:"
   echo "$NEW_ANY"
@@ -55,8 +55,8 @@ git diff origin/main | grep -E '^\+.*@ts-ignore|^\+.*@ts-expect-error' | head
 ### 4. ADR-F19 본문 갱신 확인 (phase 04 산출물)
 
 ```bash
-# placeholder 항목 사라짐
-! grep -nE 'phase-01.*실측 결과를.*카테고리별 1~2줄로 기록\|breaking 대응 패턴.*실측 후 채움' docs/adr.md
+# placeholder 항목 사라짐 (-E ERE 모드: alternation 은 `|` 그대로, `\|` 는 리터럴이라 매치 안 됨)
+! grep -nE 'phase-01.*실측 결과를.*카테고리별 1~2줄로 기록|breaking 대응 패턴.*실측 후 채움' docs/adr.md
 
 # 실측 카테고리 항목 채워짐
 grep -E 'lib\.d\.ts 변경:|inference 변경:|peer dep 충돌:' docs/adr.md | wc -l   # >= 3

--- a/tasks/plan008-typescript-v6/phase-05.md
+++ b/tasks/plan008-typescript-v6/phase-05.md
@@ -1,7 +1,7 @@
 # Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
 
 **Model**: haiku
-**Status**: pending
+**Status**: completed
 **Goal**: phase 01~04 산출물 통합 검증, typescript 5.x 잔재 0건 증명, `index.json` status `completed` 마킹.
 
 ## Context (자기완결)


### PR DESCRIPTION
## Summary

ADR-F19 결정 반영. TypeScript `^5` (5.9.3) → `^6` (6.0.3) 메이저 + `@typescript-eslint/*` 8.59.2 호환 정렬.

PR #179 (Dependabot typescript group bump only) 대체. `Closes #179`.

## 변경 사항

### dep 교체
- `typescript@^5` → `^6.0.3`
- `@typescript-eslint/eslint-plugin@^8.59.2` (신규 devDep)
- `@typescript-eslint/parser@^8.59.2` (신규 devDep)
- `typescript-eslint@^8.59.2` (신규 devDep)

### 코드
- `src/types/css.d.ts` (신규): `declare module "*.css"` — TS 6.0 의 `noUncheckedSideEffectImports` 기본값 변경 (`false` → `true`) 대응. `src/app/layout.tsx` 의 `import "./globals.css"` 가 TS2882 가 되는 문제를 declare module 추가로 해소 (tsconfig.json 변경 없이).

### docs
- `CLAUDE.md`: 기술 스택 `TypeScript 5` → `TypeScript 6`
- `docs/adr.md` ADR-F19: breaking 대응 패턴 placeholder 를 실측 데이터로 교체

## TS 6.0 영향 실측 결과

| 카테고리 | 건수 | 비고 |
|---|---|---|
| lib.d.ts 변경 | 0 | `target: ES2017` + `skipLibCheck: true` 영향 최소 |
| inference 변경 | 0 | |
| 신 기본값 (`noUncheckedSideEffectImports`) | 1 | `declare module "*.css"` 로 해소 |
| peer dep 충돌 | 1 | `@typescript-eslint/*` 8.48.1 → 8.59.2 |
| tsconfig.json 변경 | 없음 | 기존 설정이 ts6 기본값과 일치 |

신 옵션 도입 (`verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`) 은 본 plan OOS — plan009 후속.

## Test plan

- [x] `pnpm tsc --noEmit`: 0 errors
- [x] `pnpm lint`: 통과
- [x] `pnpm test`: 211 passed
- [x] `pnpm build`: 통과 (.env 설정 시)
- [x] v5 잔재 grep 0건 (`"typescript": "^5"` 제거)
- [x] 신규 `any` / `@ts-ignore` 도입 0건

## 검증 게이트 (build-with-teams)

- critic: APPROVE (REVISE 1회 — grep escape 버그 + /tmp 충돌 + 임계 통일 등 6개 지적 반영)
- code-reviewer: PASS (블로킹 0건)
- docs-verifier: PASS (ADR-F19 준수 + dead reference 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)