### PR TITLE
feat(layout): BottomNavigation Teal 리디자인 (plan009)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,7 +55,7 @@
   --shadow-popover: 0 8px 24px -8px rgb(15 23 42 / 0.12), 0 2px 6px -2px rgb(15 23 42 / 0.06);
   --shadow-modal:   0 24px 48px -16px rgb(15 23 42 / 0.18), 0 8px 16px -8px rgb(15 23 42 / 0.10);
   --shadow-fab:     0 6px 20px -4px oklch(0.640 0.140 188 / 0.45),
-                    0 2px 6px -2px rgb(0 0 0 / 0.12);
+                    0 2px 6px -2px rgb(15 23 42 / 0.10);
 
   /* ── font (mono only — sans/num from next/font) ─ */
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,8 @@
   --shadow-default: 0 2px 8px -2px rgb(15 23 42 / 0.06), 0 1px 3px -1px rgb(15 23 42 / 0.04);
   --shadow-popover: 0 8px 24px -8px rgb(15 23 42 / 0.12), 0 2px 6px -2px rgb(15 23 42 / 0.06);
   --shadow-modal:   0 24px 48px -16px rgb(15 23 42 / 0.18), 0 8px 16px -8px rgb(15 23 42 / 0.10);
+  --shadow-fab:     0 6px 20px -4px oklch(0.640 0.140 188 / 0.45),
+                    0 2px 6px -2px rgb(0 0 0 / 0.12);
 
   /* ── font (mono only — sans/num from next/font) ─ */
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;

--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -15,18 +15,31 @@ interface NavButtonProps {
   onClick: () => void;
 }
 
+function FAB({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="지출 추가"
+      className="absolute bottom-[28px] left-1/2 -translate-x-1/2 w-14 h-14 rounded-full bg-brand-500 text-white border-4 border-bg-elev shadow-[var(--shadow-fab)] flex items-center justify-center transition-all hover:bg-brand-600"
+    >
+      <Plus className="w-6 h-6" strokeWidth={2.4} />
+    </button>
+  );
+}
+
 function NavButton({ icon: Icon, label, isActive, onClick }: NavButtonProps) {
   return (
     <Button
       variant="ghost"
       className={cn(
         "flex flex-col items-center space-y-0.5 md:space-y-1 h-auto py-1.5 md:py-2",
-        isActive ? "text-blue-600" : "text-gray-500"
+        isActive ? "text-brand-600" : "text-fg-subtle"
       )}
       onClick={onClick}
     >
-      <Icon className="w-4.5 h-4.5 md:w-5 md:h-5" />
-      <span className={cn("text-[10px] md:text-xs", isActive && "font-medium")}>
+      <Icon className="w-4.5 h-4.5 md:w-5 md:h-5" strokeWidth={isActive ? 2 : 1.6} />
+      <span className={cn("text-[10px] md:text-xs", isActive && "font-semibold")}>
         {label}
       </span>
     </Button>
@@ -46,8 +59,8 @@ export function BottomNavigation() {
 
   return (
     <>
-      <div className="fixed bottom-0 left-0 right-0 z-50 bg-white/90 backdrop-blur-xl border-t border-gray-200/50 safe-area-pb">
-        <div className="max-w-7xl mx-auto px-2 md:px-4">
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-bg-elev/95 backdrop-blur-xl border-t border-border safe-area-pb">
+        <div className="relative max-w-7xl mx-auto px-2 md:px-4">
           <div className="flex justify-around items-center h-14 md:h-16">
             {/* 홈 */}
             <NavButton
@@ -65,15 +78,8 @@ export function BottomNavigation() {
               onClick={() => router.push("/transactions?tab=expenses")}
             />
 
-            {/* 지출 추가 */}
-            <div className="relative -mt-4 md:-mt-6">
-              <Button
-                className="w-12 h-12 md:w-14 md:h-14 rounded-xl md:rounded-2xl gradient-primary hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-200"
-                onClick={() => setIsExpenseDialogOpen(true)}
-              >
-                <Plus className="w-5 h-5 md:w-6 md:h-6 text-white" />
-              </Button>
-            </div>
+            {/* center slot — FAB 위치 확보 */}
+            <div className="flex-1" />
 
             {/* 분석 */}
             <NavButton
@@ -91,6 +97,7 @@ export function BottomNavigation() {
               onClick={() => router.push("/settings")}
             />
           </div>
+          <FAB onClick={() => setIsExpenseDialogOpen(true)} />
         </div>
       </div>
 

--- a/tasks/plan009-bottom-navigation-redesign/index.json
+++ b/tasks/plan009-bottom-navigation-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan009-bottom-navigation-redesign",
   "description": "BottomNavigation Teal fintech 리디자인 — handoff MobileShell TabBar (5 메뉴: 홈/내역/추가/분석/설정) + FAB (brand-500 + white ring + custom shadow) 적용. 현 blue-600 → brand-600 토큰 + 활성 상태 sw=2.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
   "total_phases": 3,
   "related_docs": [
@@ -22,21 +22,21 @@
       "file": "phase-01.md",
       "title": "BottomNavigation TabBar 디자인 — brand 토큰 + 활성 sw 강화 + 5 메뉴 일관",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "FAB 신 디자인 — brand-500 단색 + 4px white ring + custom shadow + 위치 정밀화",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan009-bottom-navigation-redesign/phase-01.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-01.md
@@ -1,7 +1,7 @@
 # Phase 01 — TabBar 디자인 갱신 (brand 토큰 + 활성 sw 강화)
 
 **Model**: sonnet
-**Status**: pending
+**Status**: completed
 **Goal**: BottomNavigation 의 5 탭 (홈/내역/추가/분석/설정) 시각을 handoff MobileShell TabBar 패턴에 맞춰 갱신. blue-600 하드코딩 → brand-600 토큰, 활성 상태 typography 강화.
 
 ## Context (자기완결)

--- a/tasks/plan009-bottom-navigation-redesign/phase-02.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-02.md
@@ -1,7 +1,7 @@
 # Phase 02 — FAB 신 디자인 (brand 단색 + white ring + custom shadow)
 
 **Model**: sonnet
-**Status**: pending
+**Status**: completed
 **Goal**: 현 BottomNavigation 의 FAB 를 handoff `<FAB />` 디자인으로 교체 — `gradient-primary` 단색 → `bg-brand-500` + 4px white ring + Teal-toned soft shadow.
 
 ## Context (자기완결)

--- a/tasks/plan009-bottom-navigation-redesign/phase-03.md
+++ b/tasks/plan009-bottom-navigation-redesign/phase-03.md
@@ -1,7 +1,7 @@
 # Phase 03 — 통합 검증 + legacy 잔재 grep + completed 마킹
 
 **Model**: haiku
-**Status**: pending
+**Status**: completed
 **Goal**: phase 01~02 산출물 통합 검증, hardcoded 색 잔재 0건 증명, `index.json` status `completed` 마킹.
 
 ## Context (자기완결)


### PR DESCRIPTION
## Summary

handoff MobileShell TabBar + FAB 패턴을 BottomNavigation 에 적용한 Teal 리디자인. (plan009)

- **TabBar**: 하드코딩 색 → brand·surface 토큰 (text-brand-600 / text-fg-subtle / bg-bg-elev / border-border) + 활성 강조 (font-semibold + strokeWidth 2)
- **FAB**: 별도 컴포넌트 추출 + 신 디자인 (bg-brand-500 단색 + rounded-full + 4px white ring + Teal-toned soft shadow)
- **globals.css**: `--shadow-fab` 토큰 추가 (brand-tone alpha shadow)

## Phase

- phase-01 — TabBar 토큰 교체 + 활성 강조 (NavButton)
- phase-02 — FAB 신 디자인 + `--shadow-fab` 토큰 추가
- phase-03 — 통합 grep 검증 + status completed 마킹

## Verification

- `pnpm lint` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm test` 211/211 ✅
- `pnpm build` ✅ (NextAuth env 가정)
- 하드코딩 색 잔재 0건 (text-blue-600 / text-gray-500 / gradient-primary / bg-white\/ / border-gray-)
- brand·surface 토큰 적용 확인
- AddExpenseDialog 진입점 보존

## Review

- critic — APPROVE
- code-reviewer — PASS (금지사항 0건, 시맨틱 토큰 일관)
- docs-verifier — PASS (ADR-F07/F13/F15 위반 없음, docs stale 0건)

## Test plan

- [ ] 모바일 viewport: 활성 탭 brand-600 + icon 두꺼움
- [ ] FAB: Teal 단색 + 4px white ring + soft shadow + TabBar 위에 떠 있음
- [ ] FAB 클릭 → AddExpenseDialog Sheet (모바일) / Dialog (데스크톱)
- [ ] Light ↔ Dark 토글: surface 토큰 자동 전환, FAB ring 자연스러움

🤖 Generated with [Claude Code](https://claude.com/claude-code)