### PR TITLE
docs(plan011): Landing 페이지 신규 + Auth signin/signout/error 리디자인 task

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -322,3 +322,13 @@
   - 향후 ts7+ 이전 시 본 ADR 참조점.
 - **적용 범위**: `package.json`, `tsconfig.json`, src/ 전체 (해당 파일만 fix).
 
+## ADR-F20: 인증 안 한 사용자의 `/` 진입은 Landing 표시 (2026-05-11)
+
+- **결정**: `/` 라우트를 public 으로 변경. 인증 안 한 사용자는 Landing (Hero + Features 3 + CTA), 인증 사용자는 `/dashboard` 자동 redirect. middleware 의 public matcher 에 `/` 추가, `src/app/page.tsx` 가 page-level 에서 session 분기.
+- **맥락**: 기존 동작은 인증 안 한 모든 진입 = `/auth/signin` 강제 redirect. login 페이지가 사실상 첫 화면이라 "어떤 서비스인지" 가 부재 — 신규 사용자가 가입 가치를 판단할 정보 없음. 부부 가계부 라는 도메인 특성상 가치 제안 (가족·카테고리·분석) 을 먼저 보여줄 entry 가 필요.
+- **대안 기각**:
+  - `/auth/signin` 만 운영하고 그 안에 가치 제안 카피 추가: signin 페이지가 비대해지고 (form + marketing 혼재) 분석/추적 단위가 모호.
+  - 별도 `/landing` 라우트 + `/` 는 그대로 redirect: URL 두 개로 분기되어 marketing 전환 추적 + SEO root domain 가치 분산.
+- **트레이드오프**: protected route 직접 URL 진입 (예: `/dashboard` 의 deep link 공유) 시 Landing 으로 한 단계 더 거쳐야 함. `(authenticated)/layout.tsx` 의 unauth redirect 대상도 Landing 으로 통일.
+- **적용 범위**: `src/middleware.ts`, `src/app/page.tsx`, `src/app/(authenticated)/layout.tsx`.
+

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -3,16 +3,17 @@
 ## 1. 최초 사용자 온보딩
 
 ```
-[앱 접속]
+[앱 접속 = /]
     │
     ▼
-세션 확인
+세션 확인 (src/app/page.tsx)
     │
-    ├─ 미로그인 → /auth/signin
-    │               └─ Google / Naver OAuth 선택
-    │                       └─ NextAuth 처리 → JWT 발급 → /
+    ├─ 미로그인 → / (Landing 표시: Hero + Features 3 + CTA)
+    │               └─ CTA "지금 시작하기" → /auth/signin
+    │                       └─ Google / Naver OAuth 선택
+    │                               └─ NextAuth 처리 → JWT 발급 → /
     │
-    └─ 로그인됨 → defaultFamilyUuid 확인
+    └─ 로그인됨 → /dashboard redirect → defaultFamilyUuid 확인
                     │
                     ├─ 없음 → /families/create
                     │           └─ 가족 이름 + 월 예산 입력

--- a/tasks/plan011-landing-auth-redesign/index.json
+++ b/tasks/plan011-landing-auth-redesign/index.json
@@ -1,0 +1,58 @@
+{
+  "name": "plan011-landing-auth-redesign",
+  "description": "Landing (/) 신규 + Auth signin/signout/error 리디자인. handoff Screens 9~12. 로그인 전 첫 진입 경로 완성 + welcoming Teal 톤 + 소셜 로그인 (Google/Naver) 시각 일관.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/code-architecture.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign",
+    "plan006-analytics-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH/Pretendard/data-theme) ✅",
+    "plan002 머지 (CoupleAvatars / Donut 패턴 — Landing Features card 재사용) ✅",
+    "plan006 머지 (MonthlyTrendBar — Landing Features card 재사용) ✅",
+    "handoff: /tmp/handoff_plan011/fos-accountbook/project/screens/{mobile,desktop}-landing-auth.jsx Screens 9~12"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "Landing 페이지 (/) 신규 — Hero + Features 3 (가족/카테고리/분석) + CTA + footer",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "SignIn 페이지 리디자인 — bg-bg-elev card + 소셜 버튼 + brand 강조",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "SignOut + AuthError 페이지 리디자인 — 동일 카드 패턴",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "auth layout + 라우팅 점검 — / 가 로그인 안 한 사용자에게 Landing 표시 (인증 사용자는 /dashboard redirect)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan011-landing-auth-redesign/phase-01.md
+++ b/tasks/plan011-landing-auth-redesign/phase-01.md
@@ -1,0 +1,130 @@
+# Phase 01 — Landing 페이지 (/) 신규
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screen 9 (Landing) 신규 구현 — Hero + Features 3 (가족/카테고리/분석) + CTA + footer. login 전 사용자가 처음 보는 첫 진입 화면.
+
+## Context (자기완결)
+
+- 현재 `/` 라우트: `src/app/(authenticated)/page.tsx` → 인증 후 dashboard redirect. 로그인 안 한 사용자가 `/` 접근 시 middleware 가 `/auth/signin` 으로 redirect.
+- handoff 결정: 로그인 안 한 사용자에게 Landing 표시 → CTA "지금 시작하기" 클릭 시 `/auth/signin` 진입.
+- handoff 참조: `/tmp/handoff_plan011/fos-accountbook/project/screens/mobile-landing-auth.jsx` line 73~254 + `desktop-landing-auth.jsx` line 6~283.
+
+## 작업 항목
+
+### 1. `src/app/page.tsx` 신규 (Landing — Server Component)
+
+기존 `src/app/(authenticated)/page.tsx` 는 dashboard redirect — 그대로 보존. 새 `src/app/page.tsx` 가 `/` 의 실제 진입점:
+
+```tsx
+// src/app/page.tsx
+import { auth } from "@/lib/server/auth";
+import { redirect } from "next/navigation";
+import { LandingPage } from "@/components/landing/LandingPage";
+
+export default async function Page() {
+  const session = await auth();
+  if (session?.user) {
+    redirect("/dashboard");
+  }
+  return <LandingPage />;
+}
+```
+
+middleware 의 redirect 우선순위 점검 — `/` 가 인증 안 한 사용자에게 Landing 표시되도록 middleware 처리. 미들웨어가 `/` 을 `/auth/signin` 으로 강제 redirect 하면 본 phase 가 작동 안 함. middleware 의 public route 목록에 `/` 추가.
+
+### 2. `LandingPage` 컴포넌트 (메인 client)
+
+`src/components/landing/LandingPage.tsx` 신규. handoff 구조:
+
+- **Top bar**: 좌측 로고 (28px brand-500 round + "f" + brand-700 텍스트) + 우측 "로그인" 텍스트 링크
+- **Hero**:
+  - Badge: "부부를 위한 가계부" (`bg-bg-elev border-border + brand-500 dot`)
+  - H1: 36~56px font-extrabold tracking-tight `text-fg`
+  - 부제: `text-fg-muted` 15px
+  - 배경 그라디언트: `linear-gradient(180deg, oklch(0.975 0.025 188) 0%, var(--ab-bg) 320px)`
+  - 큰 CTA: "지금 시작하기" → `/auth/signin` 으로 `<Link>` (button 스타일 `bg-brand-500 text-white rounded-md py-3 px-6 font-semibold`)
+- **Features section** (모바일 stack / 데스크톱 3-col grid):
+  - 각 카드는 `FeatureCard` (badge / title / sub) 구조
+  - 1) 가족: `CoupleAvatars` 36px (plan002 재사용) + "부부가 같이 입력해요"
+  - 2) 카테고리: `MiniDonut` 64px (handoff 신규 헬퍼) + "어디에 썼는지 한눈에"
+  - 3) 분석: `MiniBars` 90×44 (handoff 신규) + "추세까지 한 화면에"
+- **CTA section**: "지금 무료로 시작하기" 큰 버튼 + "Google · Naver 로 5초 만에 시작" 카피
+- **Footer**: copyright + 이용약관 / 개인정보처리방침 (text-fg-subtle 11~12px)
+
+### 3. mini 시각 컴포넌트 추출
+
+handoff 의 `MiniDonut` / `MiniBars` 헬퍼는 plan002/006 의 작은 버전. `src/components/landing/MiniStats.tsx` 신규:
+
+```ts
+export function MiniDonut({ size = 64 }: { size?: number }) {
+  // SVG donut — segments brand-500 + brand-300 + brand-100
+}
+export function MiniBars({ w = 90, h = 44 }: { w?: number; h?: number }) {
+  // 7 bars, 마지막만 brand-500 강조
+}
+```
+
+handoff 의 정확한 segment 비율 + bar height array 그대로 복제.
+
+### 4. SEO + metadata
+
+`src/app/page.tsx` 의 metadata export:
+
+```ts
+export const metadata: Metadata = {
+  title: "fos-accountbook — 가족과 함께 쓰는 가계부",
+  description: "부부가 같이 입력하고, 한눈에 보는 가족 가계부",
+  openGraph: { ... },
+};
+```
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/011-landing-auth-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/page.tsx
+test -f src/components/landing/LandingPage.tsx
+test -f src/components/landing/MiniStats.tsx
+
+# Hero CTA → /auth/signin Link
+grep -nE 'href=["\x27]/auth/signin' src/components/landing/LandingPage.tsx | wc -l   # >= 2 (top bar + Hero CTA)
+
+# Features 3 카드
+grep -n 'FeatureCard\|MiniDonut\|MiniBars\|CoupleAvatars' src/components/landing/LandingPage.tsx | wc -l   # >= 4
+
+# 토큰만 사용 (하드코딩 색 0)
+! grep -nE '#[0-9a-fA-F]{6}|text-gray-|bg-blue-' src/components/landing/LandingPage.tsx
+```
+
+수동 smoke: 시크릿 창 + `/` 진입 → Landing 표시. 로그인 시 `/dashboard` redirect. CTA 클릭 → `/auth/signin`.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/page.tsx` | 신규 (인증 안 한 사용자 — Landing 표시) |
+| `src/components/landing/LandingPage.tsx` | 신규 |
+| `src/components/landing/MiniStats.tsx` | 신규 (MiniDonut + MiniBars) |
+| `src/lib/server/middleware.ts` (또는 root middleware.ts) | 수정 — `/` public route 추가 |
+
+## Out of Scope
+
+- Auth signin/signout/error (phase 2~3)
+- 인증 사용자가 `/` 접근 시 dashboard redirect — phase 4 의 라우팅 점검에서 처리
+- Hero 배경 애니메이션 / Lottie — 정적 SVG 만
+- 다국어 — 한국어만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| middleware 의 / public 처리가 next-auth 기본 동작과 충돌 | middleware.ts grep 으로 현재 로직 확인. public matcher 에 `/` 추가 시 다른 protected route 보존 확인 |
+| LandingPage 가 client component 라 SEO 약화 | 메타데이터는 server `page.tsx` 가 export. LandingPage 자체는 인터랙션 (CTA Link) 만 → `"use client"` 없어도 무방. shadcn `<Button>` 도 server 동작 OK |
+| MiniDonut SVG segment 비율이 handoff 와 불일치 | handoff 의 정확한 값 그대로 inline 복제. recharts 사용 안 함 (overkill) |

--- a/tasks/plan011-landing-auth-redesign/phase-02.md
+++ b/tasks/plan011-landing-auth-redesign/phase-02.md
@@ -1,0 +1,116 @@
+# Phase 02 — SignIn 페이지 리디자인
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screen 10 (SignIn) 적용 — `app-background + Card` 패턴 폐기, `bg-bg-elev` 중앙 카드 + 소셜 로그인 (Google/Naver) 시각 일관.
+
+## Context (자기완결)
+
+- 현재: `src/app/auth/signin/page.tsx` — Server Component, `min-h-screen flex items-center justify-center app-background` + Card. 에러 박스 `bg-red-50 border-red-200 text-red-700` 하드코딩.
+- 관련: `src/components/auth/SignInForm.tsx` + `GoogleIcon.tsx` + `NaverIcon.tsx`
+- handoff 참조: `mobile-landing-auth.jsx` line 273~358 + `desktop-landing-auth.jsx` line 304~394
+- plan010 결정: `app-background` / `glass-card` 폐기 — 이 페이지에도 동일 적용
+
+## 작업 항목
+
+### 1. signin page.tsx 배경 + 카드 토큰 교체
+
+```tsx
+// 변경 전
+<div className="min-h-screen flex items-center justify-center app-background p-4">
+  <Card className="w-full max-w-md">
+
+// 변경 후
+<div className="min-h-screen flex items-center justify-center bg-bg p-4">
+  <Card className="w-full max-w-md bg-bg-elev border-border shadow-default">
+```
+
+handoff 패턴: hero 상단 gradient 살짝 (배경 `linear-gradient(180deg, oklch(0.975 0.025 188) 0%, var(--ab-bg) 240px)`) — 사용자 결정 따라 simple `bg-bg` 또는 light gradient.
+
+본 plan 은 simple `bg-bg` 선택 — Landing 이 gradient 강조니 SignIn 은 조용한 카드 진입감.
+
+### 2. 카드 상단 로고 + 제목
+
+기존 `<CardTitle>우리집 가계부</CardTitle>` → handoff 패턴:
+
+- 상단 96px round + `gradient-family` 배경 + Users 아이콘 white (plan010 FamiliesCreate 패턴 재사용)
+- 제목: "우리집 가계부" (24px font-bold tracking-tight text-fg)
+- 부제: "가족과 함께 관리하는 스마트 가계부" (14px text-fg-muted)
+
+### 3. 에러/메시지 박스 토큰 교체
+
+```tsx
+// 변경 전
+<div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+
+// 변경 후
+<div className="bg-expense/10 border border-expense/20 text-expense px-4 py-3 rounded-md">
+```
+
+`bg-expense/10` 처럼 alpha 표기 — Tailwind v4 가 OKLCH 토큰 alpha 변형 지원 (`oklch(... / 0.1)`).
+
+### 4. SignInForm 소셜 버튼 시각 갱신
+
+`src/components/auth/SignInForm.tsx` 현재 구조 점검 후 토큰 교체:
+
+- Google 버튼: `bg-bg border-border text-fg hover:bg-bg-muted` + `<GoogleIcon size={20} />` + "Google 로 시작하기"
+- Naver 버튼: `bg-[#03C75A] text-white hover:opacity-90` + `<NaverIcon size={18} />` + "네이버로 시작하기"
+  - Naver brand 색은 외부 브랜드 가이드라인이라 예외 (ADR-F13 OKLCH 강제의 예외) — 주석 명시
+- 버튼 사이 gap-3, 풀 너비
+
+### 5. 하단 안내 토큰
+
+```tsx
+// 변경 전
+<div className="text-center text-sm text-gray-500">
+
+// 변경 후
+<div className="text-center text-sm text-fg-muted">
+```
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/011-landing-auth-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# 하드코딩 잔재 0 (Naver brand 색 #03C75A 는 예외)
+! grep -nE 'app-background|glass-card|bg-red-50|text-red-700|text-gray-' \
+  src/app/auth/signin/page.tsx \
+  src/components/auth/SignInForm.tsx
+
+# 신 토큰 사용
+grep -nE 'bg-bg-elev|border-border|text-fg-muted|bg-expense/|gradient-family' \
+  src/app/auth/signin/page.tsx \
+  src/components/auth/SignInForm.tsx | wc -l   # >= 3
+
+# Naver 브랜드 색은 예외 명시 주석 있음
+grep -B1 '#03C75A' src/components/auth/SignInForm.tsx | grep -i 'brand\|예외\|exception' | wc -l   # >= 1
+```
+
+수동 smoke: `/auth/signin` → 중앙 카드 + gradient-family 로고 원형 + Google/Naver 버튼. 에러 상태 (URL `?error=foo`) → expense 톤 박스.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/auth/signin/page.tsx` | 배경 + 카드 + 에러 박스 + 안내 토큰 |
+| `src/components/auth/SignInForm.tsx` | 소셜 버튼 시각 갱신 |
+
+## Out of Scope
+
+- SignOut / AuthError 페이지 (phase 3)
+- 소셜 로그인 동작 자체 (NextAuth 콜백 흐름) — UI 만
+- 이메일 로그인 추가 — 현재 소셜만, plan012+ 검토
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `bg-expense/10` 의 alpha 변형이 Tailwind v4 OKLCH 토큰에서 미작동 | plan001 의 `--color-expense` 가 OKLCH 평면 값 — Tailwind v4 가 자동 alpha 변형 지원 확인. 안 되면 inline `style={{ background: "oklch(0.620 0.180 25 / 0.1)" }}` |
+| Naver brand 색 외부 가이드라인 변경 | 주석에 외부 brand color 명시. `oklch` 표기로도 가능하지만 hex 유지 (가이드라인 hex 정확 매치 우선) |
+| gradient-family round 가 plan010 FamiliesCreate 와 시각 중복 | 동일 디자인 의도 — Auth/Family 진입 두 곳 모두 가족 도메인 강조. 일관성 유지 |

--- a/tasks/plan011-landing-auth-redesign/phase-03.md
+++ b/tasks/plan011-landing-auth-redesign/phase-03.md
@@ -1,0 +1,114 @@
+# Phase 03 — SignOut + AuthError 페이지 리디자인
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screens 11~12 적용 — SignOut + AuthError 페이지 시각 갱신. phase 02 의 SignIn 카드 패턴 일관.
+
+## Context (자기완결)
+
+- 현재:
+  - `src/app/auth/signout/page.tsx` — Server Component, 단순 로그아웃 메시지
+  - `src/app/auth/error/page.tsx` — Server Component, NextAuth 에러 메시지
+- handoff 참조:
+  - Screen 11 SignOut: `mobile-landing-auth.jsx` line 361~412 + `desktop-landing-auth.jsx` line 398~445
+  - Screen 12 AuthError: `mobile-landing-auth.jsx` line 414~478 + `desktop-landing-auth.jsx` line 447~488
+- phase 02 의 카드 패턴 (bg-bg-elev / gradient-family round 로고 / center 정렬) 동일 적용.
+
+## 작업 항목
+
+### 1. SignOut 페이지
+
+handoff Screen 11 패턴:
+
+- 배경: `bg-bg`, 중앙 max-w-md 카드
+- 상단: 64px round + `bg-bg-muted` (회색 톤 — 작별 인사) + 손 흔드는 아이콘 또는 LogOut (text-fg-muted)
+- 제목: "로그아웃됐어요" (24px font-bold)
+- 부제: "다시 만날 날을 기다릴게요" (14px text-fg-muted)
+- CTA: "다시 로그인" → `/auth/signin` (`bg-brand-500 text-white w-full`)
+- 보조 링크 (선택): "홈으로" → `/` (text-fg-muted)
+
+### 2. AuthError 페이지
+
+handoff Screen 12 패턴:
+
+- 배경 + 카드 동일
+- 상단: 64px round + `bg-expense/10` (warm coral 톤) + AlertCircle 아이콘 (text-expense)
+- 제목: "문제가 발생했어요" (24px font-bold)
+- 부제: 에러 원인 (NextAuth 의 `error` query param 매핑)
+  - `OAuthAccountNotLinked` → "이미 다른 방법으로 가입된 계정이에요"
+  - `OAuthSignin` / `Callback` → "로그인 중 오류가 발생했어요"
+  - 기타 → "잠시 후 다시 시도해주세요"
+- 디버그 (개발 환경만): 원본 에러 메시지 `text-fg-subtle 11px font-mono`
+- CTA: "다시 시도" → `/auth/signin` (`bg-brand-500`)
+- 보조: "고객 지원" 또는 "홈으로" → `/` (text-fg-muted 링크)
+
+### 3. 공용 helper — `AuthCenterCard`
+
+SignIn / SignOut / AuthError 가 동일 카드 wrapper 패턴 사용 — 공통 helper 추출:
+
+`src/components/auth/AuthCenterCard.tsx`:
+
+```ts
+interface AuthCenterCardProps {
+  iconBg: string;             // "gradient-family" / "bg-bg-muted" / "bg-expense/10"
+  iconColor?: string;         // "text-white" / "text-fg-muted" / "text-expense"
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;  // CTA / form / extras
+}
+```
+
+phase 02 의 SignIn 도 이 helper 사용으로 리팩토링 (phase 02 의 작업항목 추가 — 본 phase 시작 시 점검).
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/011-landing-auth-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/auth/AuthCenterCard.tsx
+
+# 3 페이지에서 helper 사용
+grep -rln 'AuthCenterCard' src/app/auth/ | wc -l   # >= 3 (signin/signout/error)
+
+# 하드코딩 잔재 0
+! grep -rnE 'app-background|glass-card|bg-red-50|text-red-700|text-gray-' \
+  src/app/auth/
+
+# CTA → 적절한 destination
+grep -n 'href=["\x27]/auth/signin' src/app/auth/signout/page.tsx | wc -l   # >= 1
+grep -n 'href=["\x27]/auth/signin' src/app/auth/error/page.tsx | wc -l   # >= 1
+```
+
+수동 smoke:
+- `/auth/signout` → "로그아웃됐어요" 카드 + 다시 로그인 CTA
+- `/auth/error?error=OAuthAccountNotLinked` → "이미 다른 방법으로 가입됐어요" + 다시 시도 CTA
+- 개발 환경 `?error=foo` → 부제 + 원본 에러 디버그 표시
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/auth/AuthCenterCard.tsx` | 신규 |
+| `src/app/auth/signout/page.tsx` | 수정 — AuthCenterCard 사용 |
+| `src/app/auth/error/page.tsx` | 수정 — 동일 + 에러 매핑 |
+| `src/app/auth/signin/page.tsx` | 수정 — phase 02 의 카드를 helper 호출로 리팩토링 |
+
+## Out of Scope
+
+- 에러 매핑 본격화 (전체 NextAuth 에러 코드 목록 매칭) — 본 plan 은 위 명시한 3 케이스 + default 메시지 ("잠시 후 다시 시도해주세요") 만 처리
+- 고객 지원 페이지 / 채널 — 외부 링크 placeholder
+- 자동 redirect (signout 후 N초 후 / 진입) — 즉시 카드 표시 유지
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| AuthCenterCard 가 SignIn 의 form prop 까지 받는 구조라 prop 수 폭증 | children 으로 form 본문 위임. helper 는 wrapper 만 책임 |
+| `bg-expense/10` alpha 변형 — phase 02 와 동일 검증 | 동일 alpha 토큰 패턴. phase 02 검증으로 사전 확인 |
+| signout 페이지가 단순해 helper 도입이 오버엔지니어링 | 3 페이지가 같은 패턴 → 도입 가치 있음. 단 helper 가 20줄 미만이면 inline 도 OK |

--- a/tasks/plan011-landing-auth-redesign/phase-04.md
+++ b/tasks/plan011-landing-auth-redesign/phase-04.md
@@ -1,0 +1,107 @@
+# Phase 04 — auth layout + 라우팅 점검
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 인증 안 한 사용자 = `/` Landing 표시 / 인증 사용자 = `/` 진입 시 `/dashboard` redirect. middleware + page-level auth() 가 일관되게 동작.
+
+## Context (자기완결)
+
+- phase 01 에서 `src/app/page.tsx` 신규 (Landing) — 내부 `auth()` 으로 인증 사용자 redirect 처리
+- 현재 middleware (`src/middleware.ts` 또는 `src/lib/server/middleware.ts`) 가 인증 안 한 사용자를 `/auth/signin` 으로 강제 redirect 한다면, `/` 가 Landing 표시 안 됨 → middleware public matcher 에 `/` 추가 필요
+- `src/app/(authenticated)/` route group 의 layout 이 인증 강제. 그 외 라우트는 middleware 가 게이트
+
+## 작업 항목
+
+### 1. middleware 분석 + 수정
+
+```bash
+grep -rn 'middleware' src/ --include='*.ts' | grep -v node_modules
+```
+
+현재 matcher / public route 목록 확인. handoff 라우팅 정책:
+
+- public (인증 무관): `/`, `/auth/signin`, `/auth/signout`, `/auth/error`
+- protected: 그 외 모두 (`/dashboard`, `/expenses`, `/incomes`, `/analytics`, `/family`, `/settings` 등)
+
+미들웨어가 protected 라우트 진입을 인증 안 한 상태에서 막을 때 `/auth/signin` 으로 redirect 하는 동작은 유지. `/` 만 public 으로 추가.
+
+### 2. `src/app/page.tsx` 인증 분기 (phase 01 에서 이미 구현 — 점검)
+
+```tsx
+const session = await auth();
+if (session?.user) redirect("/dashboard");
+return <LandingPage />;
+```
+
+이 분기는 middleware 와 무관하게 page 자체에서 처리. middleware 가 `/` 를 통과시키고, 인증 사용자는 page 가 `/dashboard` 로 보낸다.
+
+### 3. `(authenticated)` route group layout 점검
+
+`src/app/(authenticated)/layout.tsx` 의 인증 강제 로직 점검. session 없으면 `/auth/signin` 이 아닌 `/` (Landing) 으로 redirect 변경:
+
+```tsx
+// 변경 전
+if (!session?.user) redirect("/auth/signin");
+
+// 변경 후
+if (!session?.user) redirect("/");
+```
+
+이유: 인증 안 한 사용자가 protected page 직접 URL 입력 시 Landing 으로 안내 (CTA 클릭으로 자연스러운 signin 진입). 단 middleware 가 이미 처리하면 layout 분기는 방어 코드 (도달 안 함) — 그래도 변경 일관성 유지.
+
+### 4. `src/app/(authenticated)/page.tsx` 정리
+
+기존 `(authenticated)/page.tsx` 가 dashboard redirect 했다면, route group 의 `/` 인덱스 — 본 plan 에서 `src/app/page.tsx` 가 우선이라 충돌. 둘 중 하나 삭제:
+
+- `src/app/(authenticated)/page.tsx` 삭제 (route group 의 / 인덱스는 더 이상 의미 없음)
+- 또는 `src/app/page.tsx` 단독으로 / 처리
+
+App Router 의 route group 은 URL 에 영향 없음 — `(authenticated)/page.tsx` 와 `page.tsx` 가 모두 `/` 라우트를 노리면 Next.js build error. 본 phase 시작 시 현재 상태 grep 으로 확인 후 삭제 대상 결정.
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/011-landing-auth-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build   # build 가 / 라우트 충돌 시 즉시 실패
+
+# middleware public matcher 에 / 포함
+grep -nE "['\"]/(['\"]|\$)" src/middleware.ts src/lib/server/middleware.ts 2>/dev/null
+
+# (authenticated)/layout redirect 변경
+grep -nE 'redirect\(["\x27]/["\x27]\)' src/app/\(authenticated\)/layout.tsx
+
+# / 라우트 단일 — src/app/page.tsx 만 존재
+find src/app -maxdepth 3 -name 'page.tsx' | xargs -I{} dirname {} | grep -E '/app(/\([^)]+\))?$' | wc -l   # 1 (src/app/page.tsx)
+```
+
+수동 smoke:
+1. 시크릿 창 → `/` 진입 → Landing 표시
+2. 시크릿 창 → `/dashboard` 진입 → middleware 가 `/` 로 redirect (또는 `/auth/signin` — 정책 결정)
+3. 로그인 후 → `/` 진입 → `/dashboard` 자동 redirect
+4. 로그인 후 → `/auth/signin` 진입 → (선택) Landing 또는 dashboard 로 redirect — 본 phase 에선 페이지 노출 유지 (혼동 방지 목적 redirect 는 별도 plan)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/middleware.ts` (또는 동등 위치) | public matcher 에 `/` 추가 |
+| `src/app/(authenticated)/layout.tsx` | unauth redirect 대상을 `/` 로 변경 |
+| `src/app/(authenticated)/page.tsx` | 삭제 (또는 `src/app/page.tsx` 와의 충돌 해결) |
+
+## Out of Scope
+
+- `/auth/signin` 진입한 인증 사용자 자동 redirect — 본 phase 에선 페이지 그대로 노출. 별도 plan
+- 로그인 후 returnTo URL 보존 — 본 plan 은 항상 `/dashboard` 직행
+- Middleware matcher 패턴 전면 재설계 — 최소 변경만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `/` 라우트 충돌 (App Router build error) | `find src/app -name 'page.tsx'` 로 사전 확인 후 한쪽 삭제 |
+| middleware 변경이 다른 protected route 동작 망가뜨림 | phase 시작 시 현재 matcher 전체 출력 → 변경 diff 최소화. 모든 protected route 수동 smoke |
+| `(authenticated)/layout` redirect 변경이 deep link 경험 악화 | Landing CTA → `/auth/signin` 한 번 더 클릭. 트레이드오프 수용 (Landing 이 첫 진입의 일관 entry) |

--- a/tasks/plan011-landing-auth-redesign/phase-05.md
+++ b/tasks/plan011-landing-auth-redesign/phase-05.md
@@ -1,0 +1,76 @@
+# Phase 05 — 통합 검증 + legacy 잔재 grep + index.json completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan011 전체 phase 결과 통합 검증. legacy 토큰/패턴 0 확인. index.json status="completed" 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/011-landing-auth-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+모두 통과해야 함.
+
+### 2. legacy 토큰 잔재 grep
+
+```bash
+# Auth 영역 전체에서 legacy 클래스/색 잔재 0
+! grep -rnE 'app-background|glass-card|bg-red-50|text-red-700|text-gray-[0-9]' \
+  src/app/auth/ \
+  src/components/auth/ \
+  src/components/landing/
+
+# 하드코딩 hex 0 (Naver brand #03C75A 는 예외 — 주석 동반)
+LEAK=$(grep -rnE '#[0-9a-fA-F]{6}' src/app/auth/ src/components/auth/ src/components/landing/ \
+  | grep -v '03C75A' || true)
+[ -z "$LEAK" ] || { echo "❌ 하드코딩 hex 잔재: $LEAK"; exit 1; }
+```
+
+### 3. 신규 파일 존재 확인
+
+```bash
+test -f src/app/page.tsx
+test -f src/components/landing/LandingPage.tsx
+test -f src/components/landing/MiniStats.tsx
+test -f src/components/auth/AuthCenterCard.tsx
+```
+
+### 4. 라우팅 smoke (사용자 수동)
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 시크릿 창 + `/` | Landing 표시 |
+| 시크릿 창 + `/dashboard` | `/` 또는 `/auth/signin` 으로 redirect |
+| 로그인 후 + `/` | `/dashboard` 자동 redirect |
+| `/auth/signin` | 새 카드 디자인 (gradient-family 로고 + Google/Naver 버튼) |
+| `/auth/signout` | 새 카드 + "다시 로그인" CTA |
+| `/auth/error?error=OAuthAccountNotLinked` | 매핑된 한국어 메시지 + AlertCircle 아이콘 |
+
+### 5. index.json completed 마킹
+
+```bash
+# 모든 phase status="completed" 갱신 + 최상위 status="completed" + completed_at
+```
+
+`tasks/plan011-landing-auth-redesign/index.json` 의 phases 배열 각 `status` 를 `"completed"` 로, 최상위 `status` 를 `"completed"`, `completed_at` 필드를 오늘 날짜로 추가.
+
+### 6. 최종 커밋
+
+```bash
+git add tasks/plan011-landing-auth-redesign/index.json
+git commit -m "chore(plan011): mark completed"
+```
+
+## Out of Scope
+
+- 사용자 onboarding 흐름 (Landing → signin → family 생성) end-to-end 자동 테스트 — 수동 smoke 만
+- Lighthouse / SEO score 측정


### PR DESCRIPTION
## Summary

handoff Screens 9~12 적용 task 파일. 인증 안 한 사용자에게 Landing (Hero + Features 3 + CTA) 을 표시해 가치 제안 entry 확보.

## 변경 내용

- `docs/adr.md`: ADR-F20 추가 — `/` 라우트 public 결정, Landing 표시 정책
- `docs/flow.md`: 1번 온보딩 다이어그램에 Landing 진입 흐름 반영
- `tasks/plan011-landing-auth-redesign/`: 5 phase task 파일
  - 01 Landing 페이지 (/) 신규 + MiniDonut/MiniBars
  - 02 SignIn 리디자인 (bg-bg-elev card + 소셜 버튼)
  - 03 SignOut + AuthError + AuthCenterCard helper
  - 04 middleware + (authenticated)/layout 라우팅 점검
  - 05 통합 검증 + completed 마킹

## Test plan

- [ ] 머지 후 `/build-with-teams plan011` 로 실제 구현 진행
- [ ] 구현 PR 에서 시크릿 창 `/` Landing + `/dashboard` redirect 동작 검증