### PR TITLE
docs(plan012): Empty / Error / Loading state task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -335,6 +335,18 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
 
 ---
 
+## 14-2. 빈 상태 / 에러 / 로딩 (plan012)
+
+App Router 의 segment 경계에서 일관 표시:
+
+- **Empty** (`src/components/empty/EmptyState.tsx`): 거래 0건 등 — 96px brand-50 round + inbox 아이콘 + 제목/부제 + (선택) CTA + (선택) 팁 박스
+- **Error** (`src/app/error.tsx` + `src/app/global-error.tsx` + `src/app/(authenticated)/error.tsx`): 88px expense/10 round + AlertCircle + "문제가 발생했어요" + DEV ONLY 디버그 박스 (production 숨김) + 다시 시도 / 홈으로
+- **Loading** (`src/app/(authenticated)/{dashboard,transactions,analytics,*}/loading.tsx`): `Skel` shimmer (ab-shimmer keyframe + .ab-skel class in globals.css) — 페이지별 구조 매치
+
+`error.tsx` 는 모두 `"use client"` 첫 줄 필수 (App Router 규약). `loading.tsx` 는 Server Component OK.
+
+---
+
 ## 14-3. /budget 페이지 (plan013)
 
 Dashboard BudgetHeroCard 의 확장 전용 페이지. 분석은 /analytics, 예산 소화는 /budget 으로 역할 분리.

--- a/tasks/plan012-empty-error-loading-states/index.json
+++ b/tasks/plan012-empty-error-loading-states/index.json
@@ -1,0 +1,52 @@
+{
+  "name": "plan012-empty-error-loading-states",
+  "description": "handoff Screens 13~15 — Empty / Error / Loading state 통합. transactions/dashboard empty 일러스트, App Router error.tsx 글로벌 + 라우트별, loading.tsx skeleton.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 4,
+  "related_docs": [
+    "docs/code-architecture.md",
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign",
+    "plan003-transactions-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH/Pretendard) ✅",
+    "plan002 머지 (Dashboard 구조) ✅",
+    "plan003 머지 (Transactions 구조) ✅",
+    "handoff: /tmp/handoff_plan011/fos-accountbook/project/screens/mobile-landing-auth.jsx Screens 13~15"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "Empty state — Transactions / Dashboard 빈 일러스트 + 팁 박스",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "Error state — App Router error.tsx (글로벌 + 라우트별) + AlertCircle 카드",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "Loading skeleton — loading.tsx (글로벌 + 라우트별) + Skel shimmer 컴포넌트",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "통합 검증 + legacy 잔재 grep + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan012-empty-error-loading-states/phase-01.md
+++ b/tasks/plan012-empty-error-loading-states/phase-01.md
@@ -1,0 +1,104 @@
+# Phase 01 — Empty state (Transactions / Dashboard)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screen 13 적용 — 거래 0건 / 가족 미생성 같은 빈 상태에 일러스트 카드 + 팁 박스 표시. UX 가 비어있는 화면 = "에러" 로 오해되는 문제 해결.
+
+## Context (자기완결)
+
+- handoff 참조: `mobile-landing-auth.jsx` line 480~593 (MobileEmpty)
+- 패턴: 96px brand-50 round 배경 + 48px inbox 아이콘 (brand-500 opacity 0.85) + 제목 17px + 부제 13px + CTA 버튼 + brand-50 톤 팁 박스
+- 현재 거래 페이지 (`src/app/(authenticated)/transactions/page.tsx`) 가 빈 결과 시 표시하는 내용 점검 — 단순 텍스트만이면 본 phase 가 카드로 격상
+
+## 작업 항목
+
+### 1. `EmptyState` 공용 컴포넌트
+
+`src/components/empty/EmptyState.tsx` 신규:
+
+```ts
+interface EmptyStateProps {
+  icon: LucideIcon;       // inbox / coins / users
+  title: string;
+  description: string;    // <br/> 줄바꿈은 \n
+  cta?: { label: string; href: string; icon?: LucideIcon };
+  tip?: { title: string; body: string };
+}
+```
+
+구성:
+- 96px round + `bg-brand-50` + 48px 아이콘 (`text-brand-500 opacity-85`)
+- 카드 wrapper: `bg-bg-elev border-border rounded-2xl px-6 pt-13 pb-10 text-center`
+- 제목: `text-[17px] font-bold tracking-tight`
+- 부제: `text-[13px] text-fg-muted leading-relaxed` (`whitespace-pre-line` 으로 \n 처리)
+- CTA: `h-11 px-5 rounded-xl bg-brand-500 text-white shadow-[0_6px_16px_-6px_oklch(0.640_0.140_188/0.5)]`
+- 팁 박스 (있을 때만): `bg-brand-50 rounded-xl p-4 text-brand-700` + sparkle 아이콘 + title + body
+
+### 2. Transactions 빈 결과 EmptyState 적용
+
+`src/app/(authenticated)/transactions/page.tsx` (또는 `ExpenseListClient` / `IncomeListClient`):
+
+거래 0건이면 EmptyState 렌더:
+- icon: `Inbox`
+- title: "아직 거래가 없어요"
+- description: "지출이나 수입을 추가하면\n여기에 표시돼요."
+- cta: { label: "지출 추가", href: "?openAdd=expense", icon: Plus }
+  - 또는 기존 FAB 의존 (CTA 생략)
+- tip: { title: "팁", body: "가족 누구나 입력할 수 있어요. 카드 청구서 도착 전에\n그때 그때 짧게 적어두면 편해요." }
+
+### 3. Dashboard 빈 상태 (가족 미생성 외 케이스)
+
+대시보드는 보통 `/families/create` redirect 라 빈 상태 자체 도달 어려움. 단 가족 있고 거래 0건일 때 RecentActivity / CategoryDistribution 섹션이 빈 상태:
+
+- `RecentActivity` 0건: 인라인 단순 메시지 ("아직 거래가 없어요") + brand-50 round 32px inbox 아이콘
+- `CategoryDistribution` 0건: 도넛 placeholder + "이번 달 지출이 아직 없어요"
+
+EmptyState 컴포넌트의 mini 변형 또는 inline JSX. 본 phase 에선 inline JSX 유지 (mini 변형이 별도 prop 폭증 위험).
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/012-empty-error-loading-states
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/empty/EmptyState.tsx
+
+# Transactions 페이지에서 EmptyState 사용
+grep -rln 'EmptyState' src/app/\(authenticated\)/transactions/ src/components/transactions/ | wc -l   # >= 1
+
+# 하드코딩 색 0
+! grep -rnE 'text-gray-|bg-gray-' src/components/empty/
+
+# brand 토큰 사용
+grep -nE 'bg-brand-50|text-brand-500|text-brand-700' src/components/empty/EmptyState.tsx | wc -l   # >= 3
+```
+
+수동 smoke: 거래 0건 가족 계정으로 `/transactions` → EmptyState 카드 + 팁 표시. CTA 클릭 → AddExpenseDialog 열림 (또는 FAB 안내).
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/empty/EmptyState.tsx` | 신규 |
+| `src/app/(authenticated)/transactions/page.tsx` | 수정 — 0건 분기에 EmptyState |
+| `src/components/transactions/ExpenseListClient.tsx` | 수정 (해당 시) |
+| `src/components/dashboard/RecentActivity.tsx` | 수정 — 0건 inline 메시지 갱신 |
+| `src/components/dashboard/CategoryDistribution.tsx` | 수정 — 0건 placeholder |
+
+## Out of Scope
+
+- 검색 결과 0건 (`?q=foo` 매칭 없음) 별도 UI — 본 plan 은 "원본 데이터 0건" 케이스만. 검색 0건은 후속 plan
+- `/families/create` 자체의 빈 가족 onboarding — 이미 별도 페이지
+- 카테고리 0개 / 멤버 0명 empty state — 본 plan 범위 외
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| EmptyState 가 너무 일반화돼 페이지마다 prop 폭증 | tip 은 optional, CTA 도 optional. 페이지마다 다른 변형은 inline JSX 허용 (forced abstraction 회피) |
+| 거래 0건 / 검색 0건 / 필터 0건 구분 모호 | 본 phase 는 originalCount === 0 만 처리. searchParams 가 있으면 EmptyState 미표시 (검색 결과 0건 UI 는 후속) |
+| inbox 아이콘 lucide-react 버전 호환 | `Inbox` 컴포넌트 import 가능. 없으면 `Package` 대체 |

--- a/tasks/plan012-empty-error-loading-states/phase-02.md
+++ b/tasks/plan012-empty-error-loading-states/phase-02.md
@@ -1,0 +1,141 @@
+# Phase 02 — Error state (App Router error.tsx)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screen 14 적용 — Next.js App Router 의 `error.tsx` 글로벌 + 라우트별 boundary 에서 동일 시각 패턴 (AlertCircle 88px round + 제목/부제 + DEV ONLY 디버그 박스 + "다시 시도" CTA + "홈으로" 보조 링크) 표시.
+
+## Context (자기완결)
+
+- handoff 참조: `mobile-landing-auth.jsx` line 598~666 (MobileErrorState)
+- App Router 의 `error.tsx`:
+  - **반드시 Client Component** (`"use client"` 필수)
+  - props: `{ error: Error & { digest?: string }, reset: () => void }`
+  - 라우트별 경계 — 위치한 segment 하위에서 발생한 에러를 잡음
+- 현재 `src/app/(authenticated)/error.tsx` 또는 `src/app/error.tsx` 존재 여부 점검 (없으면 default Next.js error UI)
+
+## 작업 항목
+
+### 1. `ErrorBoundaryCard` 공용 컴포넌트
+
+`src/components/error/ErrorBoundaryCard.tsx` 신규 (`"use client"`):
+
+```ts
+interface ErrorBoundaryCardProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  homeHref?: string;   // default "/"
+}
+```
+
+구성:
+- 외부 wrapper: `min-h-screen bg-bg flex items-center justify-center p-5`
+- 카드: `max-w-[360px] w-full flex flex-col items-center text-center`
+- 88px round: `bg-expense/10 text-expense` + AlertCircle 44px
+- 제목: "문제가 발생했어요" (22px font-bold)
+- 부제: "잠시 후 다시 시도해주세요" (13.5px text-fg-muted)
+- DEV ONLY 박스 (`process.env.NODE_ENV !== "production"` 일 때만):
+  - `bg-bg-elev border-border rounded-xl p-3.5`
+  - "DEV ONLY" 라벨 (10.5px font-bold uppercase tracking-wider text-fg-subtle)
+  - 본문: `font-mono text-[12px] text-expense break-all`
+  - `error.message` + `\nstatus=... digest={error.digest}`
+- CTA: "다시 시도" (`h-12 rounded-xl bg-brand-500 text-white`) → `onClick={reset}`
+- 보조: "홈으로" → `<Link>` text-fg-muted 13px font-semibold
+
+### 2. 글로벌 `error.tsx`
+
+`src/app/error.tsx` 신규 (`"use client"`):
+
+```tsx
+"use client";
+import { ErrorBoundaryCard } from "@/components/error/ErrorBoundaryCard";
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorBoundaryCard error={error} reset={reset} />;
+}
+```
+
+### 3. `(authenticated)` 그룹 error boundary
+
+`src/app/(authenticated)/error.tsx` 신규 (`"use client"`) — 인증 영역 전반의 에러 캐치. 동일 카드 사용 + `homeHref="/dashboard"` 로 보조 링크 변경.
+
+### 4. `global-error.tsx` (root layout 에러용)
+
+App Router 는 root layout 자체에서 에러 발생 시 `app/global-error.tsx` 필요 — `<html>` / `<body>` 자체 렌더 책임.
+
+`src/app/global-error.tsx` 신규 (`"use client"`):
+
+```tsx
+"use client";
+import { ErrorBoundaryCard } from "@/components/error/ErrorBoundaryCard";
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html lang="ko">
+      <body>
+        <ErrorBoundaryCard error={error} reset={reset} />
+      </body>
+    </html>
+  );
+}
+```
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/012-empty-error-loading-states
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/error/ErrorBoundaryCard.tsx
+test -f src/app/error.tsx
+test -f src/app/global-error.tsx
+test -f src/app/\(authenticated\)/error.tsx
+
+# 모두 "use client" 첫 줄
+head -1 src/app/error.tsx src/app/global-error.tsx src/app/\(authenticated\)/error.tsx | grep -c 'use client'   # == 3
+
+# AlertCircle 사용
+grep -nE 'AlertCircle' src/components/error/ErrorBoundaryCard.tsx | wc -l   # >= 1
+
+# 하드코딩 색 0
+! grep -nE 'bg-red-|text-red-|text-gray-' src/components/error/ErrorBoundaryCard.tsx
+
+# production 번들에 DEV ONLY 텍스트 / error.message 잔재 0 (자동 검증)
+NODE_ENV=production pnpm build
+if grep -rq 'DEV ONLY' .next/static/ 2>/dev/null; then
+  echo "❌ production 번들에 'DEV ONLY' 텍스트 노출 — process.env.NODE_ENV 분기 점검"
+  exit 1
+fi
+```
+
+수동 smoke:
+- `(authenticated)/dashboard/page.tsx` 에 임시 `throw new Error("test")` 삽입 → AlertCircle 카드 표시 + DEV 박스에 메시지
+- "다시 시도" 클릭 → reset() 으로 boundary 재시도
+- production build (`pnpm build && pnpm start`) → DEV 박스 미표시 (위 자동 grep 가 1차 안전망, 수동 smoke 가 최종 확인)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/error/ErrorBoundaryCard.tsx` | 신규 (use client) |
+| `src/app/error.tsx` | 신규 (use client) |
+| `src/app/global-error.tsx` | 신규 (use client + html/body) |
+| `src/app/(authenticated)/error.tsx` | 신규 (use client) |
+
+## Out of Scope
+
+- 에러 리포팅 (Sentry / 자체 telemetry) wiring — 별도 plan
+- 404 not-found.tsx — 본 plan 은 5xx / unexpected 에러만. 404 는 후속
+- 인라인 에러 (form validation / Server Action 결과) — toast 로 이미 처리, 본 plan 미수정
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `error.tsx` 가 server component 로 작성되면 Next.js 빌드 에러 | 모든 파일 첫 줄 `"use client"` 강제. verification 에서 grep |
+| DEV 박스가 production 에 노출 | `process.env.NODE_ENV` 분기 + verification 의 production build 수동 smoke |
+| `global-error.tsx` 가 `<html>` 미포함 시 hydration 사고 | handoff 예시 그대로 html/body wrap |
+| reset() 호출 후에도 에러 재발 시 무한 루프 시각 | 본 plan 미해결 (Next.js 표준 동작). 사용자가 "홈으로" 보조 링크로 빠져나갈 수 있게 보장 |

--- a/tasks/plan012-empty-error-loading-states/phase-03.md
+++ b/tasks/plan012-empty-error-loading-states/phase-03.md
@@ -1,0 +1,135 @@
+# Phase 03 — Loading skeleton (loading.tsx)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: handoff Screen 15 적용 — Next.js App Router 의 `loading.tsx` 에 shimmer skeleton 표시. 페이지 진입 시 빈 화면 / hydration 깜빡임 제거.
+
+## Context (자기완결)
+
+- handoff 참조: `mobile-landing-auth.jsx` line 671~797 (MobileLoading + SHIMMER_CSS + Skel)
+- App Router `loading.tsx`: route segment 의 Suspense boundary. Server Component pending 동안 표시
+- 현재 `loading.tsx` 가 라우트별로 존재하는지 점검 — 없으면 default Next.js (빈 화면) 표시
+
+## 작업 항목
+
+### 1. `Skel` 컴포넌트 + shimmer 애니메이션
+
+`src/components/loading/Skel.tsx` 신규:
+
+```ts
+interface SkelProps {
+  w?: string | number;   // default "100%"
+  h?: number;            // default 12
+  r?: number;            // border-radius, default 8
+  className?: string;
+}
+```
+
+shimmer 애니메이션은 `src/app/globals.css` 의 `@theme` 블록 외부에 추가:
+
+```css
+@keyframes ab-shimmer {
+  0% { background-position: -200px 0; }
+  100% { background-position: calc(200px + 100%) 0; }
+}
+.ab-skel {
+  background-color: var(--color-bg-muted);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0,
+    color-mix(in srgb, var(--color-bg-muted), white 35%) 50%,
+    transparent 100%
+  );
+  background-size: 200px 100%;
+  background-repeat: no-repeat;
+  animation: ab-shimmer 1.4s ease-in-out infinite;
+  border-radius: 8px;
+}
+```
+
+`Skel` 컴포넌트는 `<div className="ab-skel" style={{ width, height, borderRadius }} />` 단순 wrapper.
+
+### 2. Dashboard `loading.tsx`
+
+`src/app/(authenticated)/dashboard/loading.tsx` 신규:
+
+handoff 의 MobileLoading 구조 그대로:
+- Header skeleton: 50%/22 + 32%/13
+- Hero card skeleton: 40%/11 + 65%/30 + 100%/6 progress + 2-col stat (60%/10 + 80%/16) × 2
+- Donut card skeleton: 35%/14 + 120/120 round + 4 legend rows
+- List skeleton: 30%/11 + 4 rows (36/36 round + 70%/12 + 40%/10 + 70/14)
+
+Server Component 로 작성 가능 (Skel 자체가 client 일 필요 없음 — CSS animation 만).
+
+### 3. Transactions `loading.tsx`
+
+`src/app/(authenticated)/transactions/loading.tsx` 신규:
+- 헤더 skeleton (검색바 + filter chip)
+- Tab skeleton (3 segment)
+- List skeleton (8 row)
+
+### 4. Analytics `loading.tsx`
+
+`src/app/(authenticated)/analytics/loading.tsx` 신규:
+- Period toggle skeleton
+- Donut card + 2 stat card
+- MonthlyTrendBar skeleton (12 bar 가변 높이)
+- CategoryDetailList skeleton (6 row)
+
+### 5. 글로벌 `loading.tsx`
+
+`src/app/(authenticated)/loading.tsx` 신규 — 위 라우트별 loading 이 없는 protected page (예: `/settings`, `/family`) 진입 시 generic skeleton:
+- 헤더 영역 (1 row) + 컨텐츠 영역 (3 card)
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/012-empty-error-loading-states
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/loading/Skel.tsx
+test -f src/app/\(authenticated\)/loading.tsx
+test -f src/app/\(authenticated\)/dashboard/loading.tsx
+test -f src/app/\(authenticated\)/transactions/loading.tsx
+test -f src/app/\(authenticated\)/analytics/loading.tsx
+
+# globals.css 에 ab-shimmer keyframe + .ab-skel 클래스
+grep -nE 'ab-shimmer|\.ab-skel' src/app/globals.css | wc -l   # >= 2
+
+# Skel 사용 카운트
+grep -rln 'Skel' src/app/\(authenticated\)/ | wc -l   # >= 4
+```
+
+수동 smoke:
+- DevTools Network throttle Slow 3G → 페이지 진입 → shimmer skeleton 표시 → 데이터 로드 후 실제 컨텐츠 교체
+- 다크 모드 토글 → skeleton 톤이 자연스럽게 어두워짐 (`var(--color-bg-muted)` 토큰)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/loading/Skel.tsx` | 신규 |
+| `src/app/globals.css` | shimmer keyframe + .ab-skel 추가 |
+| `src/app/(authenticated)/loading.tsx` | 신규 (generic) |
+| `src/app/(authenticated)/dashboard/loading.tsx` | 신규 |
+| `src/app/(authenticated)/transactions/loading.tsx` | 신규 |
+| `src/app/(authenticated)/analytics/loading.tsx` | 신규 |
+
+## Out of Scope
+
+- Suspense boundary 를 페이지 안에 별도 wrapping (route-level loading.tsx 외) — 본 plan 은 route loading 만
+- Streaming SSR + partial pre-render — 별도 plan
+- 다국어 alt text (skeleton 자체는 텍스트 없음)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| shimmer 애니메이션이 dark mode 에서 너무 밝음 | `color-mix` 가 var 기반 — dark `--color-bg-muted` 가 어두우니 자연스럽게 어두운 shimmer 됨. 수동 smoke 에서 확인 |
+| skeleton 구조가 실제 페이지와 어긋나면 layout shift | handoff 의 구조 비율 (헤더/카드/리스트) 을 최대한 매치. 100% 일치는 불필요 (대략 윤곽이면 충분) |
+| App Router 의 loading.tsx 가 Server Component 인데 CSS animation 작동? | CSS animation 은 SSR 무관 — 클라 페인트 시 발동. 문제 없음 |
+| `.ab-skel` class 가 Tailwind purge 대상 | globals.css 정의 → Tailwind 가 purge 안 함 (Tailwind 는 @layer 외 CSS 보존) |

--- a/tasks/plan012-empty-error-loading-states/phase-04.md
+++ b/tasks/plan012-empty-error-loading-states/phase-04.md
@@ -1,0 +1,78 @@
+# Phase 04 — 통합 검증 + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan012 전체 phase 통합 검증. legacy 잔재 0 확인. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/012-empty-error-loading-states
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 2. 신규 파일 존재 확인
+
+```bash
+test -f src/components/empty/EmptyState.tsx
+test -f src/components/error/ErrorBoundaryCard.tsx
+test -f src/components/loading/Skel.tsx
+test -f src/app/error.tsx
+test -f src/app/global-error.tsx
+test -f src/app/\(authenticated\)/error.tsx
+test -f src/app/\(authenticated\)/loading.tsx
+test -f src/app/\(authenticated\)/dashboard/loading.tsx
+test -f src/app/\(authenticated\)/transactions/loading.tsx
+test -f src/app/\(authenticated\)/analytics/loading.tsx
+```
+
+### 3. legacy / 하드코딩 잔재 0
+
+```bash
+# Empty/Error/Loading 디렉터리에서 회색·red 하드코딩 0
+! grep -rnE 'text-gray-|bg-gray-|bg-red-|text-red-' \
+  src/components/empty/ \
+  src/components/error/ \
+  src/components/loading/
+
+# error.tsx 들 모두 "use client" 첫 줄
+for f in src/app/error.tsx src/app/global-error.tsx src/app/\(authenticated\)/error.tsx; do
+  head -1 "$f" | grep -q '"use client"' || { echo "❌ $f: use client missing"; exit 1; }
+done
+```
+
+### 4. 수동 smoke (사용자)
+
+| 시나리오 | 기대 |
+|---|---|
+| 거래 0건 가족 + `/transactions` | EmptyState 카드 + 팁 |
+| 임시 `throw new Error("test")` + `/dashboard` | ErrorBoundaryCard + AlertCircle + DEV 디버그 박스 |
+| Network Slow 3G + `/dashboard` 진입 | shimmer skeleton → 컨텐츠 |
+| `/auth/signin` 진입 (loading.tsx 없음) | 즉시 표시 (이상 없음) |
+| Dark mode + 위 시나리오 | 모두 자연스러운 톤 |
+
+### 5. index.json completed 마킹
+
+```bash
+# 모든 phase status="completed" + 최상위 status="completed" + completed_at
+```
+
+### 6. 최종 커밋
+
+```bash
+git add tasks/plan012-empty-error-loading-states/index.json
+git commit -m "chore(plan012): mark completed"
+```
+
+## Out of Scope
+
+- 404 not-found.tsx
+- Sentry / 에러 리포팅 wiring
+- 검색 결과 0건 / 필터 결과 0건 별도 UI


### PR DESCRIPTION
## Summary

handoff Screens 13~15 적용 task 파일. App Router 의 error.tsx (글로벌 + 라우트별) + loading.tsx (dashboard/transactions/analytics) + EmptyState 공용 컴포넌트.

## 변경 내용

- `docs/flow.md`: §14-2 빈 상태 / 에러 / 로딩 패턴 노트 추가
- `tasks/plan012-empty-error-loading-states/`: 4 phase task 파일
  - 01 Empty (Transactions / Dashboard inline)
  - 02 Error boundary 카드 + (authenticated)/error.tsx + global-error.tsx
  - 03 Loading skeleton + Skel + shimmer keyframe
  - 04 통합 검증 + completed

## Test plan

- [ ] 머지 후 `/build-with-teams plan012` 로 실제 구현 진행
- [ ] 구현 PR 에서 거래 0건 EmptyState / 임시 throw 후 ErrorBoundaryCard / Network throttle 시 skeleton 동작 검증