### PR TITLE
docs(plan013): /budget 페이지 Hero 확장 + 라인 차트 + 카테고리 top 5 task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -329,6 +329,27 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
 
 ---
 
+## 14-3. /budget 페이지 (plan013)
+
+Dashboard BudgetHeroCard 의 확장 전용 페이지. 분석은 /analytics, 예산 소화는 /budget 으로 역할 분리.
+
+```
+[/budget (server) — Promise.all 3 Action]
+    ├─ getDashboardStatsAction() → { budget, monthlyExpense, remainingBudget, year, month }
+    ├─ getMonthlyDailyStatsAction(year, month) → { items: { date, expense, income }[] }
+    └─ getMonthlyCategoryBreakdownAction() → { items: { categoryUuid, name, color?, totalAmount }[] }
+            │
+            └─ BudgetClient (use client)
+                    ├─ BudgetHeroCard (Dashboard 와 시각 일치)
+                    ├─ 3-col 통계: 일 평균 지출 / 남은 일수 / 권장 일 예산 (남은예산÷남은일수)
+                    ├─ BudgetCumulativeLine (recharts LineChart + ReferenceLine 예산선)
+                    └─ BudgetCategoryBars (수평 bar top 5 + 예산 대비 % + ↑많음 라벨)
+```
+
+예산 0 시: EmptyState 카드 + "예산 설정하기" → /settings 로. 라인 차트 + 카테고리 bar 자체 미렌더.
+
+---
+
 ## 14. 대시보드 고정비 카드
 
 ```

--- a/tasks/plan013-budget-page-redesign/index.json
+++ b/tasks/plan013-budget-page-redesign/index.json
@@ -1,0 +1,50 @@
+{
+  "name": "plan013-budget-page-redesign",
+  "description": "/budget 페이지를 Dashboard BudgetHeroCard 의 확장 전용 페이지로 재설계. shadcn legacy 토큰 (text-muted-foreground/bg-card/text-destructive) 제거 + Teal 토큰 적용 + 일별 누적 라인 차트 (recharts) + 일 평균/남은 일수/권장 일 예산 통계 단락 + 카테고리 top 5 수평 bar.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 4,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign",
+    "plan006-analytics-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH/Pretendard) ✅",
+    "plan002 머지 (BudgetHeroCard 패턴 — Hero 카드 톤 재사용) ✅",
+    "plan006 머지 (getMonthlyDailyStatsAction / getMonthlyCategoryBreakdownAction — 데이터 재사용) ✅"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "BudgetClient Hero 카드 토큰 교체 + 통계 단락 (일 평균/남은 일수/권장 일 예산)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "BudgetCumulativeLine — 일별 누적 지출 vs 예산 라인 차트 (recharts)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "BudgetCategoryBars — 카테고리 top 5 수평 bar + 예산 대비 % 슬롯",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "page.tsx 데이터 페칭 통합 + 검증 + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan013-budget-page-redesign/phase-01.md
+++ b/tasks/plan013-budget-page-redesign/phase-01.md
@@ -1,0 +1,117 @@
+# Phase 01 — BudgetClient Hero 카드 토큰 교체 + 통계 단락
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `BudgetClient.tsx` 의 shadcn legacy 토큰 제거 + Dashboard BudgetHeroCard 와 시각 일치 + 일 평균/남은 일수/권장 일 예산 통계 단락 추가.
+
+## Context (자기완결)
+
+- 현재: `src/app/(authenticated)/budget/_components/BudgetClient.tsx` (197 줄)
+  - `text-muted-foreground` / `bg-card` / `bg-muted` / `text-destructive` / `text-foreground` 같은 shadcn legacy 토큰 잔재
+  - Hero 카드는 `gradient-budget` / `gradient-expense` 사용 (시맨틱 클래스 적용됨 — 유지)
+  - 2-col Card 통계 (이번 달 지출 / 남은 예산)
+- 데이터 소스: `getDashboardStatsAction()` → `{ budget, monthlyExpense, remainingBudget, year, month }`
+- 참조: `src/components/dashboard/BudgetHeroCard.tsx` (Dashboard 의 동일 영역)
+
+## 작업 항목
+
+### 1. legacy 토큰 일괄 교체
+
+| 변경 전 | 변경 후 |
+|---|---|
+| `text-foreground` | `text-fg` |
+| `text-muted-foreground` | `text-fg-muted` |
+| `bg-card` | `bg-bg-elev` |
+| `bg-muted` | `bg-bg-muted` |
+| `text-destructive` | `text-expense` |
+| `border-border` | `border-border` (유지 — 토큰 이름 동일) |
+
+### 2. Hero 카드 — Dashboard BudgetHeroCard 와 시각 일치
+
+`BudgetHeroCard.tsx` 의 구조 참조해서 동일 레이아웃:
+- 상단 라벨: "예산 남은 금액" 또는 "예산 초과"
+- 큰 숫자: `text-4xl md:text-5xl font-bold .num` (Pretendard 수치 폰트)
+- 부제: "총 예산 ₩{budget}" + "/" + `daysRemaining` "일 남음"
+- Progress bar (사용률) — `gradient-card-overlay` 톤
+- 우상단 PiggyBank 아이콘은 유지 (월 라벨 옆 배치)
+
+기존 Card / CardContent shadcn wrapper 는 유지 (Dashboard BudgetHeroCard 와 동일).
+
+### 3. 통계 단락 신규 — 일 평균 / 남은 일수 / 권장 일 예산
+
+기존 2-col Card (이번 달 지출 / 남은 예산) 를 3-col 통계로 확장 (또는 별도 row):
+
+```ts
+const today = new Date();
+const daysInMonth = new Date(year, month, 0).getDate();
+const dayOfMonth = today.getDate();
+const daysRemaining = Math.max(daysInMonth - dayOfMonth, 0);
+
+const dailyAverage = dayOfMonth > 0 ? Math.round(monthlyExpense / dayOfMonth) : 0;
+const recommendedDailyBudget = daysRemaining > 0 ? Math.max(Math.round(remainingBudget / daysRemaining), 0) : 0;
+```
+
+3-col grid (md+) / mobile 1-col stack:
+- 카드 1: "일 평균 지출" + `dailyAverage` (.num) + 부제 `${dayOfMonth}일 기준`
+- 카드 2: "남은 일수" + `daysRemaining` (.num) + 부제 `${daysInMonth}일 중`
+- 카드 3: "권장 일 예산" + `recommendedDailyBudget` (.num) + 부제 "남은 예산 ÷ 남은 일수"
+
+카드 톤: `bg-bg-elev border-border rounded-xl p-4`. 숫자 폰트 `.num text-xl md:text-2xl font-bold text-fg`. 부제 `text-xs text-fg-muted`.
+
+### 4. 예산 미설정 빈 상태 — EmptyState 패턴 (plan012 와 일관)
+
+기존 빈 상태 카드는 plan012 의 `EmptyState` 와 톤 통일:
+- `bg-bg-elev border-dashed border-border` 또는 plan012 의 `EmptyState` 컴포넌트 재사용 (plan012 머지 후)
+- 본 phase 에선 plan012 미머지일 수 있으므로 inline 으로 작성하되 톤만 새 토큰으로:
+  - 96px round `bg-brand-50` + PiggyBank `text-brand-500 opacity-85`
+  - 제목 17px font-bold text-fg
+  - 부제 13px text-fg-muted
+  - CTA: "예산 설정하기" → `/settings` (`bg-brand-500 text-white`)
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/013-budget-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 0
+! grep -nE 'text-muted-foreground|text-destructive|bg-card|bg-muted\b' \
+  src/app/\(authenticated\)/budget/_components/BudgetClient.tsx
+
+# 신 토큰 사용
+grep -nE 'text-fg|bg-bg-elev|text-brand-500|gradient-budget' \
+  src/app/\(authenticated\)/budget/_components/BudgetClient.tsx | wc -l   # >= 3
+
+# 통계 단락 계산식
+grep -nE 'dailyAverage|recommendedDailyBudget|daysRemaining' \
+  src/app/\(authenticated\)/budget/_components/BudgetClient.tsx | wc -l   # >= 3
+
+# .num 클래스 사용 (Pretendard 수치)
+grep -n '.num' src/app/\(authenticated\)/budget/_components/BudgetClient.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/budget` → Hero + 3 통계 + (예산 미설정 시) 빈 카드 표시. 다크 모드 토글 → 자연스러운 톤 전환.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/budget/_components/BudgetClient.tsx` | 토큰 교체 + 통계 단락 추가 + 빈 상태 갱신 |
+
+## Out of Scope
+
+- 라인 차트 / 카테고리 bar (phase 02 / 03)
+- 예산 설정 폼 자체 (settings 의 일부) — 본 phase 는 CTA 만
+- 예산 알림 임계 (80%/100%) UI — 이미 NotificationBell 로 처리됨
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `daysRemaining = 0` (월 마지막 날) 시 권장 일 예산 NaN | 분모 0 분기 처리 — `daysRemaining > 0 ? ... : 0` |
+| `dayOfMonth = 0` (월 첫 날 0시) 시 일 평균 NaN | 동일 분기 처리 |
+| 시간대 차이로 month 경계에서 daysInMonth 오차 | `new Date(year, month, 0).getDate()` 는 month=1~12 기준이라 정확. 단 props 의 year/month 가 server time 인지 확인 필요 — 현재는 `stats.year/month` 그대로 사용 (server 기준이라 일관) |

--- a/tasks/plan013-budget-page-redesign/phase-02.md
+++ b/tasks/plan013-budget-page-redesign/phase-02.md
@@ -1,0 +1,103 @@
+# Phase 02 — BudgetCumulativeLine (일별 누적 지출 vs 예산 라인 차트)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 월 누적 지출 그래프 + 예산 수평선 + 초과 지점 시각 강조. recharts LineChart 사용 (Dashboard CategoryDistribution 과 일관).
+
+## Context (자기완결)
+
+- 데이터: `getMonthlyDailyStatsAction(year, month)` — analytics 페이지에서 이미 사용
+  - 응답: `{ items: { date: string; expense: number; income: number }[] }`
+- recharts 이미 의존성 설치됨 (`src/components/dashboard/CategoryDistribution.tsx` 의 PieChart 참조)
+- 라인 차트는 budget 페이지 단독 — 재사용 컴포넌트 위치 `src/app/(authenticated)/budget/_components/`
+
+## 작업 항목
+
+### 1. `BudgetCumulativeLine.tsx` 컴포넌트 (`"use client"`)
+
+`src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx`:
+
+```ts
+interface BudgetCumulativeLineProps {
+  dailyExpenses: { date: string; expense: number }[];   // 월 전체 일별 지출
+  budget: number;                                       // 월 예산
+  daysInMonth: number;
+}
+```
+
+내부 로직:
+- 일별 누적 시퀀스 계산: `acc[i] = acc[i-1] + expense[i]`
+- 라인 데이터: `[ { day: 1, cumulative: 0 }, ..., { day: daysInMonth, cumulative: total } ]`
+- 예산 수평선: `ReferenceLine y={budget} stroke="brand-700" strokeDasharray="4 4"`
+- 라인: `stroke="var(--color-brand-500)"`, `strokeWidth={2.5}`, fill area gradient (옵션)
+- 초과 지점: 누적 ≥ 예산 시 빨간 dot
+
+차트 카드 wrapper:
+- `bg-bg-elev border-border rounded-2xl p-5 md:p-6`
+- 상단: 제목 "이번 달 누적 지출" (text-fg 14px font-semibold) + 우측 범례 (• 누적 · -- 예산)
+- 본문: ResponsiveContainer 16:9 비율 (`h-48 md:h-64`)
+- 하단: 현재 누적/예산 비율 텍스트 "오늘까지 ₩{cumulative} ({pct}%)"
+
+### 2. recharts 토큰 매핑
+
+CSS 변수를 차트 색에 직접 주입:
+- 라인: `stroke="var(--color-brand-500)"`
+- 예산선: `stroke="var(--color-brand-700)"`
+- 초과 dot: `fill="var(--color-expense)"`
+- grid: `stroke="var(--color-border)" strokeOpacity={0.5}`
+- tick text: `tick={{ fill: "var(--color-fg-muted)", fontSize: 11 }}`
+
+`tooltip` 커스텀:
+- `bg-bg-elev border-border shadow-default rounded-md p-2.5 text-xs text-fg`
+- 누적 (.num) + 일자 + 일 지출 (`expense[i]`)
+
+### 3. 예산 미설정 시 처리
+
+`budget === 0` 이면 차트 카드 자체 미렌더 (page.tsx 분기). 본 컴포넌트는 `budget > 0` 전제로 동작.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/013-budget-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx
+
+# "use client" 첫 줄
+head -1 src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | grep -q 'use client'
+
+# recharts import + ReferenceLine
+grep -nE 'from "recharts"' src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | wc -l   # >= 1
+grep -n 'ReferenceLine' src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | wc -l   # >= 1
+
+# CSS 변수 색 매핑
+grep -nE 'var\(--color-brand-500\)|var\(--color-expense\)' \
+  src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | wc -l   # >= 2
+```
+
+수동 smoke: `/budget` → 라인 차트 표시. 예산 초과 직전 / 직후 데이터로 빨간 dot 확인. 마우스 hover → tooltip 표시.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx` | 신규 (use client) |
+
+## Out of Scope
+
+- 월 비교 (이번 달 vs 직전 달 라인 2개) — 본 plan 은 이번 달 단독
+- 일별 income (수입) 라인 추가 — budget 페이지 관심사 아님
+- 차트 export / 캡처 기능
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| recharts ResponsiveContainer + Tailwind h-* 충돌 | container 부모에 명시 height 지정. recharts 가 100% 채움 |
+| dailyExpenses 데이터가 일자 missing (지출 0 인 날) | client 측에서 1~daysInMonth 채워 보간 (`expense: 0`) |
+| dark mode 에서 grid 선 너무 진함 | `strokeOpacity={0.5}` + dark token 자동 적용. 수동 smoke 검증 |
+| 모바일 320px 폭에서 라벨 겹침 | x축 `interval="preserveStartEnd"` + `tick` 5일 간격 |

--- a/tasks/plan013-budget-page-redesign/phase-03.md
+++ b/tasks/plan013-budget-page-redesign/phase-03.md
@@ -1,0 +1,122 @@
+# Phase 03 — BudgetCategoryBars (카테고리 top 5 수평 bar)
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 이번 달 카테고리별 지출 top 5 를 수평 bar 로 시각화. 예산 대비 % 동시 표기 — "잘라야 할 항목" 관점 강조 (Dashboard/Analytics 의 donut 과 차별화).
+
+## Context (자기완결)
+
+- 데이터: `getMonthlyCategoryBreakdownAction()` (ADR-F16, Dashboard 에서 이미 사용)
+  - 응답: `{ items: { categoryUuid, categoryName, categoryColor?, totalAmount }[] }`
+- 카테고리 색 토큰: `--color-cat-{tone}-bg` / `--color-cat-{tone}-fg` (plan002 의 8 팔레트)
+- 수평 bar 는 순수 CSS (Tailwind w-* + bg) 또는 SVG — 본 phase 는 CSS 권장 (recharts 오버킬)
+
+## 작업 항목
+
+### 1. `BudgetCategoryBars.tsx` 컴포넌트 (Server 또는 Client — interactive 없음 → Server)
+
+`src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx`:
+
+```ts
+interface BudgetCategoryBarsProps {
+  items: { categoryUuid: string; categoryName: string; categoryColor?: string; totalAmount: number }[];
+  budget: number;
+  monthlyExpense: number;
+}
+```
+
+내부 로직:
+- top 5 만 추출: `items.sort((a,b) => b.totalAmount - a.totalAmount).slice(0, 5)`
+- 각 카테고리의 예산 대비 비율: `(totalAmount / budget) * 100`
+- bar 폭: `(totalAmount / max(items[0].totalAmount, budget * 0.5)) * 100%` — top 1 기준 100%
+- category-tone 매핑: `src/lib/client/category-tone.ts` (plan002 의 helper 재사용)
+
+카드 wrapper:
+- `bg-bg-elev border-border rounded-2xl p-5 md:p-6`
+- 제목: "카테고리 top 5" (text-fg 14px font-semibold)
+- 부제: "이번 달 지출이 큰 순" (text-fg-muted 12px)
+
+각 row 구조:
+```tsx
+<div className="flex items-center gap-3">
+  {/* 36px 카테고리 round (tone bg + fg) */}
+  <div className="h-9 w-9 rounded-xl bg-[var(--color-cat-{tone}-bg)] flex items-center justify-center">
+    {/* 카테고리 첫 글자 또는 아이콘 */}
+    <span className="text-[var(--color-cat-{tone}-fg)] text-sm font-bold">{name[0]}</span>
+  </div>
+  {/* 본문 */}
+  <div className="flex-1 min-w-0">
+    <div className="flex justify-between items-baseline">
+      <span className="text-fg text-sm font-medium truncate">{categoryName}</span>
+      <span className="num text-fg text-sm font-bold">₩{totalAmount.toLocaleString()}</span>
+    </div>
+    <div className="mt-1.5 h-1.5 rounded-full bg-bg-muted overflow-hidden">
+      <div
+        className="h-full rounded-full"
+        style={{
+          width: `${barWidthPct}%`,
+          background: `var(--color-cat-${tone}-fg)`,
+        }}
+      />
+    </div>
+    <div className="mt-1 flex justify-between text-xs text-fg-muted">
+      <span>예산의 {budgetPct}%</span>
+      {budgetPct >= 30 && <span className="text-expense font-semibold">↑ 많음</span>}
+    </div>
+  </div>
+</div>
+```
+
+### 2. 빈 상태
+
+`items.length === 0` → "이번 달 지출이 아직 없어요" 메시지 + 카드 톤만 (plan012 EmptyState 미니 변형 또는 inline).
+
+### 3. 카테고리 톤 helper 사용
+
+`getCategoryTone(categoryColor)` (plan002 helper) — 카테고리 색 토큰을 8 팔레트 중 하나에 매핑. category-tone helper 위치:
+- `src/lib/client/category-tone.ts` 또는 plan002 의 실제 helper 경로 확인 후 import
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/013-budget-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx
+
+# top 5 slice 로직
+grep -nE 'slice\(0,\s*5\)' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1
+
+# 카테고리 톤 토큰
+grep -nE 'var\(--color-cat-' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 2
+
+# 예산 % 계산
+grep -nE 'budgetPct|budget.*100' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1
+```
+
+수동 smoke: `/budget` → top 5 카테고리 수평 bar + 예산 % + ↑많음 라벨 (30%+) 표시.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx` | 신규 (server component) |
+
+## Out of Scope
+
+- 카테고리별 예산 설정 (현재 backend 미지원 — 도메인 확장 필요)
+- 카테고리 클릭 → 해당 카테고리만 필터된 transactions 페이지 이동 (선택 기능, 본 plan 미포함)
+- 6개 이상 카테고리 "더보기" 토글
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `categoryColor` 가 OKLCH 평면 값이 아닌 hex (legacy) | category-tone helper 가 어떤 입력이든 8 톤 중 매핑하도록 설계됨. plan002 머지된 helper 사용 — 본 phase 가 helper 자체 변경 안 함 |
+| budget=0 시 budgetPct 무한대 | budget > 0 분기로 컴포넌트 자체 미렌더 (page.tsx 측 처리) |
+| 모바일 320px 폭에서 % 라벨 + 금액 줄바꿈 | `truncate` + `flex-shrink-0` 적절히. 수동 smoke 에서 확인 |
+| top 5 너무 적음 (가족 카테고리 3개만) | items.length 만큼만 렌더 (slice 가 자동 처리). 빈 row 미생성 |

--- a/tasks/plan013-budget-page-redesign/phase-04.md
+++ b/tasks/plan013-budget-page-redesign/phase-04.md
@@ -1,0 +1,112 @@
+# Phase 04 — page.tsx 데이터 페칭 통합 + 검증 + completed
+
+**Model**: haiku
+**Status**: pending
+**Goal**: `/budget` 페이지가 3 Action 을 병렬 fetch 하도록 갱신. phase 01~03 결과 통합 + 검증 + index.json completed 마킹.
+
+## 작업 항목
+
+### 1. `budget/page.tsx` 갱신 — 3 Action 병렬
+
+```tsx
+import { getDashboardStatsAction } from "@/actions/dashboard/get-dashboard-stats-action";
+import { getMonthlyDailyStatsAction } from "@/actions/dashboard/get-monthly-daily-stats-action";
+import { getMonthlyCategoryBreakdownAction } from "@/actions/dashboard/get-monthly-category-breakdown-action";
+
+const [stats, daily, breakdown] = await Promise.all([
+  getDashboardStatsAction(),
+  getMonthlyDailyStatsAction(year, month),
+  getMonthlyCategoryBreakdownAction(),
+]);
+```
+
+각 Action 결과를 `getActionDataOrDefault` 로 unwrap 후 `BudgetClient` 에 props 전달:
+
+```tsx
+<BudgetClient
+  budget={...}
+  monthlyExpense={...}
+  remainingBudget={...}
+  year={...}
+  month={...}
+  dailyExpenses={daily.items}
+  categoryItems={breakdown.items}
+/>
+```
+
+`BudgetClient.tsx` 의 props 타입 확장 + 내부에서 `BudgetCumulativeLine` / `BudgetCategoryBars` 컴포넌트 배치.
+
+### 2. 레이아웃 구조
+
+```
+<div className="p-4 md:p-6 space-y-4 md:space-y-6">
+  {/* 헤더 */}
+  <BudgetHeader year={month} />
+
+  {/* Hero — phase 01 결과 */}
+  <BudgetHeroCard ... />
+
+  {/* 3-col 통계 — phase 01 결과 */}
+  <BudgetDailyStats dailyAverage daysRemaining recommended />
+
+  {/* 라인 차트 — phase 02 (budget > 0 시만) */}
+  {hasBudget && <BudgetCumulativeLine dailyExpenses budget daysInMonth />}
+
+  {/* 카테고리 top 5 — phase 03 */}
+  <BudgetCategoryBars items budget monthlyExpense />
+
+  {/* 설정 링크 */}
+  <Link href="/settings" />
+</div>
+```
+
+데스크톱에서 라인 차트 + 카테고리 bar 를 2-col grid 로 배치하는 옵션 검토 (md+ `grid-cols-2` — 카테고리 bar 가 짧으면 라인 옆에 자연스럽게 들어감). 본 phase 에선 stack 유지 (mobile-first, desktop 도 stack 으로 충분).
+
+### 3. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/013-budget-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 4. legacy 잔재 0
+
+```bash
+! grep -rnE 'text-muted-foreground|text-destructive|bg-card\b' \
+  src/app/\(authenticated\)/budget/
+
+# 신 컴포넌트 존재
+test -f src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx
+test -f src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx
+```
+
+### 5. 수동 smoke
+
+| 시나리오 | 기대 |
+|---|---|
+| 예산 0 + `/budget` | Hero 카드 자리에 EmptyState (예산 미설정) 카드 + CTA 만 표시. 라인 차트 / 카테고리 bar 미표시 |
+| 예산 100만 + 월 지출 80만 | Hero 80% 사용률 + 라인 80만 도달 + 카테고리 top 5 정상 |
+| 예산 100만 + 월 지출 110만 | Hero 초과 톤 + 라인 예산선 위 빨간 dot + ↑많음 라벨 |
+| Dark mode | 모든 시각 요소 자연스러운 톤 |
+
+### 6. index.json completed 마킹
+
+`tasks/plan013-budget-page-redesign/index.json` 의 모든 `status` → `"completed"`, `completed_at` 필드 추가.
+
+### 7. 최종 커밋
+
+```bash
+git add tasks/plan013-budget-page-redesign/index.json
+git commit -m "chore(plan013): mark completed"
+```
+
+## Out of Scope
+
+- 카테고리별 예산 설정 / 추적
+- 월 비교 (전월 대비 추세)
+- 예산 알림 임계 (80%/100%) UI 변경 — 이미 NotificationBell 처리


### PR DESCRIPTION
## Summary

/budget 을 Dashboard BudgetHeroCard 의 확장 전용 페이지로 재설계. shadcn legacy 토큰 제거 + Teal 토큰. 일별 누적 지출 vs 예산 라인 차트 (recharts) + 통계 단락 + 카테고리 top 5 수평 bar.

## 변경 내용

- `docs/flow.md`: §14-3 /budget 페이지 구조 추가
- `tasks/plan013-budget-page-redesign/`: 4 phase task 파일
  - 01 BudgetClient Hero 카드 토큰 교체 + 3-col 통계
  - 02 BudgetCumulativeLine (recharts LineChart + ReferenceLine 예산선)
  - 03 BudgetCategoryBars (수평 bar + 예산 대비 %)
  - 04 page.tsx 데이터 페칭 통합 + 검증

## Test plan

- [ ] 머지 후 `/build-with-teams plan013` 으로 실제 구현 진행
- [ ] 예산 0 / 사용률 80% / 초과 110% / Dark mode 시나리오 smoke