### PR TITLE
chore(skills): /planning 종료 시 PR 자동 생성 정책 채택

### DIFF
--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -161,20 +161,23 @@ task 파일을 **사용자에게 제출하기 전**에 반드시 [`common-pitfal
 3. **`common-pitfalls.md` 의 P1~P9 + 패턴 소진 체크리스트 사전 소진** — task 제출 전 self-check
 4. **plan 브랜치 생성** — `git switch -c plan/{N}-{kebab-slug} origin/main`. 매 plan 마다 origin/main 기준 신규 브랜치 (이전 plan 브랜치 위에 쌓지 않는다)
 5. **git commit** — docs 변경 + task 파일을 **한 커밋** 으로 묶어 생성. commit 메시지: `docs(plan{N}): {plan 한 줄 요약}`
-6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정). **PR 생성하지 않는다** — task 만으로는 머지할 가치가 없으므로 PR 단독 머지 사고 (status="pending" 인 채 main 진입) 를 처음부터 회피
-7. **main 으로 복귀** — `git switch main`. 이후 사용자가 `/build-with-teams` 호출 시 같은 브랜치에서 작업 이어가도록
-8. 사용자 보고 + 실행 안내:
+6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정).
+7. **PR 생성** — `gh pr create --base main --head plan/{N}-{kebab-slug} --title "docs(plan{N}): {요약}" --body ...`. 본문은 변경 요약 (docs 변경 + task phase 목록) + Test plan (구현 PR 검증 항목) 포함. plan 브랜치가 main 에 머지되어야 향후 다른 세션에서 `tasks/plan{N}-*/` 를 참조할 수 있고, 머지 이력에 plan 의 존재가 남는다.
+8. **main 으로 복귀** — `git switch main`. 이후 사용자가 `/build-with-teams` 호출 시 origin/main 에서 새 `feat/plan{N}-*` 브랜치로 구현 시작.
+9. 사용자 보고 + 실행 안내:
 
-> plan{N} task 파일 생성 + push 완료 (브랜치: `plan/{N}-{kebab-slug}`).
-> `/build-with-teams plan{N}` 로 구현을 시작하면 같은 브랜치에서 phase 실행 후 PR 이 생성됩니다.
+> plan{N} task 파일 생성 + PR #{번호} 생성 완료 (브랜치: `plan/{N}-{kebab-slug}`).
+> PR 머지 후 `/build-with-teams plan{N}` 로 구현을 시작하면 `feat/plan{N}-{kebab-slug}` 브랜치에서 phase 실행 후 별도 구현 PR 이 생성됩니다.
 
-**실제 구현 (phase 실행) + PR 생성은 사용자가 명시적으로 `/build-with-teams` 를 호출할 때 시작.** planning 스킬은 task 생성 + 브랜치 push 까지만 책임진다 (PR 생성 책임 없음).
+**PR 정책 (2026-05-11 결정)**: plan 의 docs + task 변경은 별도 PR 로 머지. 구현 PR 과 분리. 이유: (a) 계획 단계 검토 + 구현 단계 검토 부담을 분산, (b) 머지 이력에서 "계획 / 구현" 식별 즉시 가능, (c) plan 머지 후 `tasks/plan{N}-*/` 가 main 에 존재해야 `/build-with-teams` 가 어디서든 시작 가능. CLAUDE.md "브랜치 명명" 표의 정책과 일치.
 
-### 왜 PR 을 생성하지 않는가
+### 중복 실행 방지
 
-- task 파일 단독 PR 은 **결과물 없는 spec 만 main 으로 머지**되는 사고 패턴 — `status="pending"` 인 채 main 에 진입하면 다른 세션에서 재실행 시 사전 검증이 통과해 중복 작업 발생 (실사례: fos-blog plan024/025 사후 정리 비용)
-- task 와 결과물을 같은 PR 에 묶으면 spec ↔ 코드 정합성을 reviewer 가 한 번에 검증 가능 — 분리된 두 PR 보다 정합 보장에 유리
-- 사용자가 며칠 후 `/build-with-teams` 로 재개해도 PR 미생성 → 머지 위험 0. 브랜치만 보존되므로 안전
+`status="pending"` 인 task 가 main 에 머지된 상태에서 다른 세션이 `/build-with-teams plan{N}` 호출 시 사전 검증이 통과해 중복 실행 위험 — 다음 가드로 방지:
+
+- `/build-with-teams` 실행 시 origin/main 의 latest `index.json` 의 `status` 가 `"completed"` 면 즉시 종료
+- 구현 phase 의 마지막 단계가 항상 `status="completed"` 마킹 + commit 포함 (CLAUDE.md "Task 작업 규칙")
+- 동일 plan 을 두 세션이 동시에 잡으면 PR 생성 시 브랜치 충돌로 자연 감지
 
 ### 예외
 


### PR DESCRIPTION
## Summary

planning 스킬의 \"완료 후 절차\" 6번 항목 변경 — task push 후 PR 미생성에서 → PR 즉시 생성으로.

## Why

기존 정책 (PR 미생성) 은 결과물 없는 spec 머지 사고를 우려했지만, 운영해보니:
- plan 브랜치만 push 되고 main 에 없는 상태 → 다른 세션이나 future 작업이 task 를 참조하기 어려움
- 구현 PR 에 task 도 함께 묶으면 PR 크기 비대 + 계획 검토 단계 부재

새 정책: docs + task 변경을 plan PR 로 머지 (작은 검토 단위) → 별도 구현 PR 로 코드 작업.

중복 실행 방지 가드는 \`/build-with-teams\` 측에서 origin/main 의 \`index.json.status\` 점검 + 구현 phase 마지막 \`status=\"completed\"\` 마킹 commit 으로 처리.

## Test plan

- [ ] 다음 \`/planning\` 호출 시 PR 자동 생성되는지 확인
- [ ] PR 본문 형식 점검 (변경 요약 + Test plan)