### PR TITLE
feat(pages): 도메인 외곽 4 페이지 Teal 리디자인 (plan010)

### DIFF
--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -95,7 +95,7 @@ src/
 ├── services/{domain}/      API 호출·변환 함수
 ├── components/
 │   ├── ui/                 Shadcn 기반 기본 컴포넌트
-│   ├── layout/             Header, BottomNavigation
+│   ├── layout/             Header, BottomNavigation, SettingsCard (페이지 카드 helper)
 │   └── {domain}/           도메인별 UI 컴포넌트
 ├── app/(authenticated)/    인증 필요 라우트 (Server Component 기본)
 ├── app/api/auth/           NextAuth API Route

--- a/src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx
+++ b/src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { createCategoryAction } from "@/actions/category/create-category-action";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,9 +11,9 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { createCategoryAction } from "@/actions/category/create-category-action";
-import { toast } from "sonner";
 import type { CategoryResponse } from "@/types/category";
+import { useState } from "react";
+import { toast } from "sonner";
 
 interface AddCategoryDialogProps {
   open: boolean;
@@ -22,57 +22,21 @@ interface AddCategoryDialogProps {
   onSuccess: (category: CategoryResponse) => void;
 }
 
-// 자주 사용하는 이모지 목록
 const commonEmojis = [
-  "🍚",
-  "☕",
-  "🍰",
-  "🏠",
-  "🚗",
-  "🛍️",
-  "💊",
-  "🎬",
-  "📚",
-  "📦",
-  "💰",
-  "🎮",
-  "🏃",
-  "✈️",
-  "📱",
-  "💻",
-  "👕",
-  "🎵",
-  "🍕",
-  "🍜",
-  "🚌",
-  "⚡",
-  "🔧",
-  "🎨",
-  "📷",
-  "🏥",
-  "🏫",
-  "💳",
-  "🎁",
-  "🌟",
+  "🍚", "☕", "🍰", "🏠", "🚗", "🛍️", "💊", "🎬", "📚", "📦",
+  "💰", "🎮", "🏃", "✈️", "📱", "💻", "👕", "🎵", "🍕", "🍜",
+  "🚌", "⚡", "🔧", "🎨", "📷", "🏥", "🏫", "💳", "🎁", "🌟",
 ];
 
-// 자주 사용하는 색상
-const commonColors = [
-  "#ef4444",
-  "#f59e0b",
-  "#ec4899",
-  "#10b981",
-  "#3b82f6",
-  "#8b5cf6",
-  "#06b6d4",
-  "#f43f5e",
-  "#14b8a6",
-  "#6b7280",
-  "#84cc16",
-  "#f97316",
-  "#a855f7",
-  "#22c55e",
-  "#0ea5e9",
+const PALETTE = [
+  "oklch(0.560 0.140 35)",   // food coral
+  "oklch(0.520 0.110 60)",   // cafe bronze
+  "oklch(0.540 0.130 230)",  // transit blue
+  "oklch(0.540 0.130 280)",  // telecom violet
+  "oklch(0.510 0.110 188)",  // home teal
+  "oklch(0.560 0.140 330)",  // shopping pink
+  "oklch(0.520 0.120 152)",  // health green
+  "oklch(0.520 0.120 105)",  // leisure olive
 ];
 
 export function AddCategoryDialog({
@@ -81,8 +45,38 @@ export function AddCategoryDialog({
   familyUuid,
   onSuccess,
 }: AddCategoryDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>카테고리 추가</DialogTitle>
+          <DialogDescription>새로운 지출 카테고리를 추가합니다</DialogDescription>
+        </DialogHeader>
+        {open ? (
+          <AddCategoryDialogBody
+            familyUuid={familyUuid}
+            onOpenChange={onOpenChange}
+            onSuccess={onSuccess}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface AddCategoryDialogBodyProps {
+  familyUuid: string;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (category: CategoryResponse) => void;
+}
+
+function AddCategoryDialogBody({
+  familyUuid,
+  onOpenChange,
+  onSuccess,
+}: AddCategoryDialogBodyProps) {
   const [name, setName] = useState("");
-  const [color, setColor] = useState("#6366f1");
+  const [color, setColor] = useState(PALETTE[0]);
   const [icon, setIcon] = useState("📦");
   const [excludeFromBudget, setExcludeFromBudget] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -108,11 +102,6 @@ export function AddCategoryDialog({
         toast.success("카테고리가 생성되었습니다");
         onSuccess(result.data);
         onOpenChange(false);
-        // 폼 리셋
-        setName("");
-        setColor("#6366f1");
-        setIcon("📦");
-        setExcludeFromBudget(false);
       } else {
         toast.error(result.error.message);
       }
@@ -124,117 +113,96 @@ export function AddCategoryDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>카테고리 추가</DialogTitle>
-          <DialogDescription>
-            새로운 지출 카테고리를 추가합니다
-          </DialogDescription>
-        </DialogHeader>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="name">카테고리 이름 *</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="예: 식비, 교통비"
+          required
+        />
+      </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* 카테고리 이름 */}
-          <div className="space-y-2">
-            <Label htmlFor="name">카테고리 이름 *</Label>
-            <Input
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="예: 식비, 교통비"
-              required
-            />
-          </div>
-
-          {/* 아이콘 선택 */}
-          <div className="space-y-2">
-            <Label>아이콘</Label>
-            <div className="flex items-center gap-2 mb-2">
-              <div className="text-3xl">{icon}</div>
-              <Input
-                value={icon}
-                onChange={(e) => setIcon(e.target.value)}
-                className="flex-1"
-                placeholder="이모지 입력"
-              />
-            </div>
-            <div className="grid grid-cols-10 gap-1 p-2 border rounded-md max-h-32 overflow-y-auto">
-              {commonEmojis.map((emoji) => (
-                <button
-                  key={emoji}
-                  type="button"
-                  onClick={() => setIcon(emoji)}
-                  className={`text-2xl p-1 hover:bg-gray-100 rounded ${
-                    icon === emoji ? "bg-gray-200" : ""
-                  }`}
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* 색상 선택 */}
-          <div className="space-y-2">
-            <Label>색상</Label>
-            <div className="flex items-center gap-2 mb-2">
-              <div
-                className="w-10 h-10 rounded border"
-                style={{ backgroundColor: color }}
-              />
-              <Input
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-                className="flex-1"
-              />
-            </div>
-            <div className="grid grid-cols-10 gap-1 p-2 border rounded-md">
-              {commonColors.map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  onClick={() => setColor(c)}
-                  className={`w-8 h-8 rounded border-2 ${
-                    color === c ? "border-gray-900" : "border-transparent"
-                  }`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* 예산 포함 여부 */}
-          <div className="flex items-center space-x-2">
-            <input
-              type="checkbox"
-              id="excludeFromBudget"
-              checked={excludeFromBudget}
-              onChange={(e) => setExcludeFromBudget(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
-            <Label htmlFor="excludeFromBudget" className="cursor-pointer">
-              예산 합계에서 제외
-            </Label>
-          </div>
-
-          {/* 버튼 */}
-          <div className="flex gap-2 pt-4">
-            <Button
+      <div className="space-y-2">
+        <Label>아이콘</Label>
+        <div className="flex items-center gap-2 mb-2">
+          <div className="text-3xl">{icon}</div>
+          <Input
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            className="flex-1"
+            placeholder="이모지 입력"
+          />
+        </div>
+        <div className="grid grid-cols-10 gap-1 p-2 border rounded-md max-h-32 overflow-y-auto">
+          {commonEmojis.map((emoji) => (
+            <button
+              key={emoji}
               type="button"
-              variant="outline"
-              className="flex-1"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
+              onClick={() => setIcon(emoji)}
+              className={`text-2xl p-1 rounded hover:bg-bg-muted ${
+                icon === emoji ? "bg-bg-muted" : ""
+              }`}
             >
-              취소
-            </Button>
-            <Button type="submit" className="flex-1" disabled={isSubmitting}>
-              {isSubmitting ? "추가 중..." : "추가"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+              {emoji}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>색상</Label>
+        <div className="flex items-center gap-2 mb-2">
+          <div
+            className="w-10 h-10 rounded border border-border shrink-0"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-xs text-fg-muted flex-1 truncate">{color}</span>
+        </div>
+        <div className="flex flex-wrap gap-2 p-2 border border-border rounded-md">
+          {PALETTE.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setColor(c)}
+              className={`w-8 h-8 rounded-full border-2 transition-transform ${
+                color === c ? "border-fg scale-110" : "border-transparent"
+              }`}
+              style={{ backgroundColor: c }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          id="excludeFromBudget"
+          checked={excludeFromBudget}
+          onChange={(e) => setExcludeFromBudget(e.target.checked)}
+          className="h-4 w-4 rounded border-border"
+        />
+        <Label htmlFor="excludeFromBudget" className="cursor-pointer">
+          예산 합계에서 제외
+        </Label>
+      </div>
+
+      <div className="flex gap-2 pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={() => onOpenChange(false)}
+          disabled={isSubmitting}
+        >
+          취소
+        </Button>
+        <Button type="submit" className="flex-1" disabled={isSubmitting}>
+          {isSubmitting ? "추가 중..." : "추가"}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx
+++ b/src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import type { CategoryResponse } from "@/types/category";
 import { useState } from "react";
 import { toast } from "sonner";
+import { PALETTE, commonEmojis } from "./category-constants";
 
 interface AddCategoryDialogProps {
   open: boolean;
@@ -21,23 +22,6 @@ interface AddCategoryDialogProps {
   familyUuid: string;
   onSuccess: (category: CategoryResponse) => void;
 }
-
-const commonEmojis = [
-  "🍚", "☕", "🍰", "🏠", "🚗", "🛍️", "💊", "🎬", "📚", "📦",
-  "💰", "🎮", "🏃", "✈️", "📱", "💻", "👕", "🎵", "🍕", "🍜",
-  "🚌", "⚡", "🔧", "🎨", "📷", "🏥", "🏫", "💳", "🎁", "🌟",
-];
-
-const PALETTE = [
-  "oklch(0.560 0.140 35)",   // food coral
-  "oklch(0.520 0.110 60)",   // cafe bronze
-  "oklch(0.540 0.130 230)",  // transit blue
-  "oklch(0.540 0.130 280)",  // telecom violet
-  "oklch(0.510 0.110 188)",  // home teal
-  "oklch(0.560 0.140 330)",  // shopping pink
-  "oklch(0.520 0.120 152)",  // health green
-  "oklch(0.520 0.120 105)",  // leisure olive
-];
 
 export function AddCategoryDialog({
   open,

--- a/src/app/(authenticated)/categories/_components/CategoryItem.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryItem.tsx
@@ -15,7 +15,7 @@ interface CategoryItemProps {
 function withAlpha(color: string | undefined, a: number): string {
   if (!color) return `oklch(0.510 0.110 188 / ${a})`;
   if (color.startsWith("oklch(")) {
-    return color.replace(/\)$/, ` / ${a})`);
+    return color.replace(/(\s*\/\s*[\d.]+)?\)$/, ` / ${a})`);
   }
   // hex fallback: append 2-digit hex alpha (e.g. 0.16 → "29")
   const hex = Math.round(a * 255).toString(16).padStart(2, "0");

--- a/src/app/(authenticated)/categories/_components/CategoryItem.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryItem.tsx
@@ -12,6 +12,16 @@ interface CategoryItemProps {
   onDelete: (category: CategoryResponse) => void;
 }
 
+function withAlpha(color: string | undefined, a: number): string {
+  if (!color) return `oklch(0.510 0.110 188 / ${a})`;
+  if (color.startsWith("oklch(")) {
+    return color.replace(/\)$/, ` / ${a})`);
+  }
+  // hex fallback: append 2-digit hex alpha (e.g. 0.16 → "29")
+  const hex = Math.round(a * 255).toString(16).padStart(2, "0");
+  return color + hex;
+}
+
 export function CategoryItem({
   category,
   onEdit,
@@ -24,7 +34,10 @@ export function CategoryItem({
           <div className="flex items-start justify-between">
             <div
               className="w-10 h-8 md:w-12 md:h-12 rounded-lg flex items-center justify-center text-xl md:text-2xl shrink-0"
-              style={{ backgroundColor: category.color + "20" }}
+              style={{
+                backgroundColor: withAlpha(category.color, 0.16),
+                color: category.color,
+              }}
             >
               {category.icon}
             </div>
@@ -43,14 +56,14 @@ export function CategoryItem({
                 className="h-6 w-6 md:h-8 md:w-8"
                 onClick={() => onDelete(category)}
               >
-                <Trash2 className="w-3 h-3 md:w-4 md:h-4 text-red-500" />
+                <Trash2 className="w-3 h-3 md:w-4 md:h-4 text-expense" />
               </Button>
             </div>
           </div>
 
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
-              <h3 className="font-semibold text-sm md:text-base text-gray-900 truncate">
+              <h3 className="font-semibold text-sm md:text-base text-fg truncate">
                 {category.name}
               </h3>
 
@@ -62,7 +75,7 @@ export function CategoryItem({
               {category.excludeFromBudget && (
                 <Badge
                   variant="secondary"
-                  className="text-[10px] px-1.5 py-0 h-5 gap-1 text-gray-500 w-fit whitespace-nowrap shrink-0"
+                  className="text-[10px] px-1.5 py-0 h-5 gap-1 text-fg-muted w-fit whitespace-nowrap shrink-0"
                 >
                   <EyeOff className="w-3 h-3" />
                   <span className="hidden md:inline">예산 제외</span>
@@ -75,7 +88,7 @@ export function CategoryItem({
                 className="w-3 h-3 md:w-4 md:h-4 rounded-full"
                 style={{ backgroundColor: category.color }}
               />
-              <span className="text-xs text-gray-500">{category.color}</span>
+              <span className="text-xs text-fg-subtle">{category.color}</span>
             </div>
           </div>
         </div>

--- a/src/app/(authenticated)/categories/_components/CategoryList.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryList.tsx
@@ -56,7 +56,7 @@ export function CategoryList({
     return (
       <Card>
         <CardContent className="py-12">
-          <div className="text-center text-gray-500">
+          <div className="text-center text-fg-muted">
             <p className="text-lg mb-2">등록된 카테고리가 없습니다</p>
             <p className="text-sm">카테고리를 추가해주세요</p>
           </div>

--- a/src/app/(authenticated)/categories/_components/CategoryPageClient.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryPageClient.tsx
@@ -57,9 +57,9 @@ export function CategoryPageClient({
   return (
     <>
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-fg-muted">
           총{" "}
-          <span className="font-semibold text-gray-900">
+          <span className="font-semibold text-fg">
             {categories.length}
           </span>
           개의 카테고리

--- a/src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx
+++ b/src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import type { CategoryResponse } from "@/types/category";
 import { useState } from "react";
 import { toast } from "sonner";
+import { PALETTE, commonEmojis } from "./category-constants";
 
 interface EditCategoryDialogProps {
   open: boolean;
@@ -21,23 +22,6 @@ interface EditCategoryDialogProps {
   category: CategoryResponse;
   onSuccess: (category: CategoryResponse) => void;
 }
-
-const commonEmojis = [
-  "🍚", "☕", "🍰", "🏠", "🚗", "🛍️", "💊", "🎬", "📚", "📦",
-  "💰", "🎮", "🏃", "✈️", "📱", "💻", "👕", "🎵", "🍕", "🍜",
-  "🚌", "⚡", "🔧", "🎨", "📷", "🏥", "🏫", "💳", "🎁", "🌟",
-];
-
-const PALETTE = [
-  "oklch(0.560 0.140 35)",   // food coral
-  "oklch(0.520 0.110 60)",   // cafe bronze
-  "oklch(0.540 0.130 230)",  // transit blue
-  "oklch(0.540 0.130 280)",  // telecom violet
-  "oklch(0.510 0.110 188)",  // home teal
-  "oklch(0.560 0.140 330)",  // shopping pink
-  "oklch(0.520 0.120 152)",  // health green
-  "oklch(0.520 0.120 105)",  // leisure olive
-];
 
 export function EditCategoryDialog({
   open,

--- a/src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx
+++ b/src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { CategoryResponse } from "@/types/category";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 interface EditCategoryDialogProps {
@@ -22,57 +22,21 @@ interface EditCategoryDialogProps {
   onSuccess: (category: CategoryResponse) => void;
 }
 
-// 자주 사용하는 이모지 목록
 const commonEmojis = [
-  "🍚",
-  "☕",
-  "🍰",
-  "🏠",
-  "🚗",
-  "🛍️",
-  "💊",
-  "🎬",
-  "📚",
-  "📦",
-  "💰",
-  "🎮",
-  "🏃",
-  "✈️",
-  "📱",
-  "💻",
-  "👕",
-  "🎵",
-  "🍕",
-  "🍜",
-  "🚌",
-  "⚡",
-  "🔧",
-  "🎨",
-  "📷",
-  "🏥",
-  "🏫",
-  "💳",
-  "🎁",
-  "🌟",
+  "🍚", "☕", "🍰", "🏠", "🚗", "🛍️", "💊", "🎬", "📚", "📦",
+  "💰", "🎮", "🏃", "✈️", "📱", "💻", "👕", "🎵", "🍕", "🍜",
+  "🚌", "⚡", "🔧", "🎨", "📷", "🏥", "🏫", "💳", "🎁", "🌟",
 ];
 
-// 자주 사용하는 색상
-const commonColors = [
-  "#ef4444",
-  "#f59e0b",
-  "#ec4899",
-  "#10b981",
-  "#3b82f6",
-  "#8b5cf6",
-  "#06b6d4",
-  "#f43f5e",
-  "#14b8a6",
-  "#6b7280",
-  "#84cc16",
-  "#f97316",
-  "#a855f7",
-  "#22c55e",
-  "#0ea5e9",
+const PALETTE = [
+  "oklch(0.560 0.140 35)",   // food coral
+  "oklch(0.520 0.110 60)",   // cafe bronze
+  "oklch(0.540 0.130 230)",  // transit blue
+  "oklch(0.540 0.130 280)",  // telecom violet
+  "oklch(0.510 0.110 188)",  // home teal
+  "oklch(0.560 0.140 330)",  // shopping pink
+  "oklch(0.520 0.120 152)",  // health green
+  "oklch(0.520 0.120 105)",  // leisure olive
 ];
 
 export function EditCategoryDialog({
@@ -81,6 +45,37 @@ export function EditCategoryDialog({
   category,
   onSuccess,
 }: EditCategoryDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>카테고리 수정</DialogTitle>
+          <DialogDescription>카테고리 정보를 수정합니다</DialogDescription>
+        </DialogHeader>
+        {open ? (
+          <EditCategoryDialogBody
+            key={category.uuid}
+            category={category}
+            onOpenChange={onOpenChange}
+            onSuccess={onSuccess}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface EditCategoryDialogBodyProps {
+  category: CategoryResponse;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: (category: CategoryResponse) => void;
+}
+
+function EditCategoryDialogBody({
+  category,
+  onOpenChange,
+  onSuccess,
+}: EditCategoryDialogBodyProps) {
   const [name, setName] = useState(category.name);
   const [color, setColor] = useState(category.color);
   const [icon, setIcon] = useState(category.icon || "📦");
@@ -88,13 +83,6 @@ export function EditCategoryDialog({
     category.excludeFromBudget || false,
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  useEffect(() => {
-    setName(category.name);
-    setColor(category.color);
-    setIcon(category.icon || "📦");
-    setExcludeFromBudget(category.excludeFromBudget || false);
-  }, [category]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -128,113 +116,96 @@ export function EditCategoryDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>카테고리 수정</DialogTitle>
-          <DialogDescription>카테고리 정보를 수정합니다</DialogDescription>
-        </DialogHeader>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="name">카테고리 이름 *</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="예: 식비, 교통비"
+          required
+        />
+      </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* 카테고리 이름 */}
-          <div className="space-y-2">
-            <Label htmlFor="name">카테고리 이름 *</Label>
-            <Input
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="예: 식비, 교통비"
-              required
-            />
-          </div>
-
-          {/* 아이콘 선택 */}
-          <div className="space-y-2">
-            <Label>아이콘</Label>
-            <div className="flex items-center gap-2 mb-2">
-              <div className="text-3xl">{icon}</div>
-              <Input
-                value={icon}
-                onChange={(e) => setIcon(e.target.value)}
-                className="flex-1"
-                placeholder="이모지 입력"
-              />
-            </div>
-            <div className="grid grid-cols-10 gap-1 p-2 border rounded-md max-h-32 overflow-y-auto">
-              {commonEmojis.map((emoji) => (
-                <button
-                  key={emoji}
-                  type="button"
-                  onClick={() => setIcon(emoji)}
-                  className={`text-2xl p-1 hover:bg-gray-100 rounded ${
-                    icon === emoji ? "bg-gray-200" : ""
-                  }`}
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* 색상 선택 */}
-          <div className="space-y-2">
-            <Label>색상</Label>
-            <div className="flex items-center gap-2 mb-2">
-              <div
-                className="w-10 h-10 rounded border"
-                style={{ backgroundColor: color }}
-              />
-              <Input
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-                className="flex-1"
-              />
-            </div>
-            <div className="grid grid-cols-10 gap-1 p-2 border rounded-md">
-              {commonColors.map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  onClick={() => setColor(c)}
-                  className={`w-8 h-8 rounded border-2 ${
-                    color === c ? "border-gray-900" : "border-transparent"
-                  }`}
-                  style={{ backgroundColor: c }}
-                />
-              ))}
-            </div>
-          </div>
-
-          <div className="flex items-center space-x-2">
-            <input
-              type="checkbox"
-              id="excludeFromBudget-edit"
-              checked={excludeFromBudget}
-              onChange={(e) => setExcludeFromBudget(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-            />
-            <Label htmlFor="excludeFromBudget-edit" className="cursor-pointer">
-              예산 합계에서 제외
-            </Label>
-          </div>
-
-          <div className="flex gap-2 pt-4">
-            <Button
+      <div className="space-y-2">
+        <Label>아이콘</Label>
+        <div className="flex items-center gap-2 mb-2">
+          <div className="text-3xl">{icon}</div>
+          <Input
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            className="flex-1"
+            placeholder="이모지 입력"
+          />
+        </div>
+        <div className="grid grid-cols-10 gap-1 p-2 border rounded-md max-h-32 overflow-y-auto">
+          {commonEmojis.map((emoji) => (
+            <button
+              key={emoji}
               type="button"
-              variant="outline"
-              className="flex-1"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
+              onClick={() => setIcon(emoji)}
+              className={`text-2xl p-1 rounded hover:bg-bg-muted ${
+                icon === emoji ? "bg-bg-muted" : ""
+              }`}
             >
-              취소
-            </Button>
-            <Button type="submit" className="flex-1" disabled={isSubmitting}>
-              {isSubmitting ? "수정 중..." : "수정"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+              {emoji}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>색상</Label>
+        <div className="flex items-center gap-2 mb-2">
+          <div
+            className="w-10 h-10 rounded border border-border shrink-0"
+            style={{ backgroundColor: color }}
+          />
+          <span className="text-xs text-fg-muted flex-1 truncate">{color}</span>
+        </div>
+        <div className="flex flex-wrap gap-2 p-2 border border-border rounded-md">
+          {PALETTE.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setColor(c)}
+              className={`w-8 h-8 rounded-full border-2 transition-transform ${
+                color === c ? "border-fg scale-110" : "border-transparent"
+              }`}
+              style={{ backgroundColor: c }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          id="excludeFromBudget-edit"
+          checked={excludeFromBudget}
+          onChange={(e) => setExcludeFromBudget(e.target.checked)}
+          className="h-4 w-4 rounded border-border"
+        />
+        <Label htmlFor="excludeFromBudget-edit" className="cursor-pointer">
+          예산 합계에서 제외
+        </Label>
+      </div>
+
+      <div className="flex gap-2 pt-4">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1"
+          onClick={() => onOpenChange(false)}
+          disabled={isSubmitting}
+        >
+          취소
+        </Button>
+        <Button type="submit" className="flex-1" disabled={isSubmitting}>
+          {isSubmitting ? "수정 중..." : "수정"}
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/src/app/(authenticated)/categories/_components/category-constants.ts
+++ b/src/app/(authenticated)/categories/_components/category-constants.ts
@@ -1,0 +1,16 @@
+export const PALETTE: string[] = [
+  "oklch(0.560 0.140 35)",   // food coral
+  "oklch(0.520 0.110 60)",   // cafe bronze
+  "oklch(0.540 0.130 230)",  // transit blue
+  "oklch(0.540 0.130 280)",  // telecom violet
+  "oklch(0.510 0.110 188)",  // home teal
+  "oklch(0.560 0.140 330)",  // shopping pink
+  "oklch(0.520 0.120 152)",  // health green
+  "oklch(0.520 0.120 105)",  // leisure olive
+];
+
+export const commonEmojis: string[] = [
+  "🍚", "☕", "🍰", "🏠", "🚗", "🛍️", "💊", "🎬", "📚", "📦",
+  "💰", "🎮", "🏃", "✈️", "📱", "💻", "👕", "🎵", "🍕", "🍜",
+  "🚌", "⚡", "🔧", "🎨", "📷", "🏥", "🏫", "💳", "🎁", "🌟",
+];

--- a/src/app/(authenticated)/categories/page.tsx
+++ b/src/app/(authenticated)/categories/page.tsx
@@ -26,8 +26,8 @@ export default async function CategoriesPage() {
   return (
     <div className="container mx-auto py-6 px-4 max-w-4xl">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">카테고리 관리</h1>
-        <p className="text-gray-600 mt-1">
+        <h1 className="text-2xl font-bold text-fg">카테고리 관리</h1>
+        <p className="text-fg-muted mt-1">
           지출 카테고리를 추가, 수정, 삭제할 수 있습니다
         </p>
       </div>

--- a/src/app/(authenticated)/families/create/page.tsx
+++ b/src/app/(authenticated)/families/create/page.tsx
@@ -11,14 +11,23 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SegmentedToggle } from "@/components/ui/segmented-toggle";
 import { useSessionRefresh } from "@/lib/client/use-session-refresh";
+import { Users } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
 
+const FAMILY_TYPE_OPTIONS = [
+  { key: "family", label: "가족" },
+  { key: "personal", label: "개인" },
+] as const;
+
+type FamilyType = "personal" | "family";
+
 export default function CreateFamilyPage() {
   const [familyName, setFamilyName] = useState("");
-  const [familyType, setFamilyType] = useState<"personal" | "family">("family");
+  const [familyType, setFamilyType] = useState<FamilyType>("family");
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
   const { refreshSession } = useSessionRefresh();
@@ -34,18 +43,14 @@ export default function CreateFamilyPage() {
     setIsLoading(true);
 
     try {
-      // Server Action 호출 (백엔드 Access Token은 서버의 HTTP-only 쿠키에서 자동 전달)
       const result = await createFamilyAction({
         name: familyName.trim(),
         description: familyType === "personal" ? "개인 가계부" : undefined,
       });
 
       if (result.success) {
-        // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
         await refreshSession();
         toast.success("가족이 성공적으로 생성되었습니다!");
-        // 백엔드에서 첫 가족 생성 시 자동으로 defaultFamilyUuid 설정됨
-        // 대시보드로 바로 이동 (홈에서 리다이렉트 처리)
         router.push("/dashboard");
       } else {
         toast.error(result.error.message);
@@ -63,14 +68,17 @@ export default function CreateFamilyPage() {
   };
 
   return (
-    <div className="min-h-screen app-background p-4">
+    <div className="min-h-screen bg-bg p-4">
       <div className="max-w-md mx-auto pt-20">
-        <Card className="glass-card">
-          <CardHeader className="text-center">
-            <CardTitle className="text-2xl font-bold text-primary">
-              가족 만들기
+        <Card className="bg-bg-elev border-border shadow-default">
+          <CardHeader className="text-center pt-8 pb-4">
+            <div className="mx-auto mb-3 w-24 h-24 rounded-full gradient-family flex items-center justify-center">
+              <Users className="w-10 h-10 text-white" strokeWidth={2.2} />
+            </div>
+            <CardTitle className="text-2xl font-bold tracking-tight text-fg">
+              우리집 가계부 시작하기
             </CardTitle>
-            <CardDescription>
+            <CardDescription className="text-fg-muted">
               새로운 가족을 만들어 가계부를 시작해보세요
             </CardDescription>
           </CardHeader>
@@ -80,29 +88,14 @@ export default function CreateFamilyPage() {
               {/* 가족 타입 선택 */}
               <div className="space-y-3">
                 <Label className="text-sm font-medium">가족 타입</Label>
-                <div className="grid grid-cols-2 gap-3">
-                  <Button
-                    type="button"
-                    variant={familyType === "personal" ? "default" : "outline"}
-                    onClick={() => setFamilyType("personal")}
-                    className="h-12"
-                  >
-                    <div className="text-center">
-                      <div className="text-lg">👤</div>
-                      <div className="text-xs">혼자 사용</div>
-                    </div>
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={familyType === "family" ? "default" : "outline"}
-                    onClick={() => setFamilyType("family")}
-                    className="h-12"
-                  >
-                    <div className="text-center">
-                      <div className="text-lg">👨‍👩‍👧‍👦</div>
-                      <div className="text-xs">가족과 함께</div>
-                    </div>
-                  </Button>
+                <div className="flex justify-center">
+                  <SegmentedToggle
+                    options={FAMILY_TYPE_OPTIONS}
+                    value={familyType}
+                    onChange={(v) => setFamilyType(v as FamilyType)}
+                    disabled={isLoading}
+                    ariaLabel="가족 타입 선택"
+                  />
                 </div>
               </div>
 
@@ -129,12 +122,12 @@ export default function CreateFamilyPage() {
               {/* 제출 버튼 */}
               <Button
                 type="submit"
-                className="w-full h-12 text-white gradient-primary hover:opacity-90"
+                className="w-full h-12 bg-brand-500 hover:bg-brand-600 text-white"
                 disabled={isLoading}
               >
                 {isLoading ? (
                   <div className="flex items-center justify-center">
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
+                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
                     생성 중...
                   </div>
                 ) : (
@@ -143,14 +136,14 @@ export default function CreateFamilyPage() {
               </Button>
             </form>
 
-            {/* 설명 텍스트 */}
-            <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-              <h4 className="font-medium text-sm text-blue-900 mb-2">
+            {/* 안내 박스 */}
+            <div className="mt-6 p-4 bg-brand-50 rounded-md border border-brand-100">
+              <h4 className="font-semibold text-sm text-brand-700 mb-1">
                 {familyType === "personal"
                   ? "혼자 사용하기"
                   : "가족과 함께 사용하기"}
               </h4>
-              <p className="text-xs text-blue-700">
+              <p className="text-xs text-brand-700/80">
                 {familyType === "personal"
                   ? "개인 지출을 관리할 수 있는 가계부를 만듭니다. 언제든지 가족을 초대할 수 있습니다."
                   : "가족 구성원들과 함께 지출을 관리할 수 있는 공유 가계부를 만듭니다."}

--- a/src/app/(authenticated)/families/create/page.tsx
+++ b/src/app/(authenticated)/families/create/page.tsx
@@ -92,7 +92,7 @@ export default function CreateFamilyPage() {
                   <SegmentedToggle
                     options={FAMILY_TYPE_OPTIONS}
                     value={familyType}
-                    onChange={(v) => setFamilyType(v as FamilyType)}
+                    onChange={(v) => setFamilyType(v)}
                     disabled={isLoading}
                     ariaLabel="가족 타입 선택"
                   />

--- a/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
+++ b/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
@@ -152,8 +152,9 @@ export function SettingsPageClient({
                         >
                           {family.name}
                           {currentDefaultFamily === family.uuid && (
-                            <span className="inline-flex items-center gap-1 ml-2 text-brand-500">
+                            <span className="inline-flex items-center gap-1 ml-2 text-brand-500 text-xs font-medium">
                               <Check className="w-3.5 h-3.5" strokeWidth={2.6} />
+                              현재 기본
                             </span>
                           )}
                         </span>

--- a/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
+++ b/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
@@ -2,11 +2,12 @@
 
 import { updateFamilyAction } from "@/actions/family/update-family-action";
 import { setDefaultFamilyAction } from "@/actions/user/set-default-family-action";
+import { SettingsCard } from "@/components/layout/SettingsCard";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/client/utils";
 import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { Check, DollarSign, Edit2, Save, Users, X } from "lucide-react";
@@ -45,7 +46,6 @@ export function SettingsPageClient({
 
       if (result.success) {
         setCurrentDefaultFamily(selectedFamily);
-        // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
         await refreshSession();
         toast.success("기본 가족이 설정되었습니다");
         router.refresh();
@@ -107,98 +107,100 @@ export function SettingsPageClient({
     <div className="max-w-4xl mx-auto space-y-6">
       {/* 헤더 */}
       <div>
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
-          설정
-        </h1>
-        <p className="text-sm md:text-base text-gray-600">
-          가계부 설정을 관리합니다
+        <h1 className="text-2xl md:text-3xl font-bold text-fg mb-2">설정</h1>
+        <p className="text-sm md:text-base text-fg-muted">
+          가족 · 예산 · 알림 관리
         </p>
       </div>
 
-      {/* 기본 가족 설정 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="w-5 h-5" />
-            기본 가족 설정
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-gray-600">
-            앱 진입 시 기본으로 보여질 가족 가계부를 선택하세요.
-          </p>
-
-          <RadioGroup
-            value={selectedFamily || currentDefaultFamily}
-            onValueChange={setSelectedFamily}
-            className="space-y-3"
-          >
-            {families.map((family) => (
-              <div
-                key={family.uuid}
-                className="flex items-center space-x-2 p-4 border rounded-lg hover:bg-gray-50 transition-colors"
-              >
-                <RadioGroupItem value={family.uuid} id={family.uuid} />
-                <Label
-                  htmlFor={family.uuid}
-                  className="flex-1 cursor-pointer flex items-center justify-between"
-                >
-                  <div className="flex flex-col">
-                    <span className="font-medium text-gray-900">
-                      {family.name}
-                    </span>
-                    <span className="text-sm text-gray-500">
-                      구성원 {family.members?.length || 0}명 · 지출{" "}
-                      {family.expenseCount || 0}건
-                    </span>
-                  </div>
-                  {currentDefaultFamily === family.uuid && (
-                    <div className="flex items-center gap-1 text-sm text-green-600">
-                      <Check className="w-4 h-4" />
-                      현재 기본
-                    </div>
-                  )}
-                </Label>
-              </div>
-            ))}
-          </RadioGroup>
-
-          <div className="flex justify-end gap-3 pt-4">
-            <Button
-              onClick={handleSaveDefaultFamily}
-              disabled={
-                isSaving ||
-                !selectedFamily ||
-                selectedFamily === currentDefaultFamily
-              }
-              className="gradient-primary hover:opacity-90 text-white"
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* 기본 가족 설정 — full width */}
+        <SettingsCard
+          icon={Users}
+          title="기본 가족 설정"
+          subtitle="앱 시작 시 보여줄 가족을 선택하세요"
+          className="md:col-span-2"
+        >
+          <div className="px-2 pt-2 pb-3">
+            <RadioGroup
+              value={selectedFamily || currentDefaultFamily}
+              onValueChange={setSelectedFamily}
+              className="space-y-1"
             >
-              {isSaving ? "저장 중..." : "기본 가족으로 설정"}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+              {families.map((family) => {
+                const isSelected =
+                  (selectedFamily || currentDefaultFamily) === family.uuid;
+                return (
+                  <div
+                    key={family.uuid}
+                    className={cn(
+                      "flex items-center gap-3 p-3 rounded-md cursor-pointer transition-colors",
+                      isSelected ? "bg-brand-50" : "hover:bg-bg-muted"
+                    )}
+                  >
+                    <RadioGroupItem value={family.uuid} id={family.uuid} />
+                    <Label
+                      htmlFor={family.uuid}
+                      className="flex-1 cursor-pointer flex items-center justify-between"
+                    >
+                      <div className="flex flex-col">
+                        <span
+                          className={cn(
+                            "font-semibold text-sm",
+                            isSelected ? "text-brand-700" : "text-fg"
+                          )}
+                        >
+                          {family.name}
+                          {currentDefaultFamily === family.uuid && (
+                            <span className="inline-flex items-center gap-1 ml-2 text-brand-500">
+                              <Check className="w-3.5 h-3.5" strokeWidth={2.6} />
+                            </span>
+                          )}
+                        </span>
+                        <span className="text-xs text-fg-muted mt-0.5">
+                          구성원 {family.members?.length || 0}명 · 지출{" "}
+                          {family.expenseCount || 0}건
+                        </span>
+                      </div>
+                    </Label>
+                  </div>
+                );
+              })}
+            </RadioGroup>
 
-      {/* 월 예산 설정 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <DollarSign className="w-5 h-5" />월 예산 설정
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-gray-600 mb-4">
-            각 가족의 월 예산을 설정하세요. 예산을 초과하면 알림을 받을 수
-            있습니다.
-          </p>
-          <div className="space-y-3">
-            {families.map((family) => (
+            <div className="flex justify-end pt-3">
+              <Button
+                onClick={handleSaveDefaultFamily}
+                disabled={
+                  isSaving ||
+                  !selectedFamily ||
+                  selectedFamily === currentDefaultFamily
+                }
+                className="gradient-primary hover:opacity-90 text-white"
+              >
+                {isSaving ? "저장 중..." : "기본 가족으로 설정"}
+              </Button>
+            </div>
+          </div>
+        </SettingsCard>
+
+        {/* 월 예산 설정 */}
+        <SettingsCard
+          icon={DollarSign}
+          title="가족별 예산 설정"
+          subtitle="이번 달 목표 예산을 입력하세요"
+        >
+          <div className="flex flex-col">
+            {families.map((family, i) => (
               <div
                 key={family.uuid}
-                className="flex items-center justify-between p-4 border rounded-lg"
+                className={cn(
+                  "flex items-center justify-between px-5 py-3",
+                  i > 0 && "border-t border-border"
+                )}
               >
                 <div className="flex-1">
-                  <h3 className="font-medium text-gray-900">{family.name}</h3>
+                  <h3 className="font-medium text-fg text-sm">{family.name}</h3>
                   {editingBudget === family.uuid ? (
                     <div className="flex items-center gap-2 mt-2">
                       <Input
@@ -213,12 +215,12 @@ export function SettingsPageClient({
                           })
                         }
                         placeholder="월 예산 입력"
-                        className="w-48"
+                        className="w-36"
                       />
-                      <span className="text-sm text-gray-500">원</span>
+                      <span className="text-xs text-fg-muted">원</span>
                     </div>
                   ) : (
-                    <p className="text-sm text-gray-500 mt-1">
+                    <p className="text-xs text-fg-muted mt-0.5">
                       {family.monthlyBudget > 0
                         ? `월 예산: ${family.monthlyBudget.toLocaleString()}원`
                         : "예산 미설정"}
@@ -260,26 +262,26 @@ export function SettingsPageClient({
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </SettingsCard>
 
-      {/* 가족 목록 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="w-5 h-5" />내 가족 목록
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {families.map((family) => (
+        {/* 내 가족 목록 */}
+        <SettingsCard
+          icon={Users}
+          title="내 가족 목록"
+          subtitle="가족을 선택해 구성원·카테고리를 관리하세요"
+        >
+          <div className="flex flex-col">
+            {families.map((family, i) => (
               <div
                 key={family.uuid}
-                className="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50 transition-colors"
+                className={cn(
+                  "flex items-center justify-between px-5 py-3 hover:bg-bg-muted transition-colors",
+                  i > 0 && "border-t border-border"
+                )}
               >
                 <div>
-                  <h3 className="font-medium text-gray-900">{family.name}</h3>
-                  <p className="text-sm text-gray-500">
+                  <h3 className="font-medium text-fg text-sm">{family.name}</h3>
+                  <p className="text-xs text-fg-muted mt-0.5">
                     구성원 {family.members?.length || 0}명 · 카테고리{" "}
                     {family.categories?.length || 0}개 · 지출{" "}
                     {family.expenseCount || 0}건
@@ -295,8 +297,8 @@ export function SettingsPageClient({
               </div>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </SettingsCard>
+      </div>
     </div>
   );
 }

--- a/src/components/families/FamilySelector.tsx
+++ b/src/components/families/FamilySelector.tsx
@@ -7,6 +7,7 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/client/utils";
 import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { ChevronRight, Plus, User, Users } from "lucide-react";
@@ -29,10 +30,8 @@ export function FamilySelector({
   const { refreshSession } = useSessionRefresh();
 
   const handleFamilySelect = useCallback(async (family: Family) => {
-    // 선택한 가족을 기본 가족으로 저장
     const result = await setDefaultFamilyAction(family.uuid);
     if (result.success) {
-      // 세션 갱신 (프로필의 defaultFamilyUuid가 변경됨)
       await refreshSession();
     }
     onFamilySelect(family);
@@ -42,16 +41,13 @@ export function FamilySelector({
     initializeSelector();
   }, []);
 
-  // 기본 가족이 있으면 자동 선택, 없으면 가족이 1개일 때 자동 선택
   useEffect(() => {
     if (loading || autoSelectedRef.current || families.length === 0) return;
 
     const selectFamily = async () => {
-      // 사용자 프로필에서 기본 가족 조회
       const profileResult = await getUserProfileAction();
 
       if (profileResult.success && profileResult.data.defaultFamilyUuid) {
-        // 기본 가족이 설정되어 있으면 해당 가족 선택
         const defaultFamily = families.find(
           (f) => f.uuid === profileResult.data.defaultFamilyUuid
         );
@@ -63,7 +59,6 @@ export function FamilySelector({
         }
       }
 
-      // 기본 가족이 없고 가족이 1개뿐이면 자동 선택
       if (families.length === 1) {
         autoSelectedRef.current = true;
         await handleFamilySelect(families[0]);
@@ -109,7 +104,7 @@ export function FamilySelector({
       <div className="min-h-screen flex items-center justify-center">
         <Card className="w-full max-w-md">
           <CardContent className="py-8 text-center">
-            <p className="text-red-500 mb-4">{error}</p>
+            <p className="text-expense mb-4">{error}</p>
             <Button onClick={initializeSelector}>다시 시도</Button>
           </CardContent>
         </Card>
@@ -123,7 +118,7 @@ export function FamilySelector({
         <div className="text-center mb-8">
           <div className="flex items-center justify-between mb-4">
             <div className="flex-1" />
-            <h1 className="text-3xl font-bold text-gray-900 flex-1">
+            <h1 className="text-3xl font-bold text-fg flex-1">
               가계부 시작하기
             </h1>
             <div className="flex-1 flex justify-end">
@@ -138,7 +133,7 @@ export function FamilySelector({
               )}
             </div>
           </div>
-          <p className="text-gray-600">
+          <p className="text-fg-muted">
             {families.length > 0
               ? "기존 가족을 선택하거나 새로운 가족을 만드세요"
               : "어떤 방식으로 가계부를 관리하시겠어요?"}
@@ -149,20 +144,20 @@ export function FamilySelector({
           {/* 기존 가족들 */}
           {families.length > 0 && (
             <>
-              <h2 className="text-xl font-semibold text-gray-800 mb-4">
+              <h2 className="text-xl font-semibold text-fg mb-4">
                 기존 가족/그룹
               </h2>
               {families.map((family) => (
                 <Card
                   key={family.uuid}
-                  className="cursor-pointer hover:shadow-lg transition-all duration-200 border-2 hover:border-blue-200"
+                  className="cursor-pointer transition border-border hover:border-brand-300 hover:shadow-default bg-bg-elev"
                   onClick={() => handleFamilySelect(family)}
                 >
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="text-lg font-semibold text-gray-900">
+                          <h3 className="text-lg font-semibold text-fg">
                             {family.name}
                           </h3>
                           <Badge variant="secondary" className="text-xs">
@@ -170,7 +165,7 @@ export function FamilySelector({
                           </Badge>
                         </div>
 
-                        <div className="flex items-center gap-4 text-sm text-gray-600">
+                        <div className="flex items-center gap-4 text-sm text-fg-muted">
                           <span className="flex items-center gap-1">
                             <Users className="w-4 h-4" />
                             구성원 {family.members?.length || 0}명
@@ -181,37 +176,42 @@ export function FamilySelector({
                           </span>
                         </div>
 
-                        {/* 구성원 미리보기 */}
+                        {/* 멤버 avatar 겹침 */}
                         {family.members && family.members.length > 0 && (
-                          <div className="flex items-center gap-2 mt-3">
-                            {family.members.slice(0, 3).map((member) => (
+                          <div className="flex items-center mt-3">
+                            {family.members.slice(0, 3).map((member, i) => (
                               <div
                                 key={member.uuid}
-                                className="w-8 h-8 rounded-full bg-gray-300 flex items-center justify-center text-xs font-medium text-gray-700 overflow-hidden"
+                                className={cn(
+                                  "w-8 h-8 rounded-full ring-2 ring-bg-elev overflow-hidden",
+                                  i > 0 && "-ml-2"
+                                )}
                               >
                                 {member.userImage ? (
                                   <Image
                                     src={member.userImage}
-                                    alt={member.userName || ""}
+                                    alt={member.userName ?? ""}
                                     width={32}
                                     height={32}
-                                    className="w-full h-full object-cover"
+                                    className="object-cover w-full h-full"
                                   />
                                 ) : (
-                                  member.userName?.charAt(0) || "U"
+                                  <div className="w-full h-full bg-bg-muted text-fg-muted text-xs font-semibold flex items-center justify-center">
+                                    {member.userName?.charAt(0) ?? "U"}
+                                  </div>
                                 )}
                               </div>
                             ))}
                             {family.members.length > 3 && (
-                              <span className="text-xs text-gray-500">
+                              <div className="-ml-2 w-8 h-8 rounded-full ring-2 ring-bg-elev bg-bg-muted text-fg-muted text-xs font-semibold flex items-center justify-center">
                                 +{family.members.length - 3}
-                              </span>
+                              </div>
                             )}
                           </div>
                         )}
                       </div>
 
-                      <ChevronRight className="w-5 h-5 text-gray-400" />
+                      <ChevronRight className="w-5 h-5 text-fg-subtle" />
                     </div>
                   </CardContent>
                 </Card>
@@ -220,10 +220,10 @@ export function FamilySelector({
               <div className="my-8">
                 <div className="relative">
                   <div className="absolute inset-0 flex items-center">
-                    <div className="w-full border-t border-gray-300" />
+                    <div className="w-full border-t border-border" />
                   </div>
                   <div className="relative flex justify-center text-sm">
-                    <span className="bg-gray-50 px-3 text-gray-500">또는</span>
+                    <span className="bg-bg px-3 text-fg-muted">또는</span>
                   </div>
                 </div>
               </div>
@@ -233,7 +233,7 @@ export function FamilySelector({
           {/* 새로운 가족/그룹 생성 옵션 */}
           <div className="grid gap-4">
             <Card
-              className="cursor-pointer hover:shadow-lg transition-all duration-200 border-2 hover:border-green-200 group"
+              className="cursor-pointer hover:shadow-default transition-all duration-200 border-border hover:border-brand-300 group"
               onClick={() => onCreateFamily()}
             >
               <CardContent className="p-6">
@@ -242,20 +242,20 @@ export function FamilySelector({
                     <User className="w-7 h-7 text-white" />
                   </div>
                   <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-gray-900 mb-1">
+                    <h3 className="text-lg font-semibold text-fg mb-1">
                       혼자 사용하기
                     </h3>
-                    <p className="text-gray-600 text-sm">
+                    <p className="text-fg-muted text-sm">
                       개인 가계부로 시작하기
                     </p>
                   </div>
-                  <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-green-500 transition-colors" />
+                  <ChevronRight className="w-5 h-5 text-fg-subtle group-hover:text-brand-500 transition-colors" />
                 </div>
               </CardContent>
             </Card>
 
             <Card
-              className="cursor-pointer hover:shadow-lg transition-all duration-200 border-2 hover:border-blue-200 group"
+              className="cursor-pointer hover:shadow-default transition-all duration-200 border-border hover:border-brand-300 group"
               onClick={() => onCreateFamily()}
             >
               <CardContent className="p-6">
@@ -264,14 +264,14 @@ export function FamilySelector({
                     <Users className="w-7 h-7 text-white" />
                   </div>
                   <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-gray-900 mb-1">
+                    <h3 className="text-lg font-semibold text-fg mb-1">
                       새 가족/그룹 만들기
                     </h3>
-                    <p className="text-gray-600 text-sm">
+                    <p className="text-fg-muted text-sm">
                       가족이나 팀과 함께 관리하기
                     </p>
                   </div>
-                  <ChevronRight className="w-5 h-5 text-gray-400 group-hover:text-blue-500 transition-colors" />
+                  <ChevronRight className="w-5 h-5 text-fg-subtle group-hover:text-brand-500 transition-colors" />
                 </div>
               </CardContent>
             </Card>
@@ -279,11 +279,11 @@ export function FamilySelector({
 
           {families.length === 0 && (
             <div className="text-center py-8">
-              <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Plus className="w-8 h-8 text-gray-400" />
+              <div className="w-16 h-16 bg-bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
+                <Plus className="w-8 h-8 text-fg-subtle" />
               </div>
-              <p className="text-gray-500">아직 생성된 가족/그룹이 없습니다.</p>
-              <p className="text-gray-400 text-sm mt-1">
+              <p className="text-fg-muted">아직 생성된 가족/그룹이 없습니다.</p>
+              <p className="text-fg-subtle text-sm mt-1">
                 위의 옵션을 선택해서 시작해보세요!
               </p>
             </div>

--- a/src/components/layout/SettingsCard.tsx
+++ b/src/components/layout/SettingsCard.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/client/utils";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SettingsCardProps {
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingsCard({
+  icon: Icon,
+  title,
+  subtitle,
+  children,
+  className,
+}: SettingsCardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-bg-elev rounded-2xl border border-border overflow-hidden",
+        className
+      )}
+    >
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-border">
+        <div className="w-8 h-8 rounded-lg bg-brand-50 text-brand-700 flex items-center justify-center shrink-0">
+          <Icon size={17} strokeWidth={1.8} />
+        </div>
+        <div>
+          <div className="text-[15px] font-bold leading-tight tracking-tight">
+            {title}
+          </div>
+          {subtitle && (
+            <div className="text-xs text-fg-muted mt-0.5">{subtitle}</div>
+          )}
+        </div>
+      </div>
+      <div className="py-2">{children}</div>
+    </div>
+  );
+}

--- a/tasks/plan010-domain-pages-redesign/index.json
+++ b/tasks/plan010-domain-pages-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan010-domain-pages-redesign",
   "description": "도메인 외곽 4 페이지 Teal 리디자인 — Settings (3 카드) + Categories (list + Add/Edit/Delete dialog + plan002 톤 8 팔레트) + FamiliesSelect (카드 행 + 멤버 avatar) + FamiliesCreate (glass 제거 + gradient-family 채널). AddCategoryDialog/EditCategoryDialog 의 stale state fix 동시 적용.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
   "total_phases": 5,
   "related_docs": [
@@ -23,35 +23,35 @@
       "file": "phase-01.md",
       "title": "Settings — SettingsCard helper 추출 + 3 카드 (기본 가족 / 예산 / 알림) 토큰 적용",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "Categories — CategoryList row + Add/Edit/Delete Dialog stale state fix + plan002 톤 8 팔레트 매핑",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "FamiliesSelect — 카드 행 토큰 교체 + plan002 멤버 avatar 재사용",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "FamiliesCreate — glass 제거 + bg-bg-elev card + gradient-family 채널 + segmented type 토글",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 5,
       "file": "phase-05.md",
       "title": "통합 검증 + legacy 잔재 grep + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan010-domain-pages-redesign/phase-02.md
+++ b/tasks/plan010-domain-pages-redesign/phase-02.md
@@ -42,7 +42,7 @@ function AddCategoryDialogBody({ onOpenChange, ... }) {
 }
 ```
 
-EditCategoryDialog 의 `useEffect(() => setColor(category.color), [category.color])` 패턴은 inner body 안의 initial state 로 흡수 — open 변경 시 자동 reset, prop 변경은 key 또는 자체 동기화로.
+EditCategoryDialog 의 `useEffect(() => setColor(category.color), [category.color])` 패턴은 inner body 안의 initial state 로 흡수 — open 변경 시 자동 reset. **다른 카테고리 row 를 연속 수정 시 inner body 가 동일 prop shape 라 React 가 동일 mount 로 인식할 위험** → 반드시 `<EditCategoryDialogBody key={category.uuid} ... />` 로 key prop 강제. 강제 unmount/remount = initial value 새로 잡힘.
 
 ### 2. 색 팔레트 8개 → plan002 톤 fg 매핑
 
@@ -72,7 +72,17 @@ backend 가 hex 만 수용한다면 plan 본문에 보고 + plan011 로 backend 
 ### 3. CategoryList row 토큰 교체
 
 `CategoryList.tsx` + `CategoryItem.tsx`:
-- 카테고리 icon cell: `bg-[${color}]/15 text-[${color}]` 패턴 → `style={{ background: color + "26", color }}` (16% alpha hex `26`) 또는 inline OKLCH alpha
+- 카테고리 icon cell: 기존 `bg-[${color}]/15 text-[${color}]` Tailwind arbitrary 패턴 → inline style 로 교체. **color 가 OKLCH 문자열이므로 alpha 합성은 슬래시 문법 사용** (hex 접미사 `26` 같은 합성 불가):
+  ```ts
+  // OKLCH 슬래시 alpha 합성 helper
+  function withAlpha(oklch: string, a: number): string {
+    // "oklch(0.560 0.140 35)" → "oklch(0.560 0.140 35 / 0.16)"
+    return oklch.replace(/\)$/, ` / ${a})`);
+  }
+  // 사용
+  style={{ background: withAlpha(color, 0.16), color }}
+  ```
+  hex fallback (backend 거부 시) 의 경우만 `color + "29"` (16%) 사용 — 16진 alpha 는 hex string 일 때만 유효.
 - row hover: `hover:bg-bg-muted`
 - 텍스트: `text-fg` / `text-fg-muted` 토큰
 

--- a/tasks/plan010-domain-pages-redesign/phase-04.md
+++ b/tasks/plan010-domain-pages-redesign/phase-04.md
@@ -16,7 +16,7 @@
 
 ## 작업 항목
 
-### 1. 배경 / 카드 클래스 교체
+### 1. 배경 / 카드 / 저장 버튼 토큰 교체
 
 ```tsx
 // 변경 전
@@ -36,7 +36,15 @@
 grep -rn 'app-background\|glass-card' src/ 2>/dev/null
 ```
 
-`app-background` 가 본 페이지 외 사용처 0 이면 globals.css 에서도 제거 (별도 작업항목). 0 아니면 본 페이지 className 만 교체.
+`app-background` 가 본 페이지 외 사용처 0 이면 globals.css 에서도 제거 (본 항목 안에서 함께). 0 아니면 본 페이지 className 만 교체.
+
+저장 버튼 토큰도 동일 작업으로 통합:
+
+```bash
+grep -n 'gradient-primary\|bg-primary\|bg-blue-' src/app/\(authenticated\)/families/create/page.tsx
+```
+
+저장 버튼: `bg-brand-500 hover:bg-brand-600 text-white w-full` 토큰으로 교체.
 
 ### 2. 상단 gradient-family 채널 (아이콘 원형)
 
@@ -104,16 +112,7 @@ grep -rn 'SegmentedToggle\|segmented-toggle' src/components/ui/ src/components/ 
 
 `brand-100` 등록 — plan001 `@theme` 에 이미 있음 (brand 50~900 전 스케일).
 
-### 5. 저장 버튼 brand 토큰
-
-기존 (확인 필요 — 본 phase 시작 시 점검):
-```bash
-grep -n 'gradient-primary\|bg-primary\|bg-blue-' src/app/\(authenticated\)/families/create/page.tsx
-```
-
-저장 버튼: `bg-brand-500 hover:bg-brand-600 text-white w-full` 토큰.
-
-### 6. 자동 verification
+### 5. 자동 verification
 
 ```bash
 # cwd: /Users/nhn/personal/fos-accountbook

--- a/tasks/plan010-domain-pages-redesign/phase-05.md
+++ b/tasks/plan010-domain-pages-redesign/phase-05.md
@@ -1,7 +1,7 @@
 # Phase 05 — 통합 검증 + legacy 잔재 grep + completed 마킹
 
 **Model**: haiku
-**Status**: pending
+**Status**: completed
 **Goal**: phase 01~04 산출물 통합 검증, 4 페이지 + 카테고리 다이얼로그 의 하드코딩 색 잔재 0건 증명, `index.json` status `completed` 마킹.
 
 ## Context (자기완결)


### PR DESCRIPTION
## Summary

도메인 외곽 4 페이지(Settings / Categories / FamiliesSelect / FamiliesCreate) Teal 리디자인 — handoff mockup Screen 5~8 적용 + Category dialog stale state fix.

## Phases

- **phase-01** Settings — `SettingsCard` 공용 헬퍼 신규 + 3 카드 토큰 교체 + 활성 라디오 brand 톤 + 데스크톱 2-col grid
- **phase-02** Categories — `AddCategoryDialog` / `EditCategoryDialog` inner body 분리 + `key={category.uuid}` 강제 remount + 8 hex → OKLCH plan002 톤 팔레트 + `withAlpha` 슬래시 alpha helper
- **phase-03** FamiliesSelect — 카드 행 토큰 + 멤버 avatar 겹침 패턴(`ring-2 ring-bg-elev -ml-2`)
- **phase-04** FamiliesCreate — glass 제거 + `gradient-family` 채널(96px round) + `SegmentedToggle` 재사용 + 안내 박스 brand-50
- **phase-05** 통합 검증 + index.json completed 마킹

## Post-review fixes

- `category-constants.ts` 추출 (PALETTE / commonEmojis 중복 제거)
- `families/create/page.tsx` 불필요한 `as FamilyType` 단언 제거
- `withAlpha` 이중 alpha 방어 코드 (기존 alpha 구간 제거 후 합성)
- `docs/code-architecture.md` components/layout 라인에 SettingsCard 명시

## Build

- `pnpm lint`: PASS (warning 1건, error 0)
- `pnpm tsc --noEmit`: PASS
- `pnpm build`: PASS
- `pnpm test:ci`: 211/211 PASS
- 하드코딩 색 잔재(gray/blue): 0건 (4 페이지 전역 OKLCH 통일)

## Test plan

- [ ] `/settings` — 3 카드 표시, 기본 가족 라디오 brand 톤, 데스크톱 2-col
- [ ] `/categories` — 카테고리 row + 추가/수정 다이얼로그 두 번 열기 시 stale state 없음, 8색 OKLCH 팔레트
- [ ] `/families/select` — 카드 행 + 멤버 avatar 겹침
- [ ] `/families/create` — 상단 gradient-family 원형 + brand 카드 + 가족/개인 segmented
- [ ] Dark mode 토글 확인 (`[data-theme="dark"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)