### PR TITLE
docs(plan014): Add/Edit Transaction Dialog 3 도메인 통일 task

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -332,3 +332,13 @@
 - **트레이드오프**: protected route 직접 URL 진입 (예: `/dashboard` 의 deep link 공유) 시 Landing 으로 한 단계 더 거쳐야 함. `(authenticated)/layout.tsx` 의 unauth redirect 대상도 Landing 으로 통일.
 - **적용 범위**: `src/middleware.ts`, `src/app/page.tsx`, `src/app/(authenticated)/layout.tsx`.
 
+## ADR-F21: Add/Edit Transaction 다이얼로그 단일화 (2026-05-11)
+
+- **결정**: 지출/수입/고정지출 3 도메인의 Add 다이얼로그를 단일 `AddTransactionDialog` + 3 segmented 토글 (gradient-expense / gradient-income / gradient-budget) 로 통합. Edit 도 동일 패턴 (`EditTransactionDialog`, type 잠금). 위치: `src/components/transactions/dialogs/`.
+- **맥락**: 같은 "추가" 진입점이 6 곳 (Dashboard QuickActions / BottomNav FAB / Transactions 의 지출·수입·고정지출 탭 / Settings 고정지출) 인데 호출하는 다이얼로그가 셋 (AddExpenseDialog / AddIncomeDialog / AddRecurringExpenseSheet) 으로 분기. 시각·반응형 (Sheet 방향 right vs bottom)·field 구성·legacy 토큰 (`text-destructive`, `text-gray-500`, `text-muted-foreground`) 모두 불일치 → 사용자 인지 부담 + 유지보수 비용.
+- **대안 기각**:
+  - 도메인별 분리 유지 + 시각·토큰만 통일: 진입점마다 다른 UI 가 그대로 노출. type 전환 (지출→수입) 시 다이얼로그 닫고 다른 진입점 찾아야 함 — 같은 의도 ("거래 추가") 가 분기됨.
+  - "Add+ 페이지" 신설 (전용 라우트): 모달 흐름이 자연스러운 작업을 페이지로 격상 → 단순 추가가 무거워짐. recurring 처럼 가끔 쓰는 영역에서 매번 라우팅 비용.
+- **트레이드오프**: 단일 컴포넌트가 3 type conditional 필드 분기 — form complexity ↑ but UX 일관성 ↑. type 전환 시 type-specific 필드 (date vs dayOfMonth+name) 가 mount/unmount 되며 입력 잔존 정책은 "이전 type 의 amount/category/description 은 유지, type-specific 필드만 초기화" 로 명시.
+- **적용 범위**: `src/components/transactions/dialogs/{Add,Edit}TransactionDialog.tsx`, `src/components/transactions/forms/TransactionFormFields.tsx`, 진입점 6 곳 import 갱신, legacy 다이얼로그 4 파일 제거 (Add/EditIncomeDialog, Add/EditRecurringExpenseSheet).
+

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -54,28 +54,33 @@
 
 ---
 
-## 3. 지출 등록 플로우
+## 3. 거래 등록 플로우 (plan014 통합)
+
+ADR-F21 에 따라 6 진입점 (Dashboard QuickActions / BottomNav FAB / Transactions 의 지출·수입·고정지출 탭 / Settings 고정지출) 이 동일한 `AddTransactionDialog` 호출.
 
 ```
-[트랜잭션 페이지 또는 대시보드]
+[6 진입점 — defaultType 만 다름]
     │
-    └─ "+ 지출 추가" 버튼 (BottomNav FAB / QuickActions)
-            └─ AddExpenseDialog (responsive: mobile Sheet / md+ Dialog 720px)
-                    │
-                    ├─ Segmented toggle: 지출 / 수입 (gradient-expense / gradient-income)
-                    │
-                    ├─ ExpenseFormFields
-                    │   ├─ AmountInput (₩ + 56/64px num, 빠른 추가 칩 +1k/+5k/+10k, md+ 추가 +50k)
-                    │   ├─ CategoryGrid (5×2 mobile / 10×1 desktop, role=radiogroup, --color-cat-*-bg/-fg 톤)
-                    │   ├─ Date input (type="date", default: 오늘)
-                    │   └─ Description input (name="description", FormData key 보존)
-                    │
-                    └─ 저장 → createExpenseAction() / createIncomeAction()
-                            ├─ requireAuthOrRedirect()
-                            ├─ Zod 검증
-                            └─ create* → POST /families/{uuid}/{expenses|incomes}
-                                    └─ revalidatePath → toast 성공 메시지
+    └─ AddTransactionDialog (responsive: mobile Sheet bottom / md+ Dialog 720px)
+            │
+            ├─ Segmented 3 토글: 지출 / 수입 / 고정지출
+            │       (gradient-expense / gradient-income / gradient-budget)
+            │
+            ├─ TransactionFormFields (type 분기)
+            │   ├─ AmountInput (₩ + 56/64px num, 빠른 추가 칩 +1k/+5k/+10k, md+ +50k)
+            │   ├─ CategoryGrid (5×2 mobile / 10×1 desktop, role=radiogroup, --color-cat-*-bg/-fg 톤)
+            │   ├─ Description input (메모, name="description")
+            │   ├─ [expense/income 일 때] Date input (type="date", default: 오늘)
+            │   └─ [recurring 일 때]  Name input + DayOfMonth (1~28)
+            │
+            └─ 저장 → type 분기
+                    ├─ expense  → createExpenseAction()         → POST /families/{uuid}/expenses
+                    ├─ income   → createIncomeAction()          → POST /families/{uuid}/incomes
+                    └─ recurring→ createRecurringExpenseAction()→ POST /families/{uuid}/recurring-expenses
+                            └─ revalidatePath → toast 성공 메시지
 ```
+
+type 전환 시: amount / category / description 은 유지, type-specific 필드 (date vs name+dayOfMonth) 만 초기화.
 
 ---
 

--- a/tasks/plan014-transaction-dialog-unification/index.json
+++ b/tasks/plan014-transaction-dialog-unification/index.json
@@ -1,0 +1,50 @@
+{
+  "name": "plan014-transaction-dialog-unification",
+  "description": "Add/Edit 다이얼로그 3 도메인 (지출/수입/고정지출) 통합. AddTransactionDialog + EditTransactionDialog 단일화 + 3 segmented 토글 (gradient-expense/income/budget) + TransactionFormFields 공용. 진입점 6 곳 갱신 + legacy 다이얼로그 4 파일 제거.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 4,
+  "related_docs": [
+    "docs/adr.md",
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan005-add-expense-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH 토큰) ✅",
+    "plan005 머지 (AddExpenseDialog + ExpenseFormFields + CategoryGrid + AmountInput — 본 plan 의 기반) ✅",
+    "ADR-F21 결정 — 3 도메인 다이얼로그 단일화"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "AddTransactionDialog 신규 + TransactionFormFields (3 type 분기) + 3 토글",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "Add 진입점 6 곳 import 갱신 + legacy 2 파일 (AddIncomeDialog / AddRecurringExpenseSheet) 제거",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "EditTransactionDialog 신규 + Edit 진입점 갱신 + legacy 2 파일 (EditIncomeDialog / EditRecurringExpenseSheet) 제거",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "통합 검증 + jest 테스트 갱신 + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan014-transaction-dialog-unification/phase-01.md
+++ b/tasks/plan014-transaction-dialog-unification/phase-01.md
@@ -1,0 +1,154 @@
+# Phase 01 — AddTransactionDialog + TransactionFormFields
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `AddTransactionDialog` 단일 컴포넌트 신규 + 3 segmented 토글 + `TransactionFormFields` 공용 (type 분기 conditional 필드). 기존 `AddExpenseDialog` 의 구조 + Income/Recurring 도메인 흡수.
+
+## Context (자기완결)
+
+- 기반 컴포넌트: `src/components/expenses/dialogs/AddExpenseDialog.tsx` (205 줄, 지출+수입 토글 이미 지원)
+- 흡수 대상:
+  - `src/components/incomes/dialogs/AddIncomeDialog.tsx` (184 줄) — 단순 select + Input
+  - `src/components/recurring-expense/AddRecurringExpenseSheet.tsx` (193 줄) — name + dayOfMonth 필드 추가 필요
+- 신규 위치: `src/components/transactions/dialogs/AddTransactionDialog.tsx`
+- 공용 form: `src/components/transactions/forms/TransactionFormFields.tsx` (ExpenseFormFields 확장)
+
+## 작업 항목
+
+### 1. `AddTransactionDialog.tsx` 신규
+
+```ts
+type TransactionType = "expense" | "income" | "recurring";
+
+interface AddTransactionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultType?: TransactionType;
+}
+```
+
+구조:
+- responsive: `isDesktop ? Dialog 720px : Sheet bottom 100dvh` (AddExpenseDialog 패턴 그대로)
+- inner body `{open ? <Body /> : null}` 패턴 (stale state 방지 — PR #233 의 동일 패턴 유지)
+- 헤더: "거래 추가" (sr-only on desktop, 보이는 헤더 on mobile)
+
+### 2. 3 segmented 토글
+
+```tsx
+<div className="flex gap-1 bg-bg-muted p-1 rounded-xl">
+  <ToggleButton type="expense" label="지출" icon={TrendingDown} gradient="gradient-expense" />
+  <ToggleButton type="income"  label="수입" icon={TrendingUp}   gradient="gradient-income" />
+  <ToggleButton type="recurring" label="고정지출" icon={Repeat} gradient="gradient-budget" />
+</div>
+```
+
+토글 클릭 시 `setActiveTypeDraft(type)` — type-specific 필드만 초기화 (amount/category/description 유지).
+
+### 3. `TransactionFormFields.tsx` 신규 (공용)
+
+```ts
+interface TransactionFormFieldsProps {
+  type: TransactionType;
+  categories: CategoryResponse[];
+  // 공용
+  amount: number;
+  onAmountChange: (n: number) => void;
+  categoryUuid: string | null;
+  onCategoryChange: (uuid: string | null) => void;
+  description: string;
+  onDescriptionChange: (s: string) => void;
+  // expense/income 만
+  date?: string;
+  onDateChange?: (s: string) => void;
+  // recurring 만
+  name?: string;
+  onNameChange?: (s: string) => void;
+  dayOfMonth?: number;
+  onDayOfMonthChange?: (n: number) => void;
+  // 공통
+  isLoadingCategories: boolean;
+  errors?: Record<string, string[] | undefined>;
+}
+```
+
+본문 구조:
+- AmountInput (공용, ExpenseFormFields 의 컴포넌트 재사용)
+- CategoryGrid (공용, ExpenseFormFields 의 컴포넌트 재사용)
+- Description input (공용, name="description")
+- `{type === "recurring"}` → Name input + DayOfMonth (1~28) input
+- `{type !== "recurring"}` → Date input (default: 오늘)
+
+### 4. 3 Action dispatch 분기
+
+```ts
+const [expenseState, expenseFormAction] = useActionState(createExpenseAction, initialExpenseState);
+const [incomeState,  incomeFormAction]  = useActionState(createIncomeAction,  initialIncomeState);
+const [recurringState, recurringFormAction] = useActionState(createRecurringExpenseAction, initialRecurringState);
+
+const formAction =
+  type === "expense"   ? expenseFormAction :
+  type === "income"    ? incomeFormAction  :
+                          recurringFormAction;
+```
+
+각 state 의 success → toast + onOpenChange(false). errors 는 해당 type 의 errors 만 form fields 에 전달.
+
+`createRecurringExpenseAction` 의 현재 시그니처가 plain object 인지 useActionState 호환 (state, formData) 인지 확인 — 호환 안 되면 wrapper 추가 (`async (_, fd) => createRecurringExpenseAction(parseFormData(fd))`).
+
+### 5. CTA 버튼 톤
+
+- expense → `gradient-expense text-white`
+- income → `gradient-income text-white`
+- recurring → `gradient-budget text-white`
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/014-transaction-dialog-unification
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/transactions/dialogs/AddTransactionDialog.tsx
+test -f src/components/transactions/forms/TransactionFormFields.tsx
+
+# 3 토글 (TrendingDown / TrendingUp / Repeat)
+grep -nE 'TrendingDown|TrendingUp|Repeat' src/components/transactions/dialogs/AddTransactionDialog.tsx | wc -l   # >= 3
+
+# 3 시맨틱 그라디언트
+grep -nE 'gradient-expense|gradient-income|gradient-budget' src/components/transactions/dialogs/AddTransactionDialog.tsx | wc -l   # >= 3
+
+# 3 Action import
+grep -nE 'createExpenseAction|createIncomeAction|createRecurringExpenseAction' \
+  src/components/transactions/dialogs/AddTransactionDialog.tsx | wc -l   # >= 3
+
+# inner body conditional pattern
+grep -nE 'open\s*\?\s*<' src/components/transactions/dialogs/AddTransactionDialog.tsx | wc -l   # >= 1
+```
+
+수동 smoke (실제 사용은 phase 02 에서 진입점 갱신 후): 임시 페이지에 `<AddTransactionDialog open onOpenChange={...} />` 마운트 → 3 토글 전환 + 각 type 별 form 필드 분기 확인.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/transactions/dialogs/AddTransactionDialog.tsx` | 신규 |
+| `src/components/transactions/forms/TransactionFormFields.tsx` | 신규 |
+
+## Out of Scope
+
+- 진입점 갱신 (phase 02)
+- EditTransactionDialog (phase 03)
+- legacy 파일 제거 (phase 02 / 03)
+- AmountInput / CategoryGrid 자체 변경 — ExpenseFormFields 내부 컴포넌트 그대로 재사용
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `createRecurringExpenseAction` 시그니처 비호환 (useActionState 와) | 시그니처 확인 후 wrapper 함수로 감싸기. parseFormData 로 dayOfMonth/name 추출 |
+| type 전환 시 입력 잔존 정책 모호 (사용자 confused) | ADR-F21 명시: amount/category/description 유지, type-specific (date vs name+dayOfMonth) 초기화. 코드 주석 명시 |
+| 3 type Action state hook 3개 — 모든 type 진입 시 3개 모두 mount | useActionState 는 type 무관 항상 mount. 부작용 없음 (form action 만 분기) |
+| `gradient-budget` 토큰이 globals.css 에 정의 안 됨 | plan001 의 토큰 점검 — `gradient-budget` 존재 확인. 없으면 phase 시작 시 추가 작업 |

--- a/tasks/plan014-transaction-dialog-unification/phase-02.md
+++ b/tasks/plan014-transaction-dialog-unification/phase-02.md
@@ -1,0 +1,131 @@
+# Phase 02 — Add 진입점 6 곳 갱신 + legacy Add 다이얼로그 제거
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 6 진입점이 모두 `AddTransactionDialog` 호출하도록 import 경로 + props 갱신. `AddIncomeDialog` / `AddRecurringExpenseSheet` 파일 제거.
+
+## Context (자기완결)
+
+진입점 6 곳:
+
+| # | 파일 | 현재 호출 | 갱신 후 |
+|---|---|---|---|
+| 1 | `src/components/dashboard/QuickActions.tsx` | AddExpenseDialog + AddIncomeDialog | AddTransactionDialog (defaultType=expense / income) |
+| 2 | `src/components/layout/BottomNavigation.tsx` | AddExpenseDialog | AddTransactionDialog (defaultType=expense) |
+| 3 | `src/app/(authenticated)/transactions/_components/IncomeTabContent.tsx` | AddIncomeDialog | AddTransactionDialog (defaultType=income) |
+| 4 | `src/app/(authenticated)/transactions/_components/RecurringTabContent.tsx` | AddRecurringExpenseSheet | AddTransactionDialog (defaultType=recurring) |
+| 5 | `src/components/recurring-expense/RecurringExpenseList.tsx` | AddRecurringExpenseSheet | AddTransactionDialog (defaultType=recurring) |
+| 6 | `src/components/expenses/dialogs/AddExpenseDialog.tsx` 사용처 (지출 탭의 FAB 등) | AddExpenseDialog | AddTransactionDialog (defaultType=expense) |
+
+## 작업 항목
+
+### 1. 6 진입점 import 일괄 교체
+
+```bash
+# 패턴 점검
+grep -rln 'AddExpenseDialog\|AddIncomeDialog\|AddRecurringExpenseSheet' src/ --include='*.tsx' \
+  | grep -v __tests__ \
+  | grep -v 'src/components/transactions/dialogs/'   # 신규 컴포넌트 자체 제외
+```
+
+각 파일에서:
+- import 교체: `AddTransactionDialog` from `@/components/transactions/dialogs/AddTransactionDialog`
+- 컴포넌트 호출: `<AddTransactionDialog open={...} onOpenChange={...} defaultType="expense|income|recurring" />`
+- QuickActions 처럼 type 별 2개 dialog 가 있는 경우 → 단일 dialog + state 1개 + `currentType` 변수 도입
+
+QuickActions 예시:
+```tsx
+// 변경 전
+const [addExpenseDialogOpen, setAddExpenseDialogOpen] = useState(false);
+const [addIncomeDialogOpen, setAddIncomeDialogOpen] = useState(false);
+// ...
+<AddExpenseDialog open={addExpenseDialogOpen} onOpenChange={setAddExpenseDialogOpen} />
+<AddIncomeDialog open={addIncomeDialogOpen} onOpenChange={setAddIncomeDialogOpen} />
+
+// 변경 후
+const [dialogState, setDialogState] = useState<{ open: boolean; type: "expense" | "income" }>({ open: false, type: "expense" });
+// ...
+<AddTransactionDialog
+  open={dialogState.open}
+  onOpenChange={(open) => setDialogState((s) => ({ ...s, open }))}
+  defaultType={dialogState.type}
+/>
+```
+
+### 2. AddRecurringExpenseSheet 의 `categories` prop 처리
+
+기존 `AddRecurringExpenseSheet` 는 `categories` 외부 주입. `AddTransactionDialog` 는 내부 fetch — 진입점에서 `categories` prop 제거. (이미 fetch 가 dialog 내부니 외부 주입 불필요.)
+
+진입점이 categories 를 fetch 해서 사용하던 다른 용도가 있는지 확인 → RecurringExpenseList 에서는 list 표시에도 categories 사용. 그 경우 list 용 fetch 는 유지하되 dialog 에는 전달 안 함.
+
+### 3. legacy 파일 제거
+
+```bash
+rm src/components/incomes/dialogs/AddIncomeDialog.tsx
+rm src/components/recurring-expense/AddRecurringExpenseSheet.tsx
+```
+
+`src/components/incomes/dialogs/` 디렉터리에 다른 파일 (EditIncomeDialog) 이 남아있으면 디렉터리 유지. 다음 phase 에서 EditIncomeDialog 도 제거되면 전체 디렉터리 정리.
+
+`AddExpenseDialog.tsx` 도 사용처가 없어졌으므로 본 phase 에서 제거. 단 EditExpenseDialog 가 같은 디렉터리에 있어 디렉터리 즉시 삭제 안 함 — phase 03 에서 처리.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/014-transaction-dialog-unification
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy import 0 (테스트 제외)
+! grep -rn 'AddIncomeDialog\|AddRecurringExpenseSheet\|AddExpenseDialog' src/ \
+  --include='*.tsx' --include='*.ts' \
+  | grep -v __tests__ \
+  | grep -v 'src/components/transactions/dialogs/'
+
+# legacy 파일 제거됨
+[ ! -f src/components/incomes/dialogs/AddIncomeDialog.tsx ]
+[ ! -f src/components/recurring-expense/AddRecurringExpenseSheet.tsx ]
+[ ! -f src/components/expenses/dialogs/AddExpenseDialog.tsx ]
+
+# AddTransactionDialog 사용처 6+ 곳
+grep -rln 'AddTransactionDialog' src/ --include='*.tsx' | wc -l   # >= 6
+```
+
+수동 smoke:
+1. Dashboard → "+ 지출" 클릭 → expense 토글 활성 다이얼로그
+2. Dashboard → "+ 수입" 클릭 → income 토글 활성
+3. BottomNav FAB → expense 토글 활성
+4. Transactions 수입 탭 "+ 수입" → income 토글 활성
+5. Transactions 고정지출 탭 "+ 고정지출" → recurring 토글 활성 + name/dayOfMonth 필드
+6. 각 type 저장 → 해당 list 갱신 + toast
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/dashboard/QuickActions.tsx` | import + state 통합 |
+| `src/components/layout/BottomNavigation.tsx` | import 교체 |
+| `src/app/(authenticated)/transactions/_components/IncomeTabContent.tsx` | import 교체 |
+| `src/app/(authenticated)/transactions/_components/RecurringTabContent.tsx` | import 교체 |
+| `src/components/recurring-expense/RecurringExpenseList.tsx` | import 교체 + categories prop 제거 |
+| `src/components/incomes/dialogs/AddIncomeDialog.tsx` | 제거 |
+| `src/components/recurring-expense/AddRecurringExpenseSheet.tsx` | 제거 |
+| `src/components/expenses/dialogs/AddExpenseDialog.tsx` | 제거 |
+
+## Out of Scope
+
+- Edit 다이얼로그 (phase 03)
+- 테스트 파일 갱신 (phase 04)
+- AddIncomeDialog.test.tsx — phase 04 에서 EditIncome 과 함께 정리
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| AddExpenseDialog 가 다른 plan 의 미머지 PR 에서 import 되어 있을 가능성 | 본 PR 머지 시점에 plan011/012/013 PR 이 main 에 머지 안 됐어도 충돌 없음 — 그 PR 들은 별도 영역. plan005 의 잔재 plan 만 점검 |
+| AddIncomeDialog.test.tsx 가 import 실패로 jest 깨짐 | phase 04 에서 동시 처리. 본 phase 의 verification 에서 `pnpm test` 는 미실행 |
+| RecurringExpenseList 의 categories fetch 가 dialog 만을 위해 있던 경우 | 진입점에서 list 표시 외에 categories 사용 없으면 dialog 와 함께 fetch 제거. 사용처 grep 으로 확인 |
+| `(open) => setDialogState(...)` 함수 inline 생성으로 자식 리렌더 | 미세 비용 — 본 plan 미해결. 필요 시 useCallback 후속 plan |

--- a/tasks/plan014-transaction-dialog-unification/phase-03.md
+++ b/tasks/plan014-transaction-dialog-unification/phase-03.md
@@ -1,0 +1,159 @@
+# Phase 03 — EditTransactionDialog 신규 + Edit 진입점 갱신
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `EditTransactionDialog` 단일 컴포넌트 신규 (type 잠금) + Edit 진입점 갱신 + legacy `EditIncomeDialog` / `EditRecurringExpenseSheet` / `EditExpenseDialog` 제거.
+
+## Context (자기완결)
+
+- 기반: `src/components/expenses/dialogs/EditExpenseDialog.tsx` (149 줄)
+- 흡수: `src/components/incomes/dialogs/EditIncomeDialog.tsx` (192) / `src/components/recurring-expense/EditRecurringExpenseSheet.tsx` (189)
+- 신규 위치: `src/components/transactions/dialogs/EditTransactionDialog.tsx`
+- 공용 폼: phase 01 의 `TransactionFormFields` 재사용
+- Edit 는 Add 와 달리 **type 전환 불가** — 기존 거래의 type 이 고정. 토글은 표시만 (3 토글 중 현재 type 만 활성, 나머지 disabled — 시각 일관성)
+
+## 작업 항목
+
+### 1. `EditTransactionDialog.tsx` 신규
+
+```ts
+type TransactionType = "expense" | "income" | "recurring";
+
+interface EditTransactionDialogProps<T> {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  type: TransactionType;
+  transaction: T;   // ExpenseResponse | IncomeResponse | RecurringExpenseResponse
+}
+```
+
+구조:
+- Add 와 동일 wrapper (responsive Dialog/Sheet)
+- inner body `{open ? <Body /> : null}` 패턴
+- 헤더: type 별 라벨 ("지출 수정" / "수입 수정" / "고정지출 수정")
+- 3 토글 표시 — 현재 type 만 활성, 나머지 `disabled className="opacity-40 cursor-not-allowed"` + aria-disabled
+- TransactionFormFields 사용 — initial 값 prefill (transaction 의 amount/category/date/name/dayOfMonth/description)
+
+### 2. 3 Update Action dispatch 분기
+
+```ts
+const [expenseState, expenseFormAction] = useActionState(updateExpenseAction, initialState);
+const [incomeState,  incomeFormAction]  = useActionState(updateIncomeAction,  initialState);
+const [recurringState, recurringFormAction] = useActionState(updateRecurringExpenseAction, initialState);
+
+const formAction =
+  type === "expense"   ? expenseFormAction :
+  type === "income"    ? incomeFormAction  :
+                          recurringFormAction;
+```
+
+`<input type="hidden" name="uuid" value={transaction.uuid} />` 로 식별자 전달.
+
+### 3. Edit 진입점 갱신
+
+```bash
+grep -rln 'EditExpenseDialog\|EditIncomeDialog\|EditRecurringExpenseSheet' src/ \
+  --include='*.tsx' \
+  | grep -v __tests__
+```
+
+각 진입점 (예: ExpenseItem / IncomeItem / RecurringExpenseItem) 에서:
+
+```tsx
+// 변경 전
+<EditExpenseDialog open={...} onOpenChange={...} expense={item} />
+
+// 변경 후
+<EditTransactionDialog open={...} onOpenChange={...} type="expense" transaction={item} />
+```
+
+각 type 의 prop 이름 (`expense` / `income` / `recurringExpense`) 이 모두 `transaction` 으로 통일.
+
+### 4. legacy 파일 제거
+
+```bash
+rm src/components/expenses/dialogs/EditExpenseDialog.tsx
+rm src/components/incomes/dialogs/EditIncomeDialog.tsx
+rm src/components/recurring-expense/EditRecurringExpenseSheet.tsx
+
+# 디렉터리 잔재 정리
+[ -d src/components/expenses/dialogs ] && rmdir src/components/expenses/dialogs 2>/dev/null || true
+[ -d src/components/incomes/dialogs ] && rmdir src/components/incomes/dialogs 2>/dev/null || true
+
+# 빈 디렉터리 정리 (forms 등 다른 파일 있으면 유지)
+find src/components/expenses src/components/incomes -type d -empty -delete 2>/dev/null || true
+```
+
+### 5. ExpenseFormFields 의 정리
+
+`src/components/expenses/forms/ExpenseFormFields.tsx` — `TransactionFormFields` 가 흡수했으므로 제거 검토.
+
+확인:
+```bash
+grep -rln 'ExpenseFormFields' src/ --include='*.tsx' --include='*.ts' | grep -v __tests__
+```
+
+다른 진입점 없으면 제거. 단 phase 01 의 `TransactionFormFields` 가 AmountInput/CategoryGrid 컴포넌트는 별도 재사용 — 그 컴포넌트들은 `src/components/expenses/forms/` 의 하위에 있으면 위치 이동 (`src/components/transactions/forms/`) 또는 그대로 유지 + 경로만 그대로.
+
+본 phase 에선 위치 이동 안 함 (변경 폭 최소화) — 후속 cleanup plan.
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/014-transaction-dialog-unification
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/transactions/dialogs/EditTransactionDialog.tsx
+
+# legacy Edit 파일 0
+[ ! -f src/components/expenses/dialogs/EditExpenseDialog.tsx ]
+[ ! -f src/components/incomes/dialogs/EditIncomeDialog.tsx ]
+[ ! -f src/components/recurring-expense/EditRecurringExpenseSheet.tsx ]
+
+# legacy import 0
+! grep -rn 'EditExpenseDialog\|EditIncomeDialog\|EditRecurringExpenseSheet' src/ \
+  --include='*.tsx' --include='*.ts' \
+  | grep -v __tests__
+
+# 3 update Action import
+grep -nE 'updateExpenseAction|updateIncomeAction|updateRecurringExpenseAction' \
+  src/components/transactions/dialogs/EditTransactionDialog.tsx | wc -l   # >= 3
+
+# 비활성 토글 (disabled / aria-disabled)
+grep -nE 'aria-disabled|disabled' src/components/transactions/dialogs/EditTransactionDialog.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+1. 지출 list → 수정 아이콘 → "지출 수정" 헤더 + expense 토글 활성 + 나머지 비활성
+2. 수입 list → 수정 → "수입 수정"
+3. 고정지출 list → 수정 → "고정지출 수정" + name/dayOfMonth prefill
+4. 저장 → list 갱신
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/transactions/dialogs/EditTransactionDialog.tsx` | 신규 |
+| `src/components/expenses/dialogs/EditExpenseDialog.tsx` | 제거 |
+| `src/components/incomes/dialogs/EditIncomeDialog.tsx` | 제거 |
+| `src/components/recurring-expense/EditRecurringExpenseSheet.tsx` | 제거 |
+| Edit 진입점 (ExpenseItem / IncomeItem / RecurringExpenseItem 등) | import + props 갱신 |
+
+## Out of Scope
+
+- 테스트 갱신 (phase 04)
+- AmountInput / CategoryGrid 위치 이동 — 후속 cleanup
+- 삭제 다이얼로그 (DeleteConfirm) — 본 plan 범위 외, 이미 AlertDialog 패턴 일관
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `updateRecurringExpenseAction` 가 useActionState 시그니처 비호환 | phase 01 의 wrapper 패턴 동일 적용 |
+| Edit 시 type 잠금이 시각적으로 충분히 명확하지 않음 | disabled + opacity-40 + cursor-not-allowed + aria-disabled. 헤더 라벨도 type 명시 |
+| transaction prop 타입 union | `T extends ExpenseResponse \| IncomeResponse \| RecurringExpenseResponse` 제네릭 또는 union — 본 plan 은 union 권장 (제네릭 복잡도 회피) |
+| 빈 디렉터리 (`src/components/expenses/dialogs/`) 의 .gitkeep 등 잔재 | `find -empty -delete` 로 정리. 다른 파일 있으면 디렉터리 유지 |

--- a/tasks/plan014-transaction-dialog-unification/phase-04.md
+++ b/tasks/plan014-transaction-dialog-unification/phase-04.md
@@ -1,0 +1,87 @@
+# Phase 04 — 통합 검증 + jest 테스트 갱신 + completed
+
+**Model**: haiku
+**Status**: pending
+**Goal**: 전체 lint/tsc/build/test 통과 + jest 테스트 파일을 신 구조로 갱신 + index.json completed 마킹.
+
+## 작업 항목
+
+### 1. jest 테스트 갱신
+
+기존 테스트:
+- `src/__tests__/components/incomes/AddIncomeDialog.test.tsx`
+- `src/__tests__/actions/recurring-expense/createRecurringExpenseAction.test.ts` (Action 자체 테스트 — 변경 없음, 본 plan 의 변경 영향 없음)
+- 그 외 EditExpenseDialog / EditIncomeDialog / EditRecurringExpenseSheet 테스트가 있다면 모두
+
+처리:
+```bash
+# legacy 테스트 파일 식별
+find src/__tests__ -name '*AddIncomeDialog*' -o -name '*AddRecurringExpenseSheet*' \
+  -o -name '*EditIncomeDialog*' -o -name '*EditRecurringExpenseSheet*' \
+  -o -name '*AddExpenseDialog*' -o -name '*EditExpenseDialog*' 2>/dev/null
+```
+
+각 파일을 `AddTransactionDialog.test.tsx` / `EditTransactionDialog.test.tsx` 로 재작성 또는 삭제:
+- 신규 단일 테스트 파일 (위치: `src/__tests__/components/transactions/dialogs/`):
+  - 3 type 토글 클릭 → 활성 type 변경
+  - expense 저장 → createExpenseAction mock 호출
+  - income 저장 → createIncomeAction mock 호출
+  - recurring 저장 → createRecurringExpenseAction mock 호출
+  - type 전환 시 amount/category 유지 + date↔dayOfMonth 초기화
+
+jest.mock 패턴은 ADR-F09 그대로 유지.
+
+### 2. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/014-transaction-dialog-unification
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 3. legacy 잔재 0 최종 확인
+
+```bash
+# 4 legacy 컴포넌트 import / 정의 모두 0
+! grep -rnE 'AddExpenseDialog|AddIncomeDialog|AddRecurringExpenseSheet|EditExpenseDialog|EditIncomeDialog|EditRecurringExpenseSheet' \
+  src/ --include='*.tsx' --include='*.ts'
+
+# 신 컴포넌트만 존재
+test -f src/components/transactions/dialogs/AddTransactionDialog.tsx
+test -f src/components/transactions/dialogs/EditTransactionDialog.tsx
+test -f src/components/transactions/forms/TransactionFormFields.tsx
+```
+
+### 4. 6 진입점 수동 smoke (사용자)
+
+| 진입점 | 기대 |
+|---|---|
+| Dashboard "+ 지출" | AddTransactionDialog (expense 토글 활성) |
+| Dashboard "+ 수입" | AddTransactionDialog (income 토글) |
+| BottomNav FAB | AddTransactionDialog (expense) |
+| Transactions 수입 탭 "+ 수입" | AddTransactionDialog (income) |
+| Transactions 고정지출 탭 "+ 고정지출" | AddTransactionDialog (recurring) + name/dayOfMonth 필드 |
+| Settings 고정지출 "+" (해당 시) | 동일 |
+| 각 list 의 수정 아이콘 | EditTransactionDialog + 해당 type 잠금 |
+| Dark mode + 위 시나리오 | 자연스러운 톤 |
+
+### 5. index.json completed 마킹
+
+`tasks/plan014-transaction-dialog-unification/index.json` 의 모든 phase + 최상위 status → `"completed"`, `completed_at` 추가.
+
+### 6. 최종 커밋
+
+```bash
+git add tasks/plan014-transaction-dialog-unification/index.json
+git commit -m "chore(plan014): mark completed"
+```
+
+## Out of Scope
+
+- AmountInput / CategoryGrid 위치 이동 (후속 cleanup)
+- 삭제 다이얼로그 통합
+- categories fetch 의 SWR / cache 도입


### PR DESCRIPTION
## Summary

지출/수입/고정지출 3 도메인의 Add/Edit 다이얼로그를 \`AddTransactionDialog\` + \`EditTransactionDialog\` 단일 컴포넌트로 통합. 6 진입점 일관화.

## Why

- 같은 \"거래 추가\" 의도가 3 도메인 다이얼로그로 분기 → 진입점마다 UI/반응형/토큰 불일치 (Sheet 방향 right vs bottom, legacy \`text-destructive\` / \`text-gray-500\` 잔재)
- AddIncomeDialog 는 사실상 중복 (AddExpenseDialog 가 이미 지출+수입 토글 지원)
- 진입점 6 곳에서 type 분기를 외부에서 결정 → 통일 시 \`defaultType\` prop 하나로 처리

## 변경 내용

- \`docs/adr.md\`: ADR-F21 추가 — 3 도메인 다이얼로그 단일화 결정
- \`docs/flow.md\` §3: 거래 등록 플로우 통합 다이어그램
- \`tasks/plan014-transaction-dialog-unification/\`: 4 phase task

## Phase 구성

1. AddTransactionDialog + TransactionFormFields (3 type 분기)
2. Add 진입점 6 곳 갱신 + legacy 3 파일 제거
3. EditTransactionDialog + Edit 진입점 + legacy 3 파일 제거
4. jest 테스트 갱신 + 통합 검증

## Test plan

- [ ] 머지 후 \`/build-with-teams plan014\` 로 실제 구현 진행
- [ ] 6 진입점 수동 smoke (Dashboard QuickActions x2, BottomNav, Transactions 수입/고정지출 탭, Settings)
- [ ] type 전환 시 amount/category 유지 + date↔dayOfMonth 초기화 확인
- [ ] Dark mode 시각 일관성