### PR TITLE
docs(plan015): /invite/[token] 가족 초대 수락 페이지 시각 갱신 task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -43,8 +43,8 @@
     │
     ├─ /invite/{token} 접속
     │   └─ (인증 안 한 상태면 callbackUrl 보존해 /auth/signin — 인증 후 invite 재진입)
-    │   └─ getInvitationInfoAction(token) — skipAuth (로그인 전 미리보기 허용)
-    │           ├─ 만료/사용됨/취소 → /?error=invalid_invitation
+    │   └─ getInvitationInfoAction(token) — skipAuth (로그인 전 미리보기 허용), token Zod uuid 검증 (ADR-F06)
+    │           ├─ 만료/사용됨/취소 → /?error=invalid_invitation (단일 코드 — 토큰 상태 열거 차단, 상세 사유는 서버 로그만)
     │           └─ 유효 → InvitePageClient (plan015 centered card 패턴)
     │                   │
     │                   ├─ 96px gradient-family round + Users 아이콘 (Auth 톤 일치)
@@ -52,7 +52,7 @@
     │                   ├─ (plan016 — backend #127 머지 후) 초대자 이름·아바타 + 멤버 수
     │                   │
     │                   └─ [수락 / 거절 CTA]
-    │                           └─ 수락 → acceptInvitationAction(token)
+    │                           └─ 수락 → acceptInvitationAction(token) — requireAuth + token Zod uuid 검증 (ADR-F06)
     │                                   └─ FamilyMember 생성 (MEMBER 역할)
     │                                   └─ defaultFamilyUuid 설정
     │                                   └─ /dashboard 리다이렉트

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -42,11 +42,17 @@
 [수락자]
     │
     ├─ /invite/{token} 접속
-    │   └─ getInvitationInfoAction(token)
-    │           ├─ 만료/사용됨 → 오류 메시지
-    │           └─ 유효 → 가족명 + 초대자 표시
-    │                   └─ "수락" 클릭
-    │                           └─ acceptInvitationAction(token)
+    │   └─ (인증 안 한 상태면 callbackUrl 보존해 /auth/signin — 인증 후 invite 재진입)
+    │   └─ getInvitationInfoAction(token) — skipAuth (로그인 전 미리보기 허용)
+    │           ├─ 만료/사용됨/취소 → /?error=invalid_invitation
+    │           └─ 유효 → InvitePageClient (plan015 centered card 패턴)
+    │                   │
+    │                   ├─ 96px gradient-family round + Users 아이콘 (Auth 톤 일치)
+    │                   ├─ 가족 이름 + 만료 일시 (24h 이내 시 expense/10 warning 배지)
+    │                   ├─ (plan016 — backend #127 머지 후) 초대자 이름·아바타 + 멤버 수
+    │                   │
+    │                   └─ [수락 / 거절 CTA]
+    │                           └─ 수락 → acceptInvitationAction(token)
     │                                   └─ FamilyMember 생성 (MEMBER 역할)
     │                                   └─ defaultFamilyUuid 설정
     │                                   └─ /dashboard 리다이렉트

--- a/tasks/plan015-invite-page-redesign/index.json
+++ b/tasks/plan015-invite-page-redesign/index.json
@@ -1,0 +1,34 @@
+{
+  "name": "plan015-invite-page-redesign",
+  "description": "/invite/[token] 가족 초대 수락 페이지 시각 갱신. Auth (signin/signout/error) 와 동일 centered card 톤 + 만료 임박 (24h 이내) 경고 배지 + legacy 토큰 (app-background, text-gray-*, text-blue-600, text-orange-600, bg-muted, bg-gray-50) 제거. inviter/memberCount 추가는 backend #127 + plan016 으로 분리.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan011-landing-auth-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH/gradient-family) ✅",
+    "plan011 PR — Auth centered card 패턴. plan011 머지 후 AuthCenterCard helper 재사용. plan011 미머지 시 inline 동일 구조 작성"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "InvitePageClient 시각 갱신 — centered card + 만료 경고 + legacy 토큰 제거",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "통합 검증 + legacy 잔재 grep + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan015-invite-page-redesign/index.json
+++ b/tasks/plan015-invite-page-redesign/index.json
@@ -1,9 +1,9 @@
 {
   "name": "plan015-invite-page-redesign",
-  "description": "/invite/[token] 가족 초대 수락 페이지 시각 갱신. Auth (signin/signout/error) 와 동일 centered card 톤 + 만료 임박 (24h 이내) 경고 배지 + legacy 토큰 (app-background, text-gray-*, text-blue-600, text-orange-600, bg-muted, bg-gray-50) 제거. inviter/memberCount 추가는 backend #127 + plan016 으로 분리.",
+  "description": "/invite/[token] 가족 초대 수락 페이지 시각 갱신 + invite Server Action 입력 Zod 검증 (ADR-F06). Auth (signin/signout/error) 와 동일 centered card 톤 + 만료 임박 (24h 이내) 경고 배지 + legacy 토큰 (app-background, text-gray-*, text-blue-600, text-orange-600, bg-muted, bg-gray-50) 제거. inviter/memberCount 추가는 backend #127 + plan016 으로 분리.",
   "status": "pending",
   "created_at": "2026-05-11",
-  "total_phases": 2,
+  "total_phases": 3,
   "related_docs": [
     "docs/flow.md"
   ],
@@ -26,6 +26,13 @@
     {
       "number": 2,
       "file": "phase-02.md",
+      "title": "invite Server Action 입력 Zod 검증 보강 (ADR-F06)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
       "title": "통합 검증 + legacy 잔재 grep + completed 마킹",
       "model": "haiku",
       "status": "pending"

--- a/tasks/plan015-invite-page-redesign/phase-01.md
+++ b/tasks/plan015-invite-page-redesign/phase-01.md
@@ -1,0 +1,193 @@
+# Phase 01 — InvitePageClient 시각 갱신
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `/invite/[token]` 의 `InvitePageClient` 를 Auth 톤 centered card 패턴으로 재설계 + 만료 임박 (24h 이내) 경고 배지 + legacy 토큰 제거.
+
+## Context (자기완결)
+
+- 현재 파일: `src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx` (143 줄)
+- legacy 잔재:
+  - `app-background` (plan010 폐기 결정)
+  - `text-gray-900`, `text-gray-600`, `text-gray-700`
+  - `text-blue-600`, `text-orange-600`
+  - `bg-muted`, `bg-gray-50`
+  - `shadow-2xl`, `shadow-lg`
+  - `border-0 shadow-2xl rounded-2xl` 과한 그림자 + 너무 큰 radius
+- 데이터: `getInvitationInfoAction` 응답 = `{ valid, familyName?, expiresAt?, message? }`. inviter/memberCount 는 backend #127 머지 + plan016 으로 분리 (본 phase 범위 외).
+
+## 작업 항목
+
+### 1. 배경 + 카드 wrapper 교체
+
+```tsx
+// 변경 전
+<div className="min-h-screen flex items-center justify-center p-4 app-background">
+  <Card className="max-w-md w-full border-0 shadow-2xl">
+
+// 변경 후 (Auth 톤 일치)
+<div className="min-h-screen flex items-center justify-center p-5 bg-bg">
+  <Card className="max-w-md w-full bg-bg-elev border-border shadow-default">
+```
+
+`shadow-default` 가 globals.css 에 정의되어 있는지 확인 — 없으면 `shadow-sm` 으로 대체.
+
+### 2. 상단 헤더 — 96px gradient-family round (Auth 톤 통일)
+
+기존 `w-20 h-20 gradient-family rounded-full + Users w-10 h-10` 을 plan011 Auth 카드 패턴과 동일하게 96px 로 통일:
+
+```tsx
+<CardHeader className="text-center pb-4 pt-8">
+  <div className="w-24 h-24 gradient-family rounded-full flex items-center justify-center mx-auto mb-4">
+    <Users className="w-12 h-12 text-white" />
+  </div>
+  <CardTitle className="text-2xl font-bold text-fg tracking-tight">
+    가족 초대
+  </CardTitle>
+  <CardDescription className="text-base text-fg-muted">
+    가계부를 함께 관리하도록 초대받았어요
+  </CardDescription>
+</CardHeader>
+```
+
+### 3. 가족 정보 카드 — bg-bg-muted + 토큰 일관
+
+```tsx
+<div className="bg-bg-muted rounded-2xl p-5 space-y-4">
+  <div className="flex items-center gap-3">
+    <Users className="w-5 h-5 text-brand-500" />
+    <div className="flex-1">
+      <p className="text-xs text-fg-muted">가족 이름</p>
+      <p className="text-lg font-semibold text-fg">{familyName}</p>
+    </div>
+  </div>
+
+  <div className="flex items-center gap-3">
+    <Clock className={cn("w-5 h-5", isExpiringSoon ? "text-expense" : "text-fg-muted")} />
+    <div className="flex-1">
+      <div className="flex items-center gap-2">
+        <p className="text-xs text-fg-muted">만료 일시</p>
+        {isExpiringSoon && (
+          <span className="px-1.5 py-0.5 rounded-md bg-expense/10 text-expense text-[10.5px] font-bold uppercase tracking-wide">
+            곧 만료
+          </span>
+        )}
+      </div>
+      <p className={cn(
+        "text-lg font-semibold",
+        isExpiringSoon ? "text-expense" : "text-fg",
+      )}>
+        {format(expiresAt, "M월 d일 (E) HH:mm", { locale: ko })}
+      </p>
+    </div>
+  </div>
+</div>
+```
+
+`isExpiringSoon` 계산:
+
+```ts
+const hoursUntilExpire = (new Date(expiresAt).getTime() - Date.now()) / (1000 * 60 * 60);
+const isExpiringSoon = hoursUntilExpire <= 24;
+```
+
+### 4. 설명 박스 — brand-50 톤
+
+```tsx
+// 변경 전
+<div className="bg-gray-50 rounded-2xl p-4">
+  <p className="text-sm text-gray-700 leading-relaxed">
+    초대를 수락하면{" "}
+    <span className="font-semibold text-blue-600">{familyName}</span>
+    의 구성원이 되어 함께 가계부를 작성하고 관리할 수 있습니다.
+  </p>
+</div>
+
+// 변경 후
+<div className="bg-brand-50 rounded-xl p-4">
+  <p className="text-sm text-brand-700 leading-relaxed">
+    초대를 수락하면{" "}
+    <span className="font-semibold">{familyName}</span>
+    {" "}의 구성원이 되어 함께 가계부를 작성하고 관리할 수 있어요.
+  </p>
+</div>
+```
+
+### 5. 액션 버튼 — gradient-family + 토큰 일관
+
+```tsx
+<div className="flex flex-col sm:flex-row gap-3 pt-2">
+  <Button
+    onClick={handleDecline}
+    variant="outline"
+    className="flex-1 rounded-xl"
+    disabled={isAccepting}
+  >
+    거절하기
+  </Button>
+  <Button
+    onClick={handleAccept}
+    className="flex-1 gradient-family text-white rounded-xl shadow-default hover:opacity-90 transition-opacity"
+    disabled={isAccepting}
+  >
+    {isAccepting ? (
+      <><Loader2 className="w-4 h-4 mr-2 animate-spin" />수락 중...</>
+    ) : (
+      <><UserPlus className="w-4 h-4 mr-2" />초대 수락하기</>
+    )}
+  </Button>
+</div>
+```
+
+기존 `shadow-lg hover:shadow-xl transition-all duration-200 rounded-2xl border-2` 같은 과한 표현 제거.
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/015-invite-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 잔재 0
+! grep -nE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
+  src/app/\(authenticated\)/invite/\[token\]/_components/InvitePageClient.tsx
+
+# 신 토큰 사용
+grep -nE 'bg-bg-elev|bg-bg-muted|text-fg-muted|text-fg\b|gradient-family|bg-brand-50|text-brand-700|bg-expense/10|text-expense' \
+  src/app/\(authenticated\)/invite/\[token\]/_components/InvitePageClient.tsx | wc -l   # >= 5
+
+# 만료 임박 분기 로직
+grep -nE 'isExpiringSoon|hoursUntilExpire' \
+  src/app/\(authenticated\)/invite/\[token\]/_components/InvitePageClient.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+- `/invite/{token}` → 새 카드 디자인. 만료 > 24h → fg-muted 톤 시계 + 일반 폰트
+- 만료 < 24h (서버 응답 조작 또는 임시로 hoursUntilExpire = 12) → expense 톤 "곧 만료" 배지 + 빨간 시계
+- Dark mode → 자연스러운 톤
+- 모바일 (max-w-md 적용) + 데스크톱 동일 카드 너비
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx` | 토큰 + 시각 전체 갱신 + isExpiringSoon 분기 추가 |
+
+## Out of Scope
+
+- 초대자 이름 / 아바타 표시 (backend #127 머지 + plan016)
+- 가족 멤버 수 (동일 — plan016)
+- 인증 안 한 사용자가 /invite 직접 접속 시 미리보기 (현재 callbackUrl 흐름 유지, 별도 plan 검토)
+- 거절 시 토큰 무효화 API (현재 단순 `router.push("/")` 유지)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `shadow-default` 토큰이 globals.css 미정의 | plan001 의 토큰 점검. 없으면 `shadow-sm` 으로 대체 (verification 에 grep 추가) |
+| `bg-expense/10` alpha 변형이 Tailwind v4 OKLCH 토큰에서 미작동 | plan011 phase-02 의 동일 패턴과 일관. 작동 미확인 시 inline `style={{ background: "oklch(0.620 0.180 25 / 0.1)" }}` |
+| Date.now() 가 client 시계 의존 — 사용자 시계 어긋나면 isExpiringSoon 오판 | server time 으로 계산해서 page 가 prop 으로 전달하는 방식이 더 정확하지만, 본 plan 은 단순 client 계산 유지. 24h 임계라 분 단위 오차 무관 |
+| `isAccepting` 도중 다른 진입점에서 토큰 사용 시 race | 본 plan 미해결. Backend 의 token status 가 ACCEPTED 면 다음 진입 시 invalid 처리 — 이미 대응 |

--- a/tasks/plan015-invite-page-redesign/phase-02.md
+++ b/tasks/plan015-invite-page-redesign/phase-02.md
@@ -1,0 +1,58 @@
+# Phase 02 — 통합 검증 + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan015 phase 01 결과 통합 검증. legacy 잔재 0 최종 확인. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/015-invite-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 2. legacy 잔재 0 최종 확인
+
+```bash
+# Invite 영역 전체에서 legacy 토큰 0
+! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
+  src/app/\(authenticated\)/invite/
+
+# 하드코딩 hex 0
+! grep -rnE '#[0-9a-fA-F]{6}' src/app/\(authenticated\)/invite/
+```
+
+### 3. 수동 smoke (사용자)
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 만료 > 24h + `/invite/{token}` | 새 카드 디자인 (gradient-family round + fg-muted 시계) |
+| 만료 ≤ 24h | "곧 만료" expense 배지 + 빨간 시계 |
+| 만료된 토큰 | `/?error=invalid_invitation` redirect (page.tsx 측 처리 — 변경 없음) |
+| "초대 수락하기" 클릭 → 성공 | toast + `/` redirect |
+| Dark mode | 모든 시각 요소 자연스러운 톤 |
+| 모바일 (320px) + 데스크톱 (1280px) | max-w-md 카드 가운데 정렬 일관 |
+
+### 4. index.json completed 마킹
+
+`tasks/plan015-invite-page-redesign/index.json` 의 모든 phase + 최상위 status → `"completed"`, `completed_at` 필드 추가.
+
+### 5. 최종 커밋
+
+```bash
+git add tasks/plan015-invite-page-redesign/index.json
+git commit -m "chore(plan015): mark completed"
+```
+
+## Out of Scope
+
+- inviter / memberCount 표시 (plan016 + backend #127)
+- 인증 안 한 사용자 미리보기 (별도 plan)
+- 거절 시 token 무효화 API

--- a/tasks/plan015-invite-page-redesign/phase-02.md
+++ b/tasks/plan015-invite-page-redesign/phase-02.md
@@ -1,58 +1,124 @@
-# Phase 02 — 통합 검증 + completed 마킹
+# Phase 02 — invite Server Action 입력 Zod 검증 보강
 
-**Model**: haiku
+**Model**: sonnet
 **Status**: pending
-**Goal**: plan015 phase 01 결과 통합 검증. legacy 잔재 0 최종 확인. index.json completed 마킹.
+**Goal**: `getInvitationInfoAction` / `acceptInvitationAction` 의 `token` 입력을 Zod 로 런타임 검증 (ADR-F06 준수). 악의적 토큰 형식이 service / API 호출에 그대로 흘러가지 않도록 차단.
+
+## Context (자기완결)
+
+- 현재 두 액션 모두 `token: string` 만 받고 별도 Zod 검증 없음. service 까지 그대로 전달.
+- ADR-F06: Server Action 입력은 **Zod 런타임 검증 필수**. 현재 plan015 가 시각 변경만 다뤘던 phase-01 로 인해 보안 갭 노출됨 (PR #245 claude bot 리뷰 지적).
+- 초대 토큰은 백엔드에서 UUID v4 형식으로 발급 (`backend` 의 invitation 도메인). 형식 어긋나면 service 호출 자체가 무의미.
+- **권한 모델 명확화**: invite token 자체가 "이 가족에 join 할 권한 증명". `acceptInvitationAction` 은 `requireAuth()` 로 사용자 신원만 확인하면 충분 — 토큰이 유효한 한 누가 수락해도 join 흐름은 동일. `getSelectedFamilyUuid()` 와 비교하는 것은 invite 시맨틱에 맞지 않음 (수락자는 아직 그 가족 멤버가 아니므로). 즉 본 phase 는 **Zod 형식 검증** + **service 측 토큰 상태 검증 (만료/사용됨/취소)** 만 강화.
 
 ## 작업 항목
 
-### 1. 통합 빌드/린트/테스트
+### 1. 공용 Zod 스키마 정의
+
+`src/actions/invitation/_schemas.ts` 신규 (또는 각 액션 파일 상단에 inline):
+
+```ts
+import { z } from "zod";
+
+export const InvitationTokenSchema = z.object({
+  token: z.string().uuid(),
+});
+```
+
+UUID v4 가 표준 — `z.string().uuid()` 가 v1~v5 모두 통과. backend 가 v4 만 발급해도 검증 범위는 RFC 4122 전체로 충분.
+
+### 2. `getInvitationInfoAction` Zod 적용
+
+```ts
+// src/actions/invitation/get-invitation-info-action.ts
+export async function getInvitationInfoAction(
+  token: string
+): Promise<ActionResult<InvitationInfoData>> {
+  try {
+    const { token: validToken } = InvitationTokenSchema.parse({ token });
+    const info = await getInvitationInfo(validToken);
+    return successResult(info);
+  } catch (error) {
+    return handleActionError(error, "초대 정보를 가져오는데 실패했습니다");
+  }
+}
+```
+
+`ZodError` 가 발생하면 `handleActionError` 가 catch — 사용자에게는 일반 에러 메시지만 노출 (토큰 형식 디테일은 서버 로그만).
+
+### 3. `acceptInvitationAction` Zod 적용
+
+```ts
+// src/actions/invitation/accept-invitation-action.ts
+export async function acceptInvitationAction(
+  token: string
+): Promise<ActionResult<void>> {
+  try {
+    await requireAuth();
+    const { token: validToken } = InvitationTokenSchema.parse({ token });
+    await acceptInvitation(validToken);
+    revalidatePath("/");
+    return successResult(undefined);
+  } catch (error) {
+    return handleActionError(error, "초대 수락에 실패했습니다");
+  }
+}
+```
+
+`requireAuth()` 가 Zod 보다 먼저 — 비인증 요청은 form 진입 자체가 차단. Zod 는 토큰 형식만 본다.
+
+### 4. 단위 테스트 추가
+
+`src/__tests__/actions/invitation/get-invitation-info-action.test.ts` (또는 기존 테스트 파일 보강):
+- 잘못된 UUID 형식 (`"not-a-uuid"`, `""`, `"<script>"`) → 에러 ActionResult 반환 + service 호출 0 회 (jest.mock)
+- 정상 UUID → service 호출 + successResult
+
+`src/__tests__/actions/invitation/accept-invitation-action.test.ts` 도 동일 패턴.
+
+### 5. 자동 verification
 
 ```bash
-# cwd: /Users/nhn/personal/fos-accountbook
-# branch: plan/015-invite-page-redesign
+# cwd: /Users/nhn/personal/fos-accountbook/.claude/worktrees/plan015
+# branch: feat/plan015-...
 
 pnpm lint
 pnpm tsc --noEmit
 pnpm test --passWithNoTests
 pnpm build
+
+# Zod 검증 적용 확인
+grep -nE 'InvitationTokenSchema|z\.string\(\)\.uuid' \
+  src/actions/invitation/get-invitation-info-action.ts \
+  src/actions/invitation/accept-invitation-action.ts | wc -l   # >= 2
+
+# 두 action 에서 .parse 호출 확인
+grep -nE 'InvitationTokenSchema\.parse|Schema\.parse\(' \
+  src/actions/invitation/get-invitation-info-action.ts \
+  src/actions/invitation/accept-invitation-action.ts | wc -l   # >= 2
+
+# 테스트 파일 존재
+test -f src/__tests__/actions/invitation/get-invitation-info-action.test.ts || test -f src/__tests__/actions/invitation/accept-invitation-action.test.ts
 ```
 
-### 2. legacy 잔재 0 최종 확인
+## Critical Files
 
-```bash
-# Invite 영역 전체에서 legacy 토큰 0
-! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
-  src/app/\(authenticated\)/invite/
-
-# 하드코딩 hex 0
-! grep -rnE '#[0-9a-fA-F]{6}' src/app/\(authenticated\)/invite/
-```
-
-### 3. 수동 smoke (사용자)
-
-| 시나리오 | 기대 결과 |
+| 파일 | 상태 |
 |---|---|
-| 만료 > 24h + `/invite/{token}` | 새 카드 디자인 (gradient-family round + fg-muted 시계) |
-| 만료 ≤ 24h | "곧 만료" expense 배지 + 빨간 시계 |
-| 만료된 토큰 | `/?error=invalid_invitation` redirect (page.tsx 측 처리 — 변경 없음) |
-| "초대 수락하기" 클릭 → 성공 | toast + `/` redirect |
-| Dark mode | 모든 시각 요소 자연스러운 톤 |
-| 모바일 (320px) + 데스크톱 (1280px) | max-w-md 카드 가운데 정렬 일관 |
-
-### 4. index.json completed 마킹
-
-`tasks/plan015-invite-page-redesign/index.json` 의 모든 phase + 최상위 status → `"completed"`, `completed_at` 필드 추가.
-
-### 5. 최종 커밋
-
-```bash
-git add tasks/plan015-invite-page-redesign/index.json
-git commit -m "chore(plan015): mark completed"
-```
+| `src/actions/invitation/_schemas.ts` (또는 inline) | 신규 — InvitationTokenSchema |
+| `src/actions/invitation/get-invitation-info-action.ts` | Zod parse 추가 |
+| `src/actions/invitation/accept-invitation-action.ts` | Zod parse 추가 |
+| `src/__tests__/actions/invitation/*.test.ts` | 잘못된 토큰 검증 케이스 추가 |
 
 ## Out of Scope
 
-- inviter / memberCount 표시 (plan016 + backend #127)
-- 인증 안 한 사용자 미리보기 (별도 plan)
-- 거절 시 token 무효화 API
+- 토큰 상태 (만료/사용됨/취소) 별 에러 종류를 URL 에 구분 노출하지 않음 — 이미 `/?error=invalid_invitation` 단일 표시로 docs/flow.md 에 명시 (PR #245 리뷰 권고 사항 반영, 토큰 상태 열거 방지)
+- 권한 모델 변경 (토큰 ↔ 이메일 binding 추가) — invite 시맨틱은 "토큰 = join 권한 증명" 유지. 별도 plan 검토
+- service layer 의 검증 — 백엔드 API 가 최종 검증. action 은 형식만 차단
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 백엔드가 UUID v4 외 형식 (예: hex string) 으로 발급 변경 시 Zod 가 거부 | `z.string().uuid()` 가 RFC 4122 v1~v5 전체 허용. backend 변경 시 schema 도 동시 갱신. ADR 또는 plan note |
+| ZodError 가 사용자에게 디테일 노출 | `handleActionError` 가 일반 메시지만 반환하는 패턴 — 기존 액션과 동일. 서버 로그에 ZodError 기록 |
+| 기존 테스트 mock 이 Zod parse 통과 못함 | 기존 테스트의 토큰 fixture 를 valid UUID 로 교체. 별도 invalid case 추가 |

--- a/tasks/plan015-invite-page-redesign/phase-03.md
+++ b/tasks/plan015-invite-page-redesign/phase-03.md
@@ -1,0 +1,58 @@
+# Phase 03 — 통합 검증 + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan015 phase 01~02 결과 통합 검증. legacy 잔재 0 + Zod 검증 적용 최종 확인. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/015-invite-page-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 2. legacy 잔재 0 최종 확인
+
+```bash
+# Invite 영역 전체에서 legacy 토큰 0
+! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
+  src/app/\(authenticated\)/invite/
+
+# 하드코딩 hex 0
+! grep -rnE '#[0-9a-fA-F]{6}' src/app/\(authenticated\)/invite/
+```
+
+### 3. 수동 smoke (사용자)
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 만료 > 24h + `/invite/{token}` | 새 카드 디자인 (gradient-family round + fg-muted 시계) |
+| 만료 ≤ 24h | "곧 만료" expense 배지 + 빨간 시계 |
+| 만료된 토큰 | `/?error=invalid_invitation` redirect (page.tsx 측 처리 — 변경 없음) |
+| "초대 수락하기" 클릭 → 성공 | toast + `/` redirect |
+| Dark mode | 모든 시각 요소 자연스러운 톤 |
+| 모바일 (320px) + 데스크톱 (1280px) | max-w-md 카드 가운데 정렬 일관 |
+
+### 4. index.json completed 마킹
+
+`tasks/plan015-invite-page-redesign/index.json` 의 모든 phase + 최상위 status → `"completed"`, `completed_at` 필드 추가.
+
+### 5. 최종 커밋
+
+```bash
+git add tasks/plan015-invite-page-redesign/index.json
+git commit -m "chore(plan015): mark completed"
+```
+
+## Out of Scope
+
+- inviter / memberCount 표시 (plan016 + backend #127)
+- 인증 안 한 사용자 미리보기 (별도 plan)
+- 거절 시 token 무효화 API


### PR DESCRIPTION
## Summary

\`/invite/[token]\` 의 \`InvitePageClient\` 를 Auth 톤 centered card 로 재설계 + 만료 임박 (24h 이내) 경고 배지 추가.

## Why

- 현재 페이지가 \`app-background\` (plan010 폐기), \`text-gray-900/600\`, \`text-blue-600\`, \`text-orange-600\`, \`bg-muted\`, \`bg-gray-50\`, \`shadow-2xl\` 등 legacy 토큰 잔재
- Auth (signin/signout/error) 의 centered card 패턴 (plan011) 과 첫 인상 일관성 부재
- 만료 임박 시 사용자에게 시각적 경고 없음 — 수락 촉구 부재

## 변경 내용

- \`docs/flow.md\` §2: 수락자 다이어그램 갱신 (skipAuth 미리보기 + plan015 centered card + plan016 후속 표시 명시)
- \`tasks/plan015-invite-page-redesign/\`: 2 phase task
  - 01 InvitePageClient 시각 갱신 + 24h 임박 경고
  - 02 통합 검증 + completed

## 분리된 후속

- inviter / memberCount 표시: backend \`jon890/fos-accountbook-backend#127\` 머지 + plan016 분리

## Test plan

- [ ] 머지 후 \`/build-with-teams plan015\` 로 실제 구현 진행
- [ ] 만료 > 24h vs ≤ 24h 두 시나리오 시각 차이 (expense 배지 + 시계 색)
- [ ] Dark mode + 모바일/데스크톱 일관성