### PR TITLE
docs(plan017): Notifications 시각 통일 + /notifications 전용 페이지 task

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"e578dace-c1e6-434a-8869-04c2b9702ac3","pid":73728,"procStart":"Mon May 11 09:42:15 2026","acquiredAt":1778493249000}

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -201,10 +201,23 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
                     └─ 100% 이상 → BUDGET_EXCEEDED Notification 생성
                                     (yearMonth 기준 중복 방지)
 
-[프론트엔드]
-    └─ Header의 NotificationBell
-            ├─ getUnreadCountAction() (주기적 조회)
-            └─ 클릭 → 알림 목록 → markNotificationReadAction()
+[프론트엔드 — plan017]
+    └─ Header 의 NotificationBell (Popover trigger)
+            ├─ getUnreadCountAction() (1분 폴링) → bg-expense Badge (count > 99 시 "99+")
+            └─ 클릭 → Popover (NotificationList, max-h-[500px])
+                    │
+                    ├─ 최근 10개 + "전체보기" 링크 → /notifications
+                    │
+                    └─ NotificationItem 톤 매핑 (2 단계):
+                            ├─ BUDGET_50_EXCEEDED / BUDGET_80_EXCEEDED → warning 톤 (bg-warning/10 + text-warning)
+                            ├─ BUDGET_100_EXCEEDED                       → expense 톤 (bg-expense/10 + text-expense)
+                            └─ default                                    → brand 톤 (bg-brand-50 + text-brand-700)
+
+[/notifications 전용 페이지 — plan017]
+    └─ 전체 알림 목록 + segmented (전체 / 안 읽음) + pagination
+            ├─ Skel skeleton (plan012 .ab-skel 재사용) — loading 상태
+            ├─ EmptyState (plan012 EmptyState 재사용) — "알림이 없어요"
+            └─ "모두 읽음" 버튼 (페이지 최상단)
 ```
 
 ---

--- a/tasks/plan017-notifications-redesign/index.json
+++ b/tasks/plan017-notifications-redesign/index.json
@@ -1,0 +1,43 @@
+{
+  "name": "plan017-notifications-redesign",
+  "description": "NotificationBell / NotificationList / NotificationItem 토큰 일관화 (warning + expense + brand 2단계 매핑) + /notifications 전용 페이지 신규 + Popover '전체보기' 링크 + Skel skeleton loading.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan002-dashboard-redesign",
+    "plan012-empty-error-loading-states"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH 토큰 — brand/warning/expense) ✅",
+    "plan002 머지 (Header / Bell 위치) ✅",
+    "plan012 PR 머지 후 Skel + EmptyState 재사용 가능. 미머지 시 inline 동일 패턴 작성"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "NotificationBell + List + Item 토큰 일관화 (warning + expense + brand 2단계)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "/notifications 전용 페이지 + segmented (전체 / 안 읽음) + Skel skeleton + Popover 전체보기 링크",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증 + legacy 잔재 grep + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan017-notifications-redesign/phase-01.md
+++ b/tasks/plan017-notifications-redesign/phase-01.md
@@ -198,3 +198,4 @@ grep -nE 'getNotificationTone|TONE_BG|TONE_FG' \
 | `bg-warning/10` / `bg-expense/10` alpha 변형 미작동 (Tailwind v4 + OKLCH) | plan011/013 의 동일 패턴 일관 — 작동 확인됨. 미작동 시 inline `style={{ background: "oklch(...)" }}` |
 | `--color-warning` 토큰 미정의 | plan001 점검 — warning 토큰 존재 확인 (Tailwind v4 `--color-warning` 매핑). 없으면 phase 시작 시 globals.css 추가 |
 | AlertTriangle vs AlertCircle 50/80% 구분 모호 | 50% = AlertTriangle, 80% = AlertCircle 로 일관 유지 (현재 패턴 보존). 톤만 warning 으로 통일 |
+| Badge `bg-expense text-white` 의 dark mode 대비 약화 | `--color-expense` OKLCH 값이 dark 에서 밝아질 경우 white 텍스트 contrast 부족 가능. **구현 후 dark mode 수동 smoke test 필수** — pnpm build 외에 시각 검증 추가. 부족 시 `text-expense-fg` 같은 의미론적 foreground 토큰 도입 (별도 plan) |

--- a/tasks/plan017-notifications-redesign/phase-01.md
+++ b/tasks/plan017-notifications-redesign/phase-01.md
@@ -1,0 +1,200 @@
+# Phase 01 — NotificationBell + List + Item 토큰 일관화
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 3 컴포넌트 (Bell / List / Item) 의 legacy 하드 색 (`text-yellow-500`, `text-orange-500`, `text-red-500`, `text-blue-500`, `bg-yellow-50`, `bg-orange-50`, `bg-red-50`, `bg-blue-50`, `text-gray-*`) 제거 + warning + expense + brand 2단계 톤 매핑.
+
+## Context (자기완결)
+
+- 현재 파일:
+  - `src/components/notifications/NotificationBell.tsx` (84 줄) — Popover trigger + Badge
+  - `src/components/notifications/NotificationList.tsx` (113 줄) — 헤더 + ScrollArea + 모두읽음
+  - `src/components/notifications/NotificationItem.tsx` (139 줄) — 4 타입별 아이콘/배경
+- 알림 타입: `BUDGET_50_EXCEEDED` / `BUDGET_80_EXCEEDED` / `BUDGET_100_EXCEEDED` + default
+- 톤 매핑 (사용자 결정):
+  - 50/80% → **warning** (bg-warning/10 + text-warning + AlertTriangle/AlertCircle)
+  - 100% → **expense** (bg-expense/10 + text-expense + XCircle)
+  - default → **brand** (bg-brand-50 + text-brand-700 + AlertCircle)
+
+## 작업 항목
+
+### 1. NotificationBell — 토큰 + Badge
+
+```tsx
+// 변경 전
+<Button variant="ghost" size="sm"
+  className="relative text-gray-600 hover:text-gray-900 h-8 w-8 md:h-9 md:w-9 p-0">
+  <Bell ... />
+  {unreadCount > 0 && (
+    <Badge variant="destructive" ...>
+      {unreadCount > 99 ? "99+" : unreadCount}
+    </Badge>
+  )}
+</Button>
+
+// 변경 후
+<Button variant="ghost" size="sm"
+  className="relative text-fg-muted hover:text-fg h-8 w-8 md:h-9 md:w-9 p-0">
+  <Bell ... />
+  {unreadCount > 0 && (
+    <Badge
+      className="absolute -top-1 -right-1 h-4 w-4 md:h-5 md:w-5 p-0 flex items-center justify-center text-[10px] md:text-xs bg-expense text-white border-0">
+      {unreadCount > 99 ? "99+" : unreadCount}
+    </Badge>
+  )}
+</Button>
+```
+
+`variant="destructive"` 제거 — shadcn destructive 가 OKLCH 토큰 미적용일 수 있으므로 `bg-expense text-white` 명시.
+
+### 2. NotificationList — 토큰 + 헤더 + empty/loading
+
+```tsx
+// 변경 전 loading
+<div className="p-4 text-center text-gray-500">
+  <p>알림을 불러오는 중...</p>
+</div>
+
+// 변경 후 loading — phase 02 의 Skel skeleton 사용 (본 phase 는 임시 텍스트만 유지)
+<div className="p-4 text-center text-fg-muted">
+  <p>알림을 불러오는 중...</p>
+</div>
+
+// 변경 전 empty
+<div className="p-8 text-center text-gray-500">
+  <Bell className="w-12 h-12 mx-auto mb-2 text-gray-300" />
+  <p>알림이 없습니다</p>
+</div>
+
+// 변경 후 empty — plan012 EmptyState 패턴 (inline)
+<div className="p-8 text-center">
+  <div className="w-16 h-16 rounded-full bg-brand-50 mx-auto mb-3 flex items-center justify-center">
+    <Bell className="w-8 h-8 text-brand-500 opacity-85" />
+  </div>
+  <p className="text-sm font-semibold text-fg">알림이 없어요</p>
+  <p className="text-xs text-fg-muted mt-1">예산 80% / 100% 초과 시 알려드릴게요</p>
+</div>
+
+// 헤더 border-b → border-border 명시
+<div className="flex items-center justify-between px-4 py-3 border-b border-border">
+```
+
+### 3. NotificationItem — 톤 매핑 helper 재작성
+
+```ts
+// 변경 전
+const getNotificationBgColor = (type: NotificationType) => {
+  switch (type) {
+    case "BUDGET_50_EXCEEDED": return "bg-yellow-50 border-yellow-200";
+    case "BUDGET_80_EXCEEDED": return "bg-orange-50 border-orange-200";
+    case "BUDGET_100_EXCEEDED": return "bg-red-50 border-red-200";
+    default:                   return "bg-blue-50 border-blue-200";
+  }
+};
+
+// 변경 후 — 2단계 매핑
+type NotificationTone = "warning" | "expense" | "brand";
+
+const getNotificationTone = (type: NotificationType): NotificationTone => {
+  if (type === "BUDGET_100_EXCEEDED") return "expense";
+  if (type === "BUDGET_50_EXCEEDED" || type === "BUDGET_80_EXCEEDED") return "warning";
+  return "brand";
+};
+
+const TONE_BG: Record<NotificationTone, string> = {
+  warning: "bg-warning/10",
+  expense: "bg-expense/10",
+  brand:   "bg-brand-50",
+};
+
+const TONE_FG: Record<NotificationTone, string> = {
+  warning: "text-warning",
+  expense: "text-expense",
+  brand:   "text-brand-700",
+};
+```
+
+아이콘 매핑:
+- expense → `XCircle`
+- warning → `AlertCircle` (80%) / `AlertTriangle` (50%) — 또는 둘 다 AlertTriangle 로 통합 (warning 톤 동일)
+- brand → `AlertCircle`
+
+### 4. NotificationItem — 본문 토큰 일괄 교체
+
+```tsx
+// 변경 전
+className={cn(
+  "w-full p-4 text-left transition-colors hover:bg-gray-50",
+  !notification.isRead && "bg-blue-50/50"
+)}
+// 변경 후
+className={cn(
+  "w-full p-4 text-left transition-colors hover:bg-bg-muted",
+  !notification.isRead && "bg-brand-50/50"
+)}
+
+// title
+!notification.isRead ? "text-fg" : "text-fg-muted"
+// message
+!notification.isRead ? "text-fg-muted" : "text-fg-subtle"
+// time
+text-fg-subtle
+// 읽지 않음 dot
+bg-brand-500 → 그대로
+```
+
+### 5. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/017-notifications-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 하드 색 0
+! grep -rnE 'text-gray-|text-yellow-|text-orange-|text-red-|text-blue-|bg-yellow-|bg-orange-|bg-red-|bg-blue-' \
+  src/components/notifications/
+
+# variant="destructive" 제거됨
+! grep -rn 'variant="destructive"' src/components/notifications/
+
+# 신 토큰 사용
+grep -rnE 'text-fg|bg-bg-muted|bg-warning/|bg-expense/|bg-brand-50|text-warning|text-expense|text-brand-700' \
+  src/components/notifications/ | wc -l   # >= 5
+
+# 톤 helper 존재
+grep -nE 'getNotificationTone|TONE_BG|TONE_FG' \
+  src/components/notifications/NotificationItem.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+- 알림이 있는 가족 계정 + Dashboard → Bell 클릭 → Popover 열림
+- 50% / 80% 초과 알림 → warning 톤 (주황)
+- 100% 초과 → expense 톤 (빨강)
+- Dark mode → 모든 톤 자연스러움
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/notifications/NotificationBell.tsx` | Badge 토큰 + 색 |
+| `src/components/notifications/NotificationList.tsx` | 헤더 + empty 카드 + loading 토큰 |
+| `src/components/notifications/NotificationItem.tsx` | 톤 helper + 본문 토큰 |
+
+## Out of Scope
+
+- /notifications 전용 페이지 (phase 02)
+- Skel skeleton (phase 02)
+- Popover 전체보기 링크 (phase 02)
+- 알림 type 추가 / backend schema 변경
+- 알림 grouping (날짜별 / type별)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `bg-warning/10` / `bg-expense/10` alpha 변형 미작동 (Tailwind v4 + OKLCH) | plan011/013 의 동일 패턴 일관 — 작동 확인됨. 미작동 시 inline `style={{ background: "oklch(...)" }}` |
+| `--color-warning` 토큰 미정의 | plan001 점검 — warning 토큰 존재 확인 (Tailwind v4 `--color-warning` 매핑). 없으면 phase 시작 시 globals.css 추가 |
+| AlertTriangle vs AlertCircle 50/80% 구분 모호 | 50% = AlertTriangle, 80% = AlertCircle 로 일관 유지 (현재 패턴 보존). 톤만 warning 으로 통일 |

--- a/tasks/plan017-notifications-redesign/phase-02.md
+++ b/tasks/plan017-notifications-redesign/phase-02.md
@@ -1,0 +1,188 @@
+# Phase 02 — /notifications 전용 페이지 + Popover 전체보기 링크 + Skel skeleton
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `/notifications` 라우트 신규 (전체 알림 + segmented 필터 + pagination) + NotificationList Popover 에 "전체보기" 링크 + Skel skeleton loading.
+
+## Context (자기완결)
+
+- phase 01 의 NotificationBell/List/Item 토큰 일관화 완료 전제
+- 데이터:
+  - `getNotificationsAction(familyUuid)` — 전체 알림 반환 (현재 limit 없음 — service 측 default 100 추정)
+  - `markAllNotificationsReadAction(familyUuid)` / `markNotificationReadAction(familyUuid, uuid)`
+- 페이지 위치: `src/app/(authenticated)/notifications/page.tsx`
+- 컴포넌트 위치: `src/app/(authenticated)/notifications/_components/NotificationsClient.tsx` + 페이지별 loading.tsx
+
+## 작업 항목
+
+### 1. Popover 의 "전체보기" 링크 + 최근 10개 제한
+
+`NotificationList.tsx` 갱신:
+
+```tsx
+// 최근 10개만 표시
+const recentNotifications = notifications.slice(0, 10);
+
+// 본문 하단에 링크
+<div className="border-t border-border px-4 py-2.5 bg-bg-muted">
+  <Link
+    href="/notifications"
+    className="block text-center text-sm font-semibold text-brand-700 hover:text-brand-800"
+  >
+    전체 보기 →
+  </Link>
+</div>
+```
+
+전체보기 클릭 시 Popover 닫기 — `onLinkClick` prop 또는 useRouter 사용.
+
+### 2. /notifications 페이지 — Server Component
+
+`src/app/(authenticated)/notifications/page.tsx`:
+
+```tsx
+import { auth } from "@/lib/server/auth";
+import { redirect } from "next/navigation";
+import { getSelectedFamilyUuid } from "@/lib/server/auth/auth-helpers";
+import { getNotificationsAction } from "@/actions/notification/get-notifications-action";
+import { NotificationsClient } from "./_components/NotificationsClient";
+
+interface NotificationsPageProps {
+  searchParams: Promise<{ filter?: "all" | "unread" }>;
+}
+
+export default async function NotificationsPage({ searchParams }: NotificationsPageProps) {
+  const session = await auth();
+  if (!session) redirect("/auth/signin");
+
+  const familyUuid = await getSelectedFamilyUuid();
+  if (!familyUuid) redirect("/");
+
+  const { filter = "all" } = await searchParams;
+
+  const result = await getNotificationsAction(familyUuid);
+  const notifications = result.success ? result.data.notifications : [];
+
+  return (
+    <NotificationsClient
+      familyUuid={familyUuid}
+      notifications={notifications}
+      filter={filter}
+    />
+  );
+}
+```
+
+### 3. NotificationsClient — segmented + "모두 읽음" + list
+
+```ts
+interface NotificationsClientProps {
+  familyUuid: string;
+  notifications: Notification[];
+  filter: "all" | "unread";
+}
+```
+
+구조:
+- 페이지 헤더: "알림" 22px font-bold + "모두 읽음" CTA (unreadCount > 0 시)
+- Segmented tablist (전체 / 안 읽음 — `bg-bg-muted` + 활성 `bg-bg-elev shadow-sm`) — URL `?filter=` 단방향
+- 본문: filter 적용된 list — phase 01 의 `NotificationItem` 재사용
+- Empty: filter="unread" + 0건 → "안 읽은 알림이 없어요" / filter="all" + 0건 → "알림이 없어요" (phase 01 의 empty 카드 재사용 또는 plan012 의 EmptyState 사용)
+
+pagination 은 본 plan 미포함 (현재 100건 default 로 충분) — 후속 plan 검토.
+
+### 4. Skel skeleton — loading.tsx 신규
+
+`src/app/(authenticated)/notifications/loading.tsx` (Server Component OK):
+
+```tsx
+import { Skel } from "@/components/loading/Skel";
+
+export default function NotificationsLoading() {
+  return (
+    <div className="p-4 md:p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <Skel w="30%" h={24} />
+        <Skel w={88} h={32} r={8} />
+      </div>
+      <Skel w="100%" h={40} r={10} />
+      <div className="space-y-2">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex gap-3 p-4 rounded-xl border border-border">
+            <Skel w={40} h={40} r={999} />
+            <div className="flex-1 space-y-2">
+              <Skel w="60%" h={14} />
+              <Skel w="90%" h={12} />
+              <Skel w="20%" h={10} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+`Skel` 컴포넌트는 plan012 머지 후 사용. plan012 미머지 시 inline 동일 패턴 (`ab-skel` class).
+
+### 5. NavLink / Header — /notifications 접근 동선
+
+Header 또는 BottomNav 에 /notifications 직접 접근 링크 추가 검토:
+- Header: Bell 아이콘이 이미 Popover trigger — 별도 항목 불필요
+- BottomNav: 5 grid 가 이미 채워져 있으므로 추가 안 함
+- Popover 의 "전체보기" 만 진입점으로 충분
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/017-notifications-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/app/\(authenticated\)/notifications/page.tsx
+test -f src/app/\(authenticated\)/notifications/_components/NotificationsClient.tsx
+test -f src/app/\(authenticated\)/notifications/loading.tsx
+
+# Popover 전체보기 링크
+grep -n 'href=["\x27]/notifications' src/components/notifications/NotificationList.tsx | wc -l   # >= 1
+
+# segmented + URL filter
+grep -nE 'filter=|searchParams.*filter' src/app/\(authenticated\)/notifications/ -r | wc -l   # >= 2
+
+# Skel 사용
+grep -n 'Skel\|ab-skel' src/app/\(authenticated\)/notifications/loading.tsx | wc -l   # >= 1
+```
+
+수동 smoke:
+- Bell → "전체보기" 클릭 → /notifications 이동 + Popover 닫힘
+- /notifications → 전체 / 안 읽음 segmented 동작 + URL `?filter=unread` 갱신
+- /notifications loading (Network Slow 3G) → Skel skeleton 표시
+- /notifications + 0건 → empty 카드
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/notifications/NotificationList.tsx` | 최근 10개 제한 + "전체보기" 링크 |
+| `src/app/(authenticated)/notifications/page.tsx` | 신규 (Server Component) |
+| `src/app/(authenticated)/notifications/_components/NotificationsClient.tsx` | 신규 (use client) |
+| `src/app/(authenticated)/notifications/loading.tsx` | 신규 (Skel skeleton) |
+
+## Out of Scope
+
+- pagination (현재 default 100 으로 충분)
+- 알림 grouping (날짜별 / type별)
+- 알림 삭제 기능
+- 알림 push 통보 (브라우저 Notification API)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| Popover 안 Link 클릭이 Popover 닫지 못함 | `useRouter().push()` + `setIsOpen(false)` 동시 호출. 또는 Next.js Link 의 자연스러운 navigation 후 Popover 의 onClickOutside 자동 닫힘 |
+| `?filter=unread` URL state 와 client filter 충돌 | URL = single source. client 가 URL 변경 시 router.push 만 호출, 표시는 server props 의 filter 기반 (server 갱신) |
+| 100건 default 가 일부 가족에서 부족 | 본 plan 은 default 유지. 사용자 보고 시 pagination 후속 plan |
+| Skel skeleton 이 NotificationItem 구조와 어긋남 | phase 01 의 Item 레이아웃 (40px round + 3 line) 매치. layout shift 최소 |

--- a/tasks/plan017-notifications-redesign/phase-02.md
+++ b/tasks/plan017-notifications-redesign/phase-02.md
@@ -43,12 +43,15 @@ const recentNotifications = notifications.slice(0, 10);
 ```tsx
 import { auth } from "@/lib/server/auth";
 import { redirect } from "next/navigation";
+import { z } from "zod";
 import { getSelectedFamilyUuid } from "@/lib/server/auth/auth-helpers";
 import { getNotificationsAction } from "@/actions/notification/get-notifications-action";
 import { NotificationsClient } from "./_components/NotificationsClient";
 
+const FilterSchema = z.enum(["all", "unread"]).default("all");
+
 interface NotificationsPageProps {
-  searchParams: Promise<{ filter?: "all" | "unread" }>;
+  searchParams: Promise<{ filter?: string | string[] }>;
 }
 
 export default async function NotificationsPage({ searchParams }: NotificationsPageProps) {
@@ -58,7 +61,11 @@ export default async function NotificationsPage({ searchParams }: NotificationsP
   const familyUuid = await getSelectedFamilyUuid();
   if (!familyUuid) redirect("/");
 
-  const { filter = "all" } = await searchParams;
+  const raw = await searchParams;
+  // Zod 런타임 검증 (ADR-F06) — 잘못된 값은 default "all"
+  const filter = FilterSchema.catch("all").parse(
+    Array.isArray(raw.filter) ? raw.filter[0] : raw.filter
+  );
 
   const result = await getNotificationsAction(familyUuid);
   const notifications = result.success ? result.data.notifications : [];
@@ -75,19 +82,42 @@ export default async function NotificationsPage({ searchParams }: NotificationsP
 
 ### 3. NotificationsClient — segmented + "모두 읽음" + list
 
-```ts
+```tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+
 interface NotificationsClientProps {
   familyUuid: string;
   notifications: Notification[];
   filter: "all" | "unread";
 }
+
+export function NotificationsClient({ familyUuid, notifications, filter }: NotificationsClientProps) {
+  const router = useRouter();
+
+  // client-side filter — 페이지가 모든 알림을 받아 메모리 필터
+  const visible = filter === "unread"
+    ? notifications.filter((n) => !n.isRead)
+    : notifications;
+
+  const handleFilterChange = (next: "all" | "unread") => {
+    // URL = single source. router.push 가 server re-render 트리거하지만
+    // notifications 자체는 props 로 받은 메모리 데이터 재사용 (재요청 없음)
+    router.push(next === "all" ? "/notifications" : "/notifications?filter=unread");
+  };
+
+  // ... 헤더 + segmented (handleFilterChange) + list (visible) + empty 카드
+}
 ```
+
+⚠️ **반드시 첫 줄 `"use client"`** (CLAUDE.md 규칙). useRouter / 이벤트 핸들러가 client 훅이라 필수.
 
 구조:
 - 페이지 헤더: "알림" 22px font-bold + "모두 읽음" CTA (unreadCount > 0 시)
-- Segmented tablist (전체 / 안 읽음 — `bg-bg-muted` + 활성 `bg-bg-elev shadow-sm`) — URL `?filter=` 단방향
-- 본문: filter 적용된 list — phase 01 의 `NotificationItem` 재사용
-- Empty: filter="unread" + 0건 → "안 읽은 알림이 없어요" / filter="all" + 0건 → "알림이 없어요" (phase 01 의 empty 카드 재사용 또는 plan012 의 EmptyState 사용)
+- Segmented tablist (전체 / 안 읽음 — `bg-bg-muted` + 활성 `bg-bg-elev shadow-sm`) — `handleFilterChange` 가 router.push 로 URL 갱신, server re-render 후 props.filter 가 갱신됨. 표시 데이터는 메모리 `visible` 배열 (client-side 즉시 필터)
+- 본문: `visible` list — phase 01 의 `NotificationItem` 재사용
+- Empty: filter="unread" + visible 0건 → "안 읽은 알림이 없어요" / filter="all" + visible 0건 → "알림이 없어요" (phase 01 의 empty 카드 재사용 또는 plan012 의 EmptyState 사용)
 
 pagination 은 본 plan 미포함 (현재 100건 default 로 충분) — 후속 plan 검토.
 
@@ -151,6 +181,12 @@ grep -n 'href=["\x27]/notifications' src/components/notifications/NotificationLi
 
 # segmented + URL filter
 grep -nE 'filter=|searchParams.*filter' src/app/\(authenticated\)/notifications/ -r | wc -l   # >= 2
+
+# Zod 런타임 검증 (ADR-F06)
+grep -nE 'z\.enum\(\["all".*"unread"\]\)|FilterSchema' src/app/\(authenticated\)/notifications/page.tsx | wc -l   # >= 1
+
+# NotificationsClient "use client" 첫 줄
+head -1 src/app/\(authenticated\)/notifications/_components/NotificationsClient.tsx | grep -c 'use client'   # == 1
 
 # Skel 사용
 grep -n 'Skel\|ab-skel' src/app/\(authenticated\)/notifications/loading.tsx | wc -l   # >= 1

--- a/tasks/plan017-notifications-redesign/phase-03.md
+++ b/tasks/plan017-notifications-redesign/phase-03.md
@@ -1,0 +1,69 @@
+# Phase 03 — 통합 검증 + completed 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan017 phase 01~02 결과 통합 검증. legacy 잔재 0 확인. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/017-notifications-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 2. legacy 잔재 0 최종 확인
+
+```bash
+# Notification + /notifications 영역 legacy 토큰 0
+! grep -rnE 'text-gray-|text-yellow-|text-orange-|text-red-|text-blue-|bg-yellow-|bg-orange-|bg-red-|bg-blue-' \
+  src/components/notifications/ \
+  src/app/\(authenticated\)/notifications/
+
+# variant="destructive" 0
+! grep -rn 'variant="destructive"' src/components/notifications/
+
+# 신규 파일 존재
+test -f src/app/\(authenticated\)/notifications/page.tsx
+test -f src/app/\(authenticated\)/notifications/_components/NotificationsClient.tsx
+test -f src/app/\(authenticated\)/notifications/loading.tsx
+```
+
+### 3. 수동 smoke (사용자)
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| Dashboard + 알림 N건 (unread) | Bell 옆 expense Badge "N" |
+| Bell 클릭 → Popover | 최근 10개 + "전체보기" 링크 |
+| 50% / 80% 알림 → 톤 | warning (주황 톤) |
+| 100% 알림 → 톤 | expense (빨강 톤) |
+| "전체보기" → /notifications | 페이지 이동 + Popover 닫힘 |
+| /notifications "안 읽음" segmented | URL `?filter=unread` + 안 읽은 알림만 |
+| /notifications + 0건 (안 읽음 탭) | "안 읽은 알림이 없어요" empty |
+| Network Slow 3G + /notifications | Skel skeleton |
+| "모두 읽음" 클릭 | unread Badge 0 → 다음 진입 시 모두 읽음 톤 |
+| Dark mode | 모든 톤 자연스러움 |
+
+### 4. index.json completed 마킹
+
+`tasks/plan017-notifications-redesign/index.json` 의 모든 phase + 최상위 status → `"completed"`, `completed_at` 필드 추가.
+
+### 5. 최종 커밋
+
+```bash
+git add tasks/plan017-notifications-redesign/index.json
+git commit -m "chore(plan017): mark completed"
+```
+
+## Out of Scope
+
+- pagination / 무한 스크롤
+- 알림 grouping / 검색
+- 브라우저 push 알림 API
+- 알림 삭제


### PR DESCRIPTION
## Summary

Notification (Bell / List / Item) 시각 통일 + \`/notifications\` 전용 페이지 신규.

## Why

- 현재 NotificationItem 이 type 별 4가지 하드 색 (yellow/orange/red/blue) 사용 — OKLCH 토큰 미적용 + 시맨틱 의미 약함
- NotificationBell 의 \`variant=\"destructive\"\` Badge 도 shadcn legacy
- 전체 알림 보기 진입점 부재 — Popover 안에서만 소화 가능
- Loading 상태가 단순 텍스트 (\"알림을 불러오는 중...\") — layout shift 발생

## 변경 내용

- \`docs/flow.md\` §6: 알림 플로우의 [프론트엔드] 섹션 갱신 (Popover 10개 + 전체보기 / 톤 매핑 / 전용 페이지)
- \`tasks/plan017-notifications-redesign/\`: 3 phase task

## Phase 구성

1. NotificationBell/List/Item 토큰 일관화 + 톤 helper (warning + expense + brand 2단계)
2. /notifications 페이지 + segmented (전체 / 안 읽음) + Skel skeleton + Popover 전체보기 링크
3. 통합 검증 + completed

## Test plan

- [ ] 머지 후 \`/build-with-teams plan017\` 로 실제 구현 진행
- [ ] 50/80% (warning) vs 100% (expense) 톤 시각 차이 확인
- [ ] /notifications segmented (\`?filter=all|unread\`) URL 동기화
- [ ] Network Slow 3G 시 Skel skeleton 표시
- [ ] Dark mode 일관성