### PR TITLE
docs(plan018): 404 / 403 / 500 상태 카드 톤 차별화 task

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -342,3 +342,13 @@
 - **트레이드오프**: 단일 컴포넌트가 3 type conditional 필드 분기 — form complexity ↑ but UX 일관성 ↑. type 전환 시 type-specific 필드 (date vs dayOfMonth+name) 가 mount/unmount 되며 입력 잔존 정책은 "이전 type 의 amount/category/description 은 유지, type-specific 필드만 초기화" 로 명시.
 - **적용 범위**: `src/components/transactions/dialogs/{Add,Edit}TransactionDialog.tsx`, `src/components/transactions/forms/TransactionFormFields.tsx`, 진입점 6 곳 import 갱신, legacy 다이얼로그 4 파일 제거 (Add/EditIncomeDialog, Add/EditRecurringExpenseSheet).
 
+## ADR-F22: 민감 정보를 다루는 컴포넌트는 Server Component 로 유지 + Client 핸들러는 children 슬롯 (2026-05-18)
+
+- **결정**: `error.tsx` / `not-found.tsx` 같은 에러 경계 카드 (`StatusCard`) 는 **Server Component 로 고정**. 클라이언트 핸들러 (`reset()` 등) 가 필요한 영역은 별도 `"use client"` 래퍼 (`ErrorResetButton`) 를 만들어 Server Component 의 `children` 슬롯에 주입. `process.env.NODE_ENV` 분기를 포함한 dev-only 메시지 (`error.message`, stack trace, digest 등) 도 Server Component 본문에서 평가하여 production 트리에서 dev JSX 자체가 제외되도록 한다.
+- **맥락**: Next.js App Router 에서 `error.tsx` 는 `"use client"` 필수 (Error boundary 규약). 직관적으로는 `error.tsx` 안의 모든 컴포넌트가 Client 가 되지만, Server Component 를 `children` 으로 받으면 그 본체는 서버에서 렌더된다. 이를 활용하면 (a) `error.message` 같은 민감 정보의 `process.env.NODE_ENV` 분기를 서버측에서 평가해 production 클라이언트 번들에 dev 텍스트 누출 차단, (b) `onClick` 같은 직렬화 불가 prop 을 Server Component 인터페이스에서 제거. PR #248 코드 리뷰에서 두 사고 가능성이 동시 지적됨.
+- **대안 기각**:
+  - 전체 `"use client"` (StatusCard 도 Client): `process.env.NODE_ENV` 가 클라이언트에서 평가되어도 Next.js 번들러가 dead code elimination 으로 dev 분기를 제거하지만, `error.message` 문자열 자체가 클로저에 캡처되어 production 번들에 포함될 위험 잔존. devtools 에서 함수 본문 확인 가능. 또한 Server Component 의 정적 렌더 + 데이터 페칭 이점도 포기.
+  - `process.env.NODE_ENV` 분기를 `error.tsx` 측에서 수행 + StatusCard 는 단순 receiver: `devMessage` prop 자체를 `undefined` 로 전달해도 dev JSX 가 `error.tsx` 의 client 번들에 남음. 책임 분산이 안 됨.
+- **트레이드오프**: Server Component + Client 래퍼 분리는 파일 수 증가 (`ErrorResetButton.tsx` 같은 1-호출 래퍼). 단 보안 + 직렬화 안전성 이득이 크고, 패턴이 일관되면 후속 영역 (예: Sentry wiring) 에서 동일 구조 재사용 가능.
+- **적용 범위**: `src/components/error/StatusCard.tsx` (Server) + `src/components/error/ErrorResetButton.tsx` (Client) + `src/app/{,(authenticated)/}error.tsx` + `src/app/global-error.tsx`. 향후 server-side dev 분기를 포함하는 모든 컴포넌트에 동일 원칙 적용 (예: Sentry digest 카드, debug overlay).
+

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -353,6 +353,24 @@ App Router 의 segment 경계에서 일관 표시:
 
 ---
 
+## 14-2-2. 404 / 403 / 500 상태 카드 (plan018)
+
+`StatusCard` 공용 helper 가 3 상태를 톤으로 구분:
+
+| status | 톤 | 아이콘 | 메시지 | CTA |
+|---|---|---|---|---|
+| 404 | brand (bg-brand-50 + text-brand-700) | Compass | "찾을 수 없어요" | "홈으로" → `/` |
+| 403 | warning (bg-warning/10 + text-warning) | Lock | "권한이 없어요" | "홈으로" → `/` (+ 보조: "로그인 다시 시도" → `/auth/signin`) |
+| 500 | expense (bg-expense/10 + text-expense) | AlertCircle | "문제가 발생했어요" | "다시 시도" → reset() + "홈으로" |
+
+라우팅:
+- `src/app/not-found.tsx` (전역, public 라우트용)
+- `src/app/(authenticated)/not-found.tsx` (Header 보존 + StatusCard 404)
+- `src/app/(authenticated)/forbidden.tsx` (Next.js 16 `forbidden()` 호출 시) — status=403
+- 500 은 기존 `error.tsx` (plan012) 가 자동 처리 + 동일 StatusCard 사용
+
+---
+
 ## 14-3. /budget 페이지 (plan013)
 
 Dashboard BudgetHeroCard 의 확장 전용 페이지. 분석은 /analytics, 예산 소화는 /budget 으로 역할 분리.

--- a/tasks/plan018-not-found-status-pages/index.json
+++ b/tasks/plan018-not-found-status-pages/index.json
@@ -37,7 +37,7 @@
     "3_user_flow": "URL 없음 → not-found / forbidden() throw → forbidden / 서버 에러 → error.tsx. 모두 StatusCard 공용 카드.",
     "4_ui": "404=brand+Compass, 403=warning+Lock, 500=expense+AlertCircle. Auth 톤 centered card 패턴 일치.",
     "5_api": "변경 없음. forbidden() 호출 추가 위치는 향후 plan 별 처리 (본 plan 은 페이지/카드만).",
-    "6_arch": "src/components/error/StatusCard.tsx 신규 + src/app/{not-found,forbidden}.tsx + (authenticated) 동일 셋. error.tsx 는 status=500 default.",
+    "6_arch": "StatusCard.tsx (Server Component, 이벤트 핸들러 prop 미수용) + ErrorResetButton.tsx (Client 래퍼) + src/app/{not-found,forbidden}.tsx + (authenticated) 동일 셋. error.tsx (use client) 가 StatusCard 의 children 으로 ErrorResetButton 주입. devMessage 는 서버측 분기로 클라 번들 노출 차단.",
     "7_adr": "skip — Next.js 표준 컨벤션 + 톤 매핑 코드 즉시 추론.",
     "8_docs": "flow.md §14-2-2 신규 단락 (3 상태 표 + 라우팅 매핑)."
   }

--- a/tasks/plan018-not-found-status-pages/index.json
+++ b/tasks/plan018-not-found-status-pages/index.json
@@ -1,0 +1,44 @@
+{
+  "name": "plan018-not-found-status-pages",
+  "description": "404 not-found.tsx + 403 forbidden.tsx + 500 error.tsx 톤 차별화. StatusCard 공용 helper (status → brand/warning/expense + Compass/Lock/AlertCircle + 메시지 매핑). Next.js 16 표준 컨벤션 따름.",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan012-empty-error-loading-states"
+  ],
+  "prerequisites": [
+    "plan001 머지 (brand/warning/expense 토큰) ✅",
+    "plan012 PR (ErrorBoundaryCard 공용) — 미머지 시 본 plan 의 StatusCard 가 자체 wrapper 제공"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "StatusCard 공용 helper + not-found.tsx + forbidden.tsx + error.tsx 갱신",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "통합 검증 + 8단계 체크리스트 + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "Next.js 16 not-found/forbidden/error.tsx 표준 컨벤션 — 호출 0건 (현재 default 404). 마이그레이션 부담 낮음.",
+    "2_tech_stack": "변경 없음. Next.js 16 + lucide-react Compass/Lock/AlertCircle.",
+    "3_user_flow": "URL 없음 → not-found / forbidden() throw → forbidden / 서버 에러 → error.tsx. 모두 StatusCard 공용 카드.",
+    "4_ui": "404=brand+Compass, 403=warning+Lock, 500=expense+AlertCircle. Auth 톤 centered card 패턴 일치.",
+    "5_api": "변경 없음. forbidden() 호출 추가 위치는 향후 plan 별 처리 (본 plan 은 페이지/카드만).",
+    "6_arch": "src/components/error/StatusCard.tsx 신규 + src/app/{not-found,forbidden}.tsx + (authenticated) 동일 셋. error.tsx 는 status=500 default.",
+    "7_adr": "skip — Next.js 표준 컨벤션 + 톤 매핑 코드 즉시 추론.",
+    "8_docs": "flow.md §14-2-2 신규 단락 (3 상태 표 + 라우팅 매핑)."
+  }
+}

--- a/tasks/plan018-not-found-status-pages/phase-01.md
+++ b/tasks/plan018-not-found-status-pages/phase-01.md
@@ -23,8 +23,11 @@
 
 `src/components/error/StatusCard.tsx` (Server Component OK — interactive 없음):
 
+**StatusCard 는 Server Component 로 고정** (no `"use client"`) — 이벤트 핸들러 prop 안 받음. 직렬화 사고 + devMessage 클라이언트 번들 노출 회피.
+
 ```ts
-import { Compass, Lock, AlertCircle, type LucideIcon } from "lucide-react";
+import { Compass, Lock, AlertCircle } from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
 
 type StatusKind = "not-found" | "forbidden" | "error";
 
@@ -32,13 +35,15 @@ interface StatusCardProps {
   kind: StatusKind;
   title?: string;          // override default
   description?: string;    // override default
-  primaryCta?: { label: string; href?: string; onClick?: () => void };
+  // CTA 는 항상 Link (Server 직렬화 안전). reset() 같은 핸들러는 children 으로 Client 래퍼 주입
+  primaryCta?: { label: string; href: string };
   secondaryCta?: { label: string; href: string };
-  devMessage?: string;     // production 자동 숨김
+  devMessage?: string;     // production 자동 숨김 — 서버측 분기
+  children?: ReactNode;    // Client 래퍼 (예: ErrorResetButton) 주입 슬롯
 }
 
 const STATUS_MAP: Record<StatusKind, {
-  icon: LucideIcon;
+  icon: ComponentType<{ className?: string; size?: number | string }>;
   iconBg: string;
   iconColor: string;
   title: string;
@@ -68,15 +73,49 @@ const STATUS_MAP: Record<StatusKind, {
 };
 ```
 
+**핵심 설계 결정 (PR #248 코드 리뷰 반영)**:
+- **Server Component 고정** — 이벤트 핸들러 prop 미수용. `error.tsx` (`"use client"`) 가 CTA 핸들러 필요 시 `children` 슬롯에 Client 래퍼 주입
+- **devMessage 서버측 분기** — `{process.env.NODE_ENV !== "production" && devMessage && (...)}` 가 빌드 시 production 트리에서 제외 → `error.message` 문자열이 클라이언트 번들에 미포함
+- **primaryCta 단순 `{ label, href }`** — discriminated union 불필요 (link 전용). href/onClick 둘 다 undefined 인 컴파일 타임 허용 케이스 제거
+- **icon 타입 `ComponentType<{ className?, size? }>`** — `LucideIcon` 의 lucide-react 버전별 export 차이 회피
+
 구조:
 - 외부 wrapper: `min-h-screen bg-bg flex items-center justify-center p-5`
 - 카드: `max-w-[360px] w-full flex flex-col items-center text-center`
 - 88px round + iconBg + iconColor + icon 44px
 - title 22px font-bold tracking-tight text-fg
 - description 13.5px text-fg-muted
-- DEV ONLY 박스 (`process.env.NODE_ENV !== "production"` + devMessage 있을 때만)
-- primaryCta `bg-brand-500 text-white h-12 rounded-xl` — href 또는 onClick
+- DEV ONLY 박스 — 서버측 분기 (위 결정 참조)
+- primaryCta — 항상 `<Link href={...}>`
 - secondaryCta `text-fg-muted text-sm font-semibold` (Link)
+- children slot — CTA 영역 아래에 렌더 (Client 래퍼용)
+
+### 1-2. `ErrorResetButton` Client 래퍼 신규
+
+`src/components/error/ErrorResetButton.tsx` — `error.tsx` 의 `reset()` 호출만 담당. `devMessage` 노출 책임 없음:
+
+```tsx
+"use client";
+
+interface ErrorResetButtonProps {
+  reset: () => void;
+  label?: string;
+}
+
+export function ErrorResetButton({ reset, label = "다시 시도" }: ErrorResetButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={reset}
+      className="h-12 px-6 rounded-xl bg-brand-500 text-white font-semibold hover:opacity-90 transition-opacity"
+    >
+      {label}
+    </button>
+  );
+}
+```
+
+이 래퍼만 `"use client"` — `error.tsx` 가 StatusCard (server) 의 `children` 으로 주입.
 
 ### 2. `src/app/not-found.tsx` 신규 (전역, public)
 
@@ -122,27 +161,31 @@ export default function AuthenticatedForbidden() {
 }
 ```
 
-### 5. 기존 `error.tsx` (plan012) 갱신 — StatusCard 사용
+### 5. 기존 `error.tsx` (plan012) 갱신 — StatusCard + ErrorResetButton
 
-`src/app/error.tsx` / `src/app/global-error.tsx` / `src/app/(authenticated)/error.tsx` 의 기존 ErrorBoundaryCard 호출을 StatusCard 로 교체:
+`src/app/error.tsx` / `src/app/global-error.tsx` / `src/app/(authenticated)/error.tsx` 의 기존 ErrorBoundaryCard 호출을 StatusCard + ErrorResetButton 로 교체:
 
 ```tsx
 "use client";
 import { StatusCard } from "@/components/error/StatusCard";
+import { ErrorResetButton } from "@/components/error/ErrorResetButton";
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <StatusCard
       kind="error"
-      primaryCta={{ label: "다시 시도", onClick: reset }}
       secondaryCta={{ label: "홈으로", href: "/" }}
       devMessage={`${error.message}\ndigest=${error.digest ?? "-"}`}
-    />
+    >
+      <ErrorResetButton reset={reset} label="다시 시도" />
+    </StatusCard>
   );
 }
 ```
 
-`ErrorBoundaryCard.tsx` 는 본 phase 에서 삭제 (StatusCard 가 완전 대체). 또는 alias 로 유지 — 본 phase 는 **삭제** 권장 (중복 회피).
+`error.tsx` 는 `"use client"` 필수 (Next.js 규약). 하지만 StatusCard 본체는 Server Component 로 렌더되어 `devMessage` 의 `process.env.NODE_ENV` 분기가 서버에서 평가됨 → production 빌드에서 dev JSX 자체가 트리에서 제외 → `error.message` 문자열 클라이언트 번들 미노출.
+
+`ErrorBoundaryCard.tsx` 는 본 phase 에서 삭제 (StatusCard + ErrorResetButton 이 완전 대체). 본 phase 는 **삭제** 권장 (중복 회피).
 
 ### 6. 자동 verification (8단계 체크리스트 포함)
 
@@ -155,9 +198,22 @@ pnpm tsc --noEmit
 pnpm build
 
 test -f src/components/error/StatusCard.tsx
+test -f src/components/error/ErrorResetButton.tsx
 test -f src/app/not-found.tsx
 test -f src/app/\(authenticated\)/not-found.tsx
 test -f src/app/\(authenticated\)/forbidden.tsx
+
+# StatusCard 가 Server Component (no use client 첫 줄)
+! head -1 src/components/error/StatusCard.tsx | grep -q 'use client'
+
+# ErrorResetButton 만 use client
+head -1 src/components/error/ErrorResetButton.tsx | grep -q 'use client'
+
+# StatusCard 가 onClick prop 안 받음 (직렬화 안전)
+! grep -nE 'onClick.*StatusCardProps|primaryCta.*onClick' src/components/error/StatusCard.tsx
+
+# devMessage 서버측 분기 (process.env.NODE_ENV 가 컴포넌트 본문에 있음)
+grep -n 'process.env.NODE_ENV' src/components/error/StatusCard.tsx | wc -l   # >= 1
 
 # ErrorBoundaryCard 가 StatusCard 로 대체됨
 [ ! -f src/components/error/ErrorBoundaryCard.tsx ] || \
@@ -184,7 +240,8 @@ grep -nE 'Compass|Lock|AlertCircle' src/components/error/StatusCard.tsx | wc -l 
 
 | 파일 | 상태 |
 |---|---|
-| `src/components/error/StatusCard.tsx` | 신규 (공용) |
+| `src/components/error/StatusCard.tsx` | 신규 (Server Component — 이벤트 핸들러 prop 미수용) |
+| `src/components/error/ErrorResetButton.tsx` | 신규 (Client 래퍼 — reset() 호출만) |
 | `src/app/not-found.tsx` | 신규 |
 | `src/app/(authenticated)/not-found.tsx` | 신규 |
 | `src/app/(authenticated)/forbidden.tsx` | 신규 |
@@ -205,4 +262,6 @@ grep -nE 'Compass|Lock|AlertCircle' src/components/error/StatusCard.tsx | wc -l 
 |---|---|
 | `forbidden.tsx` 가 Next.js 16 stable 인지 확인 필요 | next 16 release note 점검. unstable 이면 본 plan 에서 forbidden.tsx 제외 + 권한 거부 케이스는 `(authenticated)/error.tsx` 가 status 분기로 처리하는 별도 plan 으로 분리 |
 | ErrorBoundaryCard 제거 시 다른 PR 의 미머지 사용처 충돌 | grep 으로 사용처 확인 (현재 0). 미머지 PR 의 사용은 본 plan 머지 후 충돌 fix |
+| StatusCard 의 children slot 이 server side 렌더링 시 Client 래퍼 hydration 미스매치 | React Server Components 표준 패턴 — Server 가 Client 컴포넌트를 children 으로 받는 것은 공식 권장. 미스매치 없음 |
+| `error.message` 가 Sentry / 외부 로거에는 보내야 하는데 server side 분기로 막힘 | 본 plan 은 DEV UI 표시만 — 외부 로거 wiring 은 별도 plan. server side 분기는 UI 노출만 차단 |
 | `bg-warning/10` 작동 안 함 | plan011/013/017 의 동일 패턴 — 작동 확인됨. 미작동 시 inline oklch |

--- a/tasks/plan018-not-found-status-pages/phase-01.md
+++ b/tasks/plan018-not-found-status-pages/phase-01.md
@@ -23,7 +23,7 @@
 
 `src/components/error/StatusCard.tsx` (Server Component OK — interactive 없음):
 
-**StatusCard 는 Server Component 로 고정** (no `"use client"`) — 이벤트 핸들러 prop 안 받음. 직렬화 사고 + devMessage 클라이언트 번들 노출 회피.
+**StatusCard 는 Server Component 로 고정** (no `"use client"`) — 이벤트 핸들러 prop 안 받음. 직렬화 사고 + devMessage 클라이언트 번들 노출 회피. ADR-F22 의 RSC server/client 경계 정책 적용.
 
 ```ts
 import { Compass, Lock, AlertCircle } from "lucide-react";

--- a/tasks/plan018-not-found-status-pages/phase-01.md
+++ b/tasks/plan018-not-found-status-pages/phase-01.md
@@ -1,0 +1,208 @@
+# Phase 01 — StatusCard + not-found.tsx + forbidden.tsx + error.tsx 갱신
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 404 / 403 / 500 세 상태에 톤 차별화된 카드 (brand / warning / expense) 표시. 공용 `StatusCard` helper 신규 + Next.js 16 표준 컨벤션 파일 (`not-found.tsx`, `forbidden.tsx`) 신규 + 기존 `error.tsx` (plan012) 가 StatusCard 사용하도록 갱신.
+
+## Context (자기완결)
+
+- 현재 상태:
+  - `src/app/(authenticated)/error.tsx` 존재 (plan012 머지 — main 에 있음)
+  - `src/app/error.tsx`, `src/app/global-error.tsx` (plan012) 존재
+  - `src/components/error/ErrorBoundaryCard.tsx` (plan012) 존재
+  - `not-found.tsx` / `forbidden.tsx` 미존재 (default Next.js 404 표시)
+  - `notFound()` / `forbidden()` 호출 0건
+- Next.js 16 컨벤션:
+  - `not-found.tsx`: Server Component OK. 일치 라우트 없거나 `notFound()` 호출 시
+  - `forbidden.tsx`: Next.js 16 신규. `forbidden()` 호출 시 (기본 `unauthorized.tsx` 대안). 본 plan 은 forbidden.tsx 채택 (권한 없음 의미 명확)
+  - `error.tsx`: `"use client"` 필수. props `{ error, reset }`
+
+## 작업 항목
+
+### 1. `StatusCard` 공용 helper 신규
+
+`src/components/error/StatusCard.tsx` (Server Component OK — interactive 없음):
+
+```ts
+import { Compass, Lock, AlertCircle, type LucideIcon } from "lucide-react";
+
+type StatusKind = "not-found" | "forbidden" | "error";
+
+interface StatusCardProps {
+  kind: StatusKind;
+  title?: string;          // override default
+  description?: string;    // override default
+  primaryCta?: { label: string; href?: string; onClick?: () => void };
+  secondaryCta?: { label: string; href: string };
+  devMessage?: string;     // production 자동 숨김
+}
+
+const STATUS_MAP: Record<StatusKind, {
+  icon: LucideIcon;
+  iconBg: string;
+  iconColor: string;
+  title: string;
+  description: string;
+}> = {
+  "not-found": {
+    icon: Compass,
+    iconBg: "bg-brand-50",
+    iconColor: "text-brand-500",
+    title: "찾을 수 없어요",
+    description: "주소를 다시 확인해 주세요",
+  },
+  "forbidden": {
+    icon: Lock,
+    iconBg: "bg-warning/10",
+    iconColor: "text-warning",
+    title: "권한이 없어요",
+    description: "이 가족 데이터에 접근할 수 없어요",
+  },
+  "error": {
+    icon: AlertCircle,
+    iconBg: "bg-expense/10",
+    iconColor: "text-expense",
+    title: "문제가 발생했어요",
+    description: "잠시 후 다시 시도해주세요",
+  },
+};
+```
+
+구조:
+- 외부 wrapper: `min-h-screen bg-bg flex items-center justify-center p-5`
+- 카드: `max-w-[360px] w-full flex flex-col items-center text-center`
+- 88px round + iconBg + iconColor + icon 44px
+- title 22px font-bold tracking-tight text-fg
+- description 13.5px text-fg-muted
+- DEV ONLY 박스 (`process.env.NODE_ENV !== "production"` + devMessage 있을 때만)
+- primaryCta `bg-brand-500 text-white h-12 rounded-xl` — href 또는 onClick
+- secondaryCta `text-fg-muted text-sm font-semibold` (Link)
+
+### 2. `src/app/not-found.tsx` 신규 (전역, public)
+
+```tsx
+import { StatusCard } from "@/components/error/StatusCard";
+
+export default function NotFound() {
+  return (
+    <StatusCard
+      kind="not-found"
+      primaryCta={{ label: "홈으로", href: "/" }}
+    />
+  );
+}
+```
+
+### 3. `src/app/(authenticated)/not-found.tsx` 신규
+
+인증 사용자의 404 — `/dashboard` 로 보내기 + 보조로 "이전 페이지":
+
+```tsx
+export default function AuthenticatedNotFound() {
+  return (
+    <StatusCard
+      kind="not-found"
+      primaryCta={{ label: "대시보드로", href: "/dashboard" }}
+    />
+  );
+}
+```
+
+### 4. `src/app/(authenticated)/forbidden.tsx` 신규
+
+```tsx
+export default function AuthenticatedForbidden() {
+  return (
+    <StatusCard
+      kind="forbidden"
+      primaryCta={{ label: "홈으로", href: "/dashboard" }}
+      secondaryCta={{ label: "로그인 다시 시도", href: "/auth/signin" }}
+    />
+  );
+}
+```
+
+### 5. 기존 `error.tsx` (plan012) 갱신 — StatusCard 사용
+
+`src/app/error.tsx` / `src/app/global-error.tsx` / `src/app/(authenticated)/error.tsx` 의 기존 ErrorBoundaryCard 호출을 StatusCard 로 교체:
+
+```tsx
+"use client";
+import { StatusCard } from "@/components/error/StatusCard";
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <StatusCard
+      kind="error"
+      primaryCta={{ label: "다시 시도", onClick: reset }}
+      secondaryCta={{ label: "홈으로", href: "/" }}
+      devMessage={`${error.message}\ndigest=${error.digest ?? "-"}`}
+    />
+  );
+}
+```
+
+`ErrorBoundaryCard.tsx` 는 본 phase 에서 삭제 (StatusCard 가 완전 대체). 또는 alias 로 유지 — 본 phase 는 **삭제** 권장 (중복 회피).
+
+### 6. 자동 verification (8단계 체크리스트 포함)
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/018-not-found-status-pages
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+test -f src/components/error/StatusCard.tsx
+test -f src/app/not-found.tsx
+test -f src/app/\(authenticated\)/not-found.tsx
+test -f src/app/\(authenticated\)/forbidden.tsx
+
+# ErrorBoundaryCard 가 StatusCard 로 대체됨
+[ ! -f src/components/error/ErrorBoundaryCard.tsx ] || \
+  ! grep -rn 'ErrorBoundaryCard' src/ --include='*.tsx' --include='*.ts' | grep -v ErrorBoundaryCard.tsx
+
+# error.tsx 들 모두 StatusCard 사용
+grep -rn 'StatusCard' src/app/error.tsx src/app/global-error.tsx src/app/\(authenticated\)/error.tsx | wc -l   # >= 3
+
+# 3 톤 매핑 존재
+grep -nE 'bg-brand-50|bg-warning/|bg-expense/' src/components/error/StatusCard.tsx | wc -l   # >= 3
+
+# 3 아이콘 import
+grep -nE 'Compass|Lock|AlertCircle' src/components/error/StatusCard.tsx | wc -l   # >= 3
+```
+
+수동 smoke:
+- 존재 안 하는 URL `/foo` (public) → not-found.tsx → brand Compass 카드
+- 존재 안 하는 protected URL `/dashboard/foo` → (authenticated)/not-found.tsx → "대시보드로" CTA
+- Action 에서 `forbidden()` 호출 (임시 테스트) → forbidden.tsx → warning Lock 카드
+- `throw new Error("test")` (Dashboard 임시) → error.tsx → expense AlertCircle 카드 + DEV 박스
+- production build → DEV 박스 미표시
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/error/StatusCard.tsx` | 신규 (공용) |
+| `src/app/not-found.tsx` | 신규 |
+| `src/app/(authenticated)/not-found.tsx` | 신규 |
+| `src/app/(authenticated)/forbidden.tsx` | 신규 |
+| `src/app/error.tsx` | StatusCard 호출로 갱신 |
+| `src/app/global-error.tsx` | StatusCard 호출로 갱신 |
+| `src/app/(authenticated)/error.tsx` | StatusCard 호출로 갱신 |
+| `src/components/error/ErrorBoundaryCard.tsx` | 제거 (StatusCard 가 흡수) |
+
+## Out of Scope
+
+- `forbidden()` 호출 위치를 코드 전반에 추가 (예: 다른 가족 expense 접근 차단) — 본 plan 은 페이지 + 카드만, 호출은 후속 plan
+- `unauthorized.tsx` (Next.js 16 401 컨벤션) — 인증 미통과는 redirect 유지
+- 404 페이지 안에 검색 / 사이트맵 링크 — 단순 카드 유지
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `forbidden.tsx` 가 Next.js 16 stable 인지 확인 필요 | next 16 release note 점검. unstable 이면 본 plan 에서 forbidden.tsx 제외 + 권한 거부 케이스는 `(authenticated)/error.tsx` 가 status 분기로 처리하는 별도 plan 으로 분리 |
+| ErrorBoundaryCard 제거 시 다른 PR 의 미머지 사용처 충돌 | grep 으로 사용처 확인 (현재 0). 미머지 PR 의 사용은 본 plan 머지 후 충돌 fix |
+| `bg-warning/10` 작동 안 함 | plan011/013/017 의 동일 패턴 — 작동 확인됨. 미작동 시 inline oklch |

--- a/tasks/plan018-not-found-status-pages/phase-02.md
+++ b/tasks/plan018-not-found-status-pages/phase-02.md
@@ -1,0 +1,79 @@
+# Phase 02 — 통합 검증 + 8단계 체크리스트 + completed
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan018 phase 01 결과 통합 검증. 8단계 체크리스트 명시 검증. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/018-not-found-status-pages
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+### 2. 8단계 체크리스트 명시 확인
+
+`tasks/plan018-not-found-status-pages/index.json` 의 `planning_checklist` 8 항목이 모두 비어있지 않은지 확인:
+
+```bash
+jq -r '.planning_checklist | keys[]' tasks/plan018-not-found-status-pages/index.json | wc -l   # >= 8
+jq '.planning_checklist | to_entries | map(select(.value == "" or .value == null)) | length' \
+  tasks/plan018-not-found-status-pages/index.json   # == 0
+```
+
+### 3. 신규 파일 존재 확인
+
+```bash
+test -f src/components/error/StatusCard.tsx
+test -f src/app/not-found.tsx
+test -f src/app/\(authenticated\)/not-found.tsx
+test -f src/app/\(authenticated\)/forbidden.tsx
+```
+
+### 4. 신 토큰 + 아이콘 매핑
+
+```bash
+# 3 톤 매핑
+grep -nE 'bg-brand-50|bg-warning/|bg-expense/' src/components/error/StatusCard.tsx | wc -l   # >= 3
+
+# 3 아이콘 import
+grep -nE 'Compass|Lock|AlertCircle' src/components/error/StatusCard.tsx | wc -l   # >= 3
+
+# ErrorBoundaryCard 잔재 0
+! grep -rn 'ErrorBoundaryCard' src/ --include='*.tsx' --include='*.ts'
+```
+
+### 5. 수동 smoke (사용자)
+
+| 시나리오 | 기대 결과 |
+|---|---|
+| 미로그인 + `/foo` (없는 경로) | not-found.tsx → brand Compass 카드 + "홈으로" → `/` |
+| 로그인 + `/dashboard/foo` | (authenticated)/not-found.tsx → "대시보드로" |
+| 임시 Action 에서 `forbidden()` 호출 | warning Lock 카드 + "홈으로" + "로그인 다시 시도" |
+| 임시 `throw new Error("test")` (Dashboard) | expense AlertCircle 카드 + DEV 박스 |
+| production build | DEV 박스 미표시 (자동 grep + 수동 확인) |
+| Dark mode | 모든 톤 자연스러움 |
+
+### 6. index.json completed 마킹
+
+phase + 최상위 status → `"completed"` + `completed_at` 추가.
+
+### 7. 최종 커밋
+
+```bash
+git add tasks/plan018-not-found-status-pages/index.json
+git commit -m "chore(plan018): mark completed"
+```
+
+## Out of Scope
+
+- `forbidden()` 호출을 Action 측에 일괄 도입
+- `unauthorized.tsx` (401)
+- 404 페이지의 검색 / 사이트맵


### PR DESCRIPTION
## Summary

Next.js 16 표준 컨벤션 (\`not-found.tsx\`, \`forbidden.tsx\`, \`error.tsx\`) 채택 + 공용 \`StatusCard\` helper 로 3 상태 톤 차별화.

## Why

- plan012 의 Out of Scope — 현재 404 는 Next.js default UI, 403 은 없음, 500 만 ErrorBoundaryCard
- 사용자에게 \"찾을 수 없음\" vs \"권한 없음\" vs \"서버 에러\" 시각 구분 없음 → 다음 행동 (CTA) 매핑 부정확
- ErrorBoundaryCard (plan012) 의 단일 톤 카드를 status 별 분기로 확장하면 중복 컴포넌트 정리 + 시맨틱 강화

## 변경 내용

- \`docs/flow.md\` §14-2-2 신규: 3 상태 표 + 라우팅 매핑
- \`tasks/plan018-not-found-status-pages/\`: 2 phase task + \`planning_checklist\` 8 항목

## /planning 8단계 회고 — 본 plan 부터 명시화

index.json 의 \`planning_checklist\` 필드에 1~8 단계 한 줄 요약을 명시. 누락 단계 즉시 식별 가능. plan011~017 회고에서 1·2·5 단계가 자주 생략된 점 보완.

## Phase 구성

1. StatusCard 공용 helper + 4 페이지 신규/갱신 (not-found x2, forbidden, error x3)
2. 통합 검증 + 8단계 체크리스트 + completed

## Test plan

- [ ] 머지 후 \`/build-with-teams plan018\` 로 실제 구현 진행
- [ ] 4 시나리오 수동 smoke (없는 URL / forbidden() / throw / production build)
- [ ] Dark mode 일관성