### PR TITLE
docs(plan019): Header / TopBar 시각 통일 + 모바일 가족 전환 진입점 task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -341,6 +341,33 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
 
 ---
 
+## 14-1. Header / TopBar 구조 (plan019)
+
+`src/components/layout/Header.tsx` 가 `(authenticated)/layout.tsx` 의 sticky top bar — 전 인증 페이지에 일관 표시.
+
+```
+[Header sticky top-0 z-50 backdrop-blur-xl bg-bg-elev/95 border-b border-border]
+    ├─ 좌: 로고 (brand-500 Wallet 아이콘 + "우리집 가계부" text-fg 단색)
+    │      → /dashboard 링크
+    │
+    └─ 우 (md+ 전용 / 모바일 별도 진입점):
+            ├─ FamilySelectorDropdown (md+ 전용 표시, 모바일은 Avatar dropdown 안 진입)
+            ├─ NotificationBell (Popover trigger — plan017)
+            └─ Avatar dropdown
+                    ├─ 프로필 (이름 + 이메일)
+                    ├─ [모바일 전용] 가족 전환 → FamilySelector Sheet
+                    ├─ 설정 → /settings
+                    └─ 로그아웃 (text-expense — variant=destructive 폐기)
+```
+
+토큰 적용:
+- `bg-bg-elev/95` backdrop-blur (light/dark 자동)
+- `border-border` (하드 회색 폐기)
+- `ring-brand-100` Avatar (`ring-blue-100` 폐기)
+- `text-fg-muted` 보조 텍스트 (`text-muted-foreground` 폐기)
+
+---
+
 ## 14-2. 빈 상태 / 에러 / 로딩 (plan012)
 
 App Router 의 segment 경계에서 일관 표시:

--- a/tasks/plan019-header-redesign/index.json
+++ b/tasks/plan019-header-redesign/index.json
@@ -1,0 +1,46 @@
+{
+  "name": "plan019-header-redesign",
+  "description": "Header.tsx 시각 통일 + 모바일 가족 전환 진입점 추가. legacy 토큰 (bg-white/80, border-gray-200/50, from-gray-900 to-gray-700 텍스트 그라디언트, gradient-primary, ring-blue-100, text-muted-foreground, variant=destructive) 제거 + Avatar dropdown 에 '가족 전환' 항목 (모바일 전용).",
+  "status": "pending",
+  "created_at": "2026-05-11",
+  "total_phases": 2,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan010-domain-pages-redesign",
+    "plan017-notifications-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (OKLCH 토큰 — bg-elev/95 alpha + border-border) ✅",
+    "plan010 머지 (FamilySelectorDropdown 구조) ✅",
+    "plan017 PR (NotificationBell 토큰) — 미머지 시 본 plan 의 Header 갱신과 동시 진행 가능 (독립 컴포넌트)"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "Header 토큰 일관화 + 로고 단색 + dropdown '가족 전환' (모바일 Sheet)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "통합 검증 + 8단계 체크리스트 + completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "Header.tsx 가 (authenticated)/layout.tsx 에서 단일 호출 — 변경 영향 전 인증 페이지. dynamic import (FamilySelectorDropdown / NotificationBell) 의 SSR/CSR 미스매치 해결 유지.",
+    "2_tech_stack": "변경 없음. shadcn DropdownMenu / Avatar / Sheet 그대로. lucide-react 의 ChevronsUpDown 또는 Users 아이콘 추가.",
+    "3_user_flow": "데스크톱: 로고 / FamilySelector / Bell / Avatar dropdown. 모바일: 로고 / Bell / Avatar dropdown (안에 '가족 전환' → Sheet).",
+    "4_ui": "토큰 일관화 + 로고 단색 + Avatar dropdown '가족 전환' 항목 (모바일 전용 표시).",
+    "5_api": "변경 없음. 가족 전환 시 기존 setSelectedFamilyAction Server Action 호출.",
+    "6_arch": "Header.tsx 단일 파일 + FamilySelectorDropdown 모바일 variant (또는 Sheet 호출 helper).",
+    "7_adr": "skip — 토큰 일관화 + 단순 진입점 추가. 코드 추론 가능 + Next.js/shadcn 표준 패턴.",
+    "8_docs": "flow.md §14-1 신규 단락 (Header 구조 도식 + 토큰 매핑)."
+  }
+}

--- a/tasks/plan019-header-redesign/phase-01.md
+++ b/tasks/plan019-header-redesign/phase-01.md
@@ -29,7 +29,7 @@
 <header className="sticky top-0 z-50 backdrop-blur-xl bg-bg-elev/95 border-b border-border shadow-sm">
 ```
 
-`bg-bg-elev/95` alpha 변형 작동 확인 — plan001 의 OKLCH 토큰 + Tailwind v4 가 자동 alpha 변형 지원. 미작동 시 inline `style={{ background: "color-mix(in srgb, var(--color-bg-elev) 95%, transparent)" }}`.
+`bg-bg-elev/95` alpha 변형 작동 확인 — plan001 의 OKLCH 토큰 + Tailwind v4 가 자동 alpha 변형 지원. 미작동 시 `globals.css` 의 `@theme` 블록 외부에 `.bg-header { background: color-mix(in srgb, var(--color-bg-elev) 95%, transparent); }` 커스텀 클래스를 추가해 사용한다. **inline `style={{ ... }}` 작성 금지** (ADR-F13 / CLAUDE.md OKLCH 토큰 규칙 — 토큰 외부 하드코딩 차단).
 
 ### 2. 로고 단색 + brand 아이콘
 
@@ -121,7 +121,7 @@ const [familySheetOpen, setFamilySheetOpen] = useState(false);
       <SheetTitle>가족 전환</SheetTitle>
     </SheetHeader>
     {/* FamilySelectorDropdown 의 list 부분만 inline — 또는 별도 FamilySelectorList 컴포넌트로 추출 */}
-    <FamilySelectorList onSelected={() => setFamilySheetOpen(false)} />
+    <FamilySelectorList onSelected={(_familyUuid) => setFamilySheetOpen(false)} />
   </SheetContent>
 </Sheet>
 ```
@@ -131,7 +131,8 @@ const [familySheetOpen, setFamilySheetOpen] = useState(false);
 ```ts
 // src/components/families/FamilySelectorList.tsx (신규)
 interface FamilySelectorListProps {
-  onSelected?: () => void;
+  /** 선택된 가족 UUID 를 호출자에게 명시적으로 전달 — 호출자가 분기 처리 가능 */
+  onSelected?: (familyUuid: string) => void;
 }
 ```
 

--- a/tasks/plan019-header-redesign/phase-01.md
+++ b/tasks/plan019-header-redesign/phase-01.md
@@ -1,0 +1,198 @@
+# Phase 01 — Header 토큰 일관화 + 로고 단색 + 모바일 '가족 전환'
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `Header.tsx` 의 legacy 토큰 제거 + 로고 텍스트 그라디언트 → text-fg 단색 + Avatar dropdown 안에 모바일 전용 "가족 전환" 항목 추가 (Sheet 형태 진입점).
+
+## Context (자기완결)
+
+- 현재: `src/components/layout/Header.tsx` (115 줄). `(authenticated)/layout.tsx` 에서 호출 → 전 인증 페이지 일관 표시.
+- legacy 잔재:
+  - `bg-white/80 border-gray-200/50` — dark mode 미지원
+  - `from-gray-900 to-gray-700 bg-clip-text text-transparent` — 텍스트 그라디언트
+  - `gradient-primary` (구 brand 토큰?)
+  - `ring-blue-100` Avatar
+  - `text-muted-foreground` shadcn legacy
+  - `variant="destructive"` DropdownMenuItem
+- 구조 약점: `<div className="hidden md:block"><FamilySelectorDropdown /></div>` — 모바일에서 FamilySelector 진입 불가
+- 데이터: session prop + selectedFamilyUuid prop (server 측 결정)
+
+## 작업 항목
+
+### 1. 헤더 외곽 토큰 교체
+
+```tsx
+// 변경 전
+<header className="sticky top-0 z-50 backdrop-blur-xl bg-white/80 border-b border-gray-200/50 shadow-sm">
+
+// 변경 후
+<header className="sticky top-0 z-50 backdrop-blur-xl bg-bg-elev/95 border-b border-border shadow-sm">
+```
+
+`bg-bg-elev/95` alpha 변형 작동 확인 — plan001 의 OKLCH 토큰 + Tailwind v4 가 자동 alpha 변형 지원. 미작동 시 inline `style={{ background: "color-mix(in srgb, var(--color-bg-elev) 95%, transparent)" }}`.
+
+### 2. 로고 단색 + brand 아이콘
+
+```tsx
+// 변경 전
+<div className="w-8 h-8 md:w-10 md:h-10 gradient-primary rounded-xl md:rounded-2xl flex items-center justify-center shadow-lg">
+  <Wallet className="w-4 h-4 md:w-5 md:h-5 text-white" />
+</div>
+<div>
+  <h1 className="text-base md:text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+    우리집 가계부
+  </h1>
+</div>
+
+// 변경 후
+<div className="w-8 h-8 md:w-10 md:h-10 bg-brand-500 rounded-xl flex items-center justify-center">
+  <Wallet className="w-4 h-4 md:w-5 md:h-5 text-white" />
+</div>
+<h1 className="text-base md:text-xl font-bold text-fg tracking-tight">
+  우리집 가계부
+</h1>
+```
+
+`gradient-primary` 폐기 — plan001 의 brand-500 단색이 대체. `shadow-lg` 도 제거 (sticky header 그림자만 유지).
+
+### 3. Avatar ring 토큰
+
+```tsx
+// 변경 전
+<Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-blue-100">
+
+// 변경 후
+<Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-brand-100">
+
+// AvatarFallback
+className="bg-brand-500 text-white font-semibold text-xs md:text-sm"
+// (기존 gradient-primary → bg-brand-500 단색)
+```
+
+### 4. Dropdown 본문 토큰 + '가족 전환' 항목
+
+```tsx
+<DropdownMenuContent align="end" className="w-56 bg-bg-elev border-border">
+  <DropdownMenuLabel>
+    <div className="flex flex-col space-y-1">
+      <p className="text-sm font-medium text-fg leading-none">{session.user?.name}</p>
+      <p className="text-xs text-fg-muted leading-none">{session.user?.email}</p>
+    </div>
+  </DropdownMenuLabel>
+  <DropdownMenuSeparator />
+
+  {/* 모바일 전용 — 가족 전환 진입점 */}
+  <DropdownMenuItem
+    className="md:hidden"
+    onClick={() => setFamilySheetOpen(true)}
+  >
+    <Users className="mr-2 h-4 w-4" />
+    <span>가족 전환</span>
+  </DropdownMenuItem>
+  <DropdownMenuSeparator className="md:hidden" />
+
+  <DropdownMenuItem onClick={() => router.push("/settings")}>
+    <User className="mr-2 h-4 w-4" />
+    <span>설정</span>
+  </DropdownMenuItem>
+  <DropdownMenuSeparator />
+  <DropdownMenuItem className="text-expense focus:text-expense" asChild>
+    <form action={signOutAction}>
+      <button type="submit" className="flex items-center w-full">
+        <LogOut className="mr-2 h-4 w-4" />
+        <span>로그아웃</span>
+      </button>
+    </form>
+  </DropdownMenuItem>
+</DropdownMenuContent>
+```
+
+`variant="destructive"` → `text-expense focus:text-expense` 명시 (시맨틱 토큰).
+
+### 5. 모바일 가족 전환 Sheet
+
+```tsx
+const [familySheetOpen, setFamilySheetOpen] = useState(false);
+
+// Header 본문 마지막에 추가:
+<Sheet open={familySheetOpen} onOpenChange={setFamilySheetOpen}>
+  <SheetContent side="bottom" className="h-auto bg-bg-elev">
+    <SheetHeader>
+      <SheetTitle>가족 전환</SheetTitle>
+    </SheetHeader>
+    {/* FamilySelectorDropdown 의 list 부분만 inline — 또는 별도 FamilySelectorList 컴포넌트로 추출 */}
+    <FamilySelectorList onSelected={() => setFamilySheetOpen(false)} />
+  </SheetContent>
+</Sheet>
+```
+
+`FamilySelectorList` 가 별도 추출 안 되어있으면 phase 시작 시 `src/components/families/FamilySelectorDropdown.tsx` 의 내부 list 부분을 분리 (가족 목록 렌더 + select handler):
+
+```ts
+// src/components/families/FamilySelectorList.tsx (신규)
+interface FamilySelectorListProps {
+  onSelected?: () => void;
+}
+```
+
+`FamilySelectorDropdown` 의 dropdown content 안에서도 `FamilySelectorList` 재사용 — 데스크톱 / 모바일 단일 책임.
+
+### 6. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/019-header-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 0
+! grep -nE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground' \
+  src/components/layout/Header.tsx
+
+# variant="destructive" 0
+! grep -n 'variant="destructive"' src/components/layout/Header.tsx
+
+# 신 토큰 사용
+grep -nE 'bg-bg-elev|border-border|bg-brand-500|ring-brand-100|text-fg|text-fg-muted|text-expense' \
+  src/components/layout/Header.tsx | wc -l   # >= 4
+
+# 모바일 가족 전환 항목
+grep -nE 'md:hidden.*가족 전환|가족 전환.*md:hidden|familySheetOpen' \
+  src/components/layout/Header.tsx | wc -l   # >= 1
+
+# FamilySelectorList 존재
+test -f src/components/families/FamilySelectorList.tsx
+```
+
+수동 smoke:
+- 데스크톱 (>= 768px) → FamilySelectorDropdown 우상단 표시 + Avatar dropdown 에 '가족 전환' 항목 미표시
+- 모바일 (< 768px) → FamilySelectorDropdown 숨김 + Avatar 클릭 → dropdown → '가족 전환' → Sheet bottom 표시
+- Sheet 에서 가족 선택 → Sheet 닫힘 + 페이지 갱신
+- Dark mode → 모든 톤 자연스러움
+- 가족 1개뿐인 사용자 → FamilySelector 표시 유지 (가족명 + 관리 진입점)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/layout/Header.tsx` | 토큰 + 로고 + dropdown + Sheet |
+| `src/components/families/FamilySelectorList.tsx` | 신규 (Dropdown 의 list 분리) |
+| `src/components/families/FamilySelectorDropdown.tsx` | FamilySelectorList 호출하도록 갱신 |
+
+## Out of Scope
+
+- 페이지별 헤더 보조 정보 (예: "이번 달 5월" 라벨 일관 표시) — 후속 plan
+- 가족 관리 페이지 신규 (현재 /families 디렉터리 검토 필요) — 별도
+- 로그아웃 확인 dialog — 현재 즉시 처리 유지
+- 다국어 (en/ja) — 한국어만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `bg-bg-elev/95` 가 backdrop-blur 와 어울려 dark mode 너무 어두움 | 수동 smoke + 필요 시 `bg-bg-elev/90` 으로 alpha 조정 |
+| FamilySelectorList 추출 시 기존 FamilySelectorDropdown 회귀 | dropdown 사용처 (Header md+) 동작 확인. 추출 = pure refactor 로 동작 변경 없음 |
+| dynamic import (ssr: false) 의 Avatar Sheet trigger 가 hydration 미스매치 | Sheet 자체는 useState 만 — server 무관. 단 가족 list 페칭은 client side |
+| 모바일 dropdown 에 '가족 전환' 추가로 메뉴 4 항목 — 클릭 영역 좁아짐 | h-11 patch — touch target 44px 이상 유지. 수동 smoke 에서 모바일 클릭 확인 |

--- a/tasks/plan019-header-redesign/phase-02.md
+++ b/tasks/plan019-header-redesign/phase-02.md
@@ -1,0 +1,74 @@
+# Phase 02 — 통합 검증 + 8단계 체크리스트 + completed
+
+**Model**: haiku
+**Status**: pending
+**Goal**: plan019 phase 01 결과 통합 검증. legacy 잔재 0 확인. index.json completed 마킹.
+
+## 작업 항목
+
+### 1. 통합 빌드/린트/테스트
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: plan/019-header-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm test --passWithNoTests
+pnpm build
+```
+
+기존 `src/__tests__/components/layout/Header.test.tsx` 가 새 구조에서 통과하는지 확인. 깨지면 본 phase 내에서 갱신 (또는 phase 01 에 포함). 깨진 expectation:
+- text 그라디언트 → 단색 text 변경
+- variant=destructive 클래스 → text-expense
+- 모바일 가족 전환 항목 신규 — 모바일 viewport 시뮬레이션 필요
+
+### 2. legacy 잔재 0 최종
+
+```bash
+# Header 영역 + FamilySelector 영역 legacy 토큰 0
+! grep -rnE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground' \
+  src/components/layout/Header.tsx \
+  src/components/families/FamilySelectorDropdown.tsx \
+  src/components/families/FamilySelectorList.tsx 2>/dev/null
+
+# variant="destructive" 0
+! grep -rn 'variant="destructive"' src/components/layout/Header.tsx
+```
+
+### 3. 8단계 체크리스트 명시 확인
+
+```bash
+jq -r '.planning_checklist | keys[]' tasks/plan019-header-redesign/index.json | wc -l   # >= 8
+jq '.planning_checklist | to_entries | map(select(.value == "" or .value == null)) | length' \
+  tasks/plan019-header-redesign/index.json   # == 0
+```
+
+### 4. 수동 smoke
+
+| 시나리오 | 기대 |
+|---|---|
+| 데스크톱 + 모든 인증 페이지 | sticky Header bg-bg-elev/95 + 로고 단색 + FamilySelector 우상단 |
+| 모바일 + Avatar 클릭 | dropdown → "가족 전환" 항목 표시 |
+| 모바일 + "가족 전환" 클릭 | Sheet bottom + 가족 목록 |
+| Sheet 에서 가족 선택 | Sheet 닫힘 + 페이지 데이터 갱신 |
+| Dark mode | 모든 톤 자연스러움 |
+| 가족 1개 사용자 | FamilySelector 표시 유지, 가족명 + 관리 진입점 |
+| 로그아웃 클릭 | text-expense + 즉시 signOut |
+
+### 5. index.json completed 마킹
+
+phase + 최상위 status → `"completed"` + `completed_at`.
+
+### 6. 최종 커밋
+
+```bash
+git add tasks/plan019-header-redesign/index.json
+git commit -m "chore(plan019): mark completed"
+```
+
+## Out of Scope
+
+- 페이지별 헤더 보조 (월/년 라벨)
+- 가족 관리 전용 페이지 신규
+- 로그아웃 confirm dialog


### PR DESCRIPTION
## Summary

\`Header.tsx\` 시각 통일 + 모바일에서 FamilySelector 진입 부재 문제 해결.

## Why

- legacy 잔재: \`bg-white/80\` (dark 미지원), \`from-gray-900 to-gray-700 bg-clip-text\` (텍스트 그라디언트), \`gradient-primary\`, \`ring-blue-100\`, \`text-muted-foreground\`, \`variant=destructive\`
- 모바일 FamilySelector \`hidden md:block\` → 모바일 사용자는 가족 전환 진입점 0
- 다중 가족 사용자에게 모바일 = 비기능 상태

## 변경 내용

- \`docs/flow.md\` §14-1 신규: Header 구조 도식 + 토큰 매핑
- \`tasks/plan019-header-redesign/\`: 2 phase + 8단계 체크리스트
  - 01 Header 토큰 일관화 + 로고 단색 + dropdown '가족 전환' + Sheet
  - 02 통합 검증 + 8단계 체크리스트 + completed

## 결정 사항

- 모바일 진입점: Avatar dropdown 안 '가족 전환' 항목 → Sheet bottom (전용 아이콘 추가 vs 공간 절약 트레이드오프)
- 로고: 텍스트 그라디언트 폐기 → text-fg 단색 + brand-500 아이콘 (dark mode 안정성)
- 가족 1개 사용자: FamilySelector 표시 유지 (일관성 우선)

## Test plan

- [ ] 머지 후 \`/build-with-teams plan019\` 로 실제 구현 진행
- [ ] 데스크톱/모바일 viewport 시각 차이 (FamilySelector 위치)
- [ ] Avatar dropdown 의 '가족 전환' 모바일 전용 표시
- [ ] Dark mode 일관성
- [ ] 가족 1개/N개 사용자 시나리오