### PR TITLE
feat(budget): /budget 페이지 Teal 리디자인 — Hero + 라인차트 + 카테고리 top 5 (plan013)

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -377,7 +377,7 @@ Dashboard BudgetHeroCard 의 확장 전용 페이지. 분석은 /analytics, 예�
     └─ getMonthlyCategoryBreakdownAction() → { items: { categoryUuid, name, color?, totalAmount }[] }
             │
             └─ BudgetClient (use client)
-                    ├─ BudgetHeroCard (Dashboard 와 시각 일치)
+                    ├─ 예산 현황 Hero 카드 (Dashboard 와 시각 일치)
                     ├─ 3-col 통계: 일 평균 지출 / 남은 일수 / 권장 일 예산 (남은예산÷남은일수)
                     ├─ BudgetCumulativeLine (recharts LineChart + ReferenceLine 예산선)
                     └─ BudgetCategoryBars (수평 bar top 5 + 예산 대비 % + ↑많음 라벨)

--- a/src/actions/dashboard/get-monthly-daily-stats-action.ts
+++ b/src/actions/dashboard/get-monthly-daily-stats-action.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { z } from "zod";
+
 import {
   ActionError,
   handleActionError,
@@ -17,6 +19,11 @@ import {
 
 export type { DailyTransactionSummary };
 
+const inputSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  month: z.number().int().min(1).max(12),
+});
+
 /**
  * 월별 일일 수입/지출 합계 조회
  * (API가 없으므로 목록 조회 후 집계)
@@ -28,12 +35,14 @@ export async function getMonthlyDailyStatsAction(
   try {
     await requireAuth();
 
+    const { year: y, month: m } = inputSchema.parse({ year, month });
+
     const familyUuid = await getSelectedFamilyUuid();
     if (!familyUuid) {
       throw ActionError.familyNotSelected();
     }
 
-    const data = await getMonthlyDailyStats(familyUuid, year, month);
+    const data = await getMonthlyDailyStats(familyUuid, y, m);
     return successResult(data);
   } catch (error) {
     return handleActionError(error, "월별 일일 통계 조회에 실패했습니다");

--- a/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
@@ -1,0 +1,93 @@
+import { getCategoryTone } from "@/lib/utils/category-tone";
+import type { CategoryBreakdownItem } from "@/types/dashboard";
+import { formatCurrency } from "@/lib/utils/format";
+
+interface BudgetCategoryBarsProps {
+  items: CategoryBreakdownItem[];
+  budget: number;
+  monthlyExpense: number;
+}
+
+export function BudgetCategoryBars({
+  items,
+  budget,
+}: BudgetCategoryBarsProps) {
+  const top5 = [...items]
+    .sort((a, b) => b.totalAmount - a.totalAmount)
+    .slice(0, 5);
+
+  const maxAmount = top5[0]?.totalAmount ?? 0;
+  const barBase = Math.max(maxAmount, budget * 0.5);
+
+  if (top5.length === 0) {
+    return (
+      <div className="bg-bg-elev border border-border rounded-2xl p-5 md:p-6">
+        <p className="text-sm font-semibold text-fg mb-1">카테고리 top 5</p>
+        <p className="text-xs text-fg-muted mb-4">이번 달 지출이 큰 순</p>
+        <p className="text-sm text-fg-muted text-center py-6">
+          이번 달 지출이 아직 없어요
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-bg-elev border border-border rounded-2xl p-5 md:p-6">
+      <p className="text-sm font-semibold text-fg mb-0.5">카테고리 top 5</p>
+      <p className="text-xs text-fg-muted mb-4">이번 달 지출이 큰 순</p>
+
+      <div className="space-y-4">
+        {top5.map((item) => {
+          const tone = getCategoryTone(item.name);
+          const budgetPct =
+            budget > 0 ? Math.round((item.totalAmount / budget) * 100) : 0;
+          const barWidthPct =
+            barBase > 0
+              ? Math.min(Math.round((item.totalAmount / barBase) * 100), 100)
+              : 0;
+
+          return (
+            <div key={item.categoryUuid} className="flex items-center gap-3">
+              {/* 카테고리 아이콘 */}
+              <div
+                className="h-9 w-9 flex-shrink-0 rounded-xl flex items-center justify-center"
+                style={{ background: tone.bg }}
+              >
+                <span
+                  className="text-sm font-bold"
+                  style={{ color: tone.fg }}
+                >
+                  {item.icon || item.name[0]}
+                </span>
+              </div>
+
+              {/* 본문 */}
+              <div className="flex-1 min-w-0">
+                <div className="flex justify-between items-baseline gap-2">
+                  <span className="text-fg text-sm font-medium truncate">
+                    {item.name}
+                  </span>
+                  <span className="num text-fg text-sm font-bold flex-shrink-0">
+                    {formatCurrency(item.totalAmount)}
+                  </span>
+                </div>
+                <div className="mt-1.5 h-1.5 rounded-full bg-bg-muted overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{ width: `${barWidthPct}%`, background: tone.fg }}
+                  />
+                </div>
+                <div className="mt-1 flex justify-between text-xs text-fg-muted">
+                  <span>예산의 {budgetPct}%</span>
+                  {budgetPct >= 30 && (
+                    <span className="text-expense font-semibold">↑ 많음</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
@@ -58,7 +58,7 @@ export function BudgetCategoryBars({
                   className="text-sm font-bold"
                   style={{ color: tone.fg }}
                 >
-                  {item.icon || item.name[0]}
+                  {item.icon || item.name[0] || "?"}
                 </span>
               </div>
 

--- a/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCategoryBars.tsx
@@ -2,10 +2,12 @@ import { getCategoryTone } from "@/lib/utils/category-tone";
 import type { CategoryBreakdownItem } from "@/types/dashboard";
 import { formatCurrency } from "@/lib/utils/format";
 
+const WARNING_BUDGET_PCT = 30;
+const BAR_SCALE_FLOOR_RATIO = 0.5;
+
 interface BudgetCategoryBarsProps {
   items: CategoryBreakdownItem[];
   budget: number;
-  monthlyExpense: number;
 }
 
 export function BudgetCategoryBars({
@@ -17,7 +19,7 @@ export function BudgetCategoryBars({
     .slice(0, 5);
 
   const maxAmount = top5[0]?.totalAmount ?? 0;
-  const barBase = Math.max(maxAmount, budget * 0.5);
+  const barBase = Math.max(maxAmount, budget * BAR_SCALE_FLOOR_RATIO);
 
   if (top5.length === 0) {
     return (
@@ -48,7 +50,6 @@ export function BudgetCategoryBars({
 
           return (
             <div key={item.categoryUuid} className="flex items-center gap-3">
-              {/* 카테고리 아이콘 */}
               <div
                 className="h-9 w-9 flex-shrink-0 rounded-xl flex items-center justify-center"
                 style={{ background: tone.bg }}
@@ -61,7 +62,6 @@ export function BudgetCategoryBars({
                 </span>
               </div>
 
-              {/* 본문 */}
               <div className="flex-1 min-w-0">
                 <div className="flex justify-between items-baseline gap-2">
                   <span className="text-fg text-sm font-medium truncate">
@@ -79,7 +79,7 @@ export function BudgetCategoryBars({
                 </div>
                 <div className="mt-1 flex justify-between text-xs text-fg-muted">
                   <span>예산의 {budgetPct}%</span>
-                  {budgetPct >= 30 && (
+                  {budgetPct >= WARNING_BUDGET_PCT && (
                     <span className="text-expense font-semibold">↑ 많음</span>
                   )}
                 </div>

--- a/src/app/(authenticated)/budget/_components/BudgetClient.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetClient.tsx
@@ -6,8 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/client/utils";
 import { formatCurrency } from "@/lib/utils/format";
+import type { CategoryBreakdownItem } from "@/types/dashboard";
 import { AlertTriangle, PiggyBank, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { BudgetCategoryBars } from "./BudgetCategoryBars";
+import { BudgetCumulativeLine } from "./BudgetCumulativeLine";
 
 interface BudgetClientProps {
   budget: number;
@@ -15,6 +18,8 @@ interface BudgetClientProps {
   remainingBudget: number;
   year: number;
   month: number;
+  dailyExpenses: { date: string; income: number; expense: number }[];
+  categoryItems: CategoryBreakdownItem[];
 }
 
 export function BudgetClient({
@@ -23,6 +28,8 @@ export function BudgetClient({
   remainingBudget,
   year,
   month,
+  dailyExpenses,
+  categoryItems,
 }: BudgetClientProps) {
   const router = useRouter();
 
@@ -224,6 +231,22 @@ export function BudgetClient({
           </Card>
         </div>
       )}
+
+      {/* 라인 차트 */}
+      {hasBudget && (
+        <BudgetCumulativeLine
+          dailyExpenses={dailyExpenses}
+          budget={budget}
+          daysInMonth={daysInMonth}
+        />
+      )}
+
+      {/* 카테고리 top 5 */}
+      <BudgetCategoryBars
+        items={categoryItems}
+        budget={budget}
+        monthlyExpense={monthlyExpense}
+      />
 
       {/* 예산 수정 링크 */}
       {hasBudget && (

--- a/src/app/(authenticated)/budget/_components/BudgetClient.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetClient.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/client/utils";
+import { formatCurrency } from "@/lib/utils/format";
 import { AlertTriangle, PiggyBank, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -36,15 +37,25 @@ export function BudgetClient({
     ? Math.max(Math.round((remainingBudget / budget) * 100), 0)
     : 0;
 
+  const today = new Date();
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const dayOfMonth = today.getDate();
+  const daysRemaining = Math.max(daysInMonth - dayOfMonth, 0);
+
+  const dailyAverage =
+    dayOfMonth > 0 ? Math.round(monthlyExpense / dayOfMonth) : 0;
+  const recommendedDailyBudget =
+    daysRemaining > 0
+      ? Math.max(Math.round(remainingBudget / daysRemaining), 0)
+      : 0;
+
   return (
     <div className="p-4 md:p-6 space-y-4 md:space-y-6">
       {/* 헤더 */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl md:text-2xl font-bold text-foreground">
-            예산 관리
-          </h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
+          <h1 className="text-xl md:text-2xl font-bold text-fg">예산 관리</h1>
+          <p className="text-sm text-fg-muted mt-0.5">
             {year}년 {month}월
           </p>
         </div>
@@ -55,21 +66,21 @@ export function BudgetClient({
 
       {/* 예산 미설정 빈 상태 */}
       {!hasBudget && (
-        <Card className="border-dashed border-2 border-border bg-card">
+        <Card className="border-dashed border-2 border-border bg-bg-elev">
           <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-            <div className="p-4 bg-muted rounded-full mb-4">
-              <PiggyBank className="w-8 h-8 text-muted-foreground" />
+            <div className="p-4 bg-brand-50 rounded-full mb-4">
+              <PiggyBank className="w-8 h-8 text-brand-500 opacity-85" />
             </div>
-            <p className="text-base font-medium text-foreground mb-1">
+            <p className="text-[17px] font-bold text-fg mb-1">
               예산이 설정되지 않았습니다
             </p>
-            <p className="text-sm text-muted-foreground mb-6">
+            <p className="text-[13px] text-fg-muted mb-6">
               월별 예산을 설정하면 지출을 효과적으로 관리할 수 있어요
             </p>
             <Button
               variant="default"
               onClick={() => router.push("/settings")}
-              className="gradient-budget text-white shadow-sm hover:opacity-90 transition-opacity"
+              className="bg-brand-500 text-white hover:opacity-90 transition-opacity"
             >
               <Settings className="w-4 h-4" />
               예산 설정하기
@@ -99,14 +110,12 @@ export function BudgetClient({
               )}
             </div>
 
-            <p className="text-3xl md:text-4xl font-bold mb-1">
-              ₩
-              {isBudgetExceeded
-                ? Math.abs(remainingBudget).toLocaleString()
-                : remainingBudget.toLocaleString()}
+            <p className="num text-4xl md:text-5xl font-bold mb-1">
+              {isBudgetExceeded ? "-" : ""}
+              {formatCurrency(Math.abs(remainingBudget))}
             </p>
             <p className="text-xs mb-4 gradient-card-sublabel">
-              총 예산 ₩{budget.toLocaleString()}
+              총 예산 {formatCurrency(budget)} / {daysRemaining}일 남음
             </p>
 
             <div className="space-y-1.5">
@@ -123,22 +132,59 @@ export function BudgetClient({
         </Card>
       )}
 
+      {/* 3-col 통계 단락 */}
+      {hasBudget && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 md:gap-4">
+          <Card className="bg-bg-elev border-border rounded-xl">
+            <CardContent className="p-4">
+              <p className="text-xs text-fg-muted mb-1">일 평균 지출</p>
+              <p className="num text-xl md:text-2xl font-bold text-fg">
+                {formatCurrency(dailyAverage)}
+              </p>
+              <p className="text-xs text-fg-muted mt-1">{dayOfMonth}일 기준</p>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-bg-elev border-border rounded-xl">
+            <CardContent className="p-4">
+              <p className="text-xs text-fg-muted mb-1">남은 일수</p>
+              <p className="num text-xl md:text-2xl font-bold text-fg">
+                {daysRemaining}일
+              </p>
+              <p className="text-xs text-fg-muted mt-1">{daysInMonth}일 중</p>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-bg-elev border-border rounded-xl">
+            <CardContent className="p-4">
+              <p className="text-xs text-fg-muted mb-1">권장 일 예산</p>
+              <p className="num text-xl md:text-2xl font-bold text-fg">
+                {formatCurrency(recommendedDailyBudget)}
+              </p>
+              <p className="text-xs text-fg-muted mt-1">
+                남은 예산 ÷ 남은 일수
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
       {/* 세부 내역 */}
       {hasBudget && (
         <div className="grid grid-cols-2 gap-3 md:gap-4">
           {/* 이번 달 지출 */}
-          <Card className="bg-card border-border">
+          <Card className="bg-bg-elev border-border">
             <CardHeader className="pb-1 p-4">
-              <CardTitle className="text-xs text-muted-foreground font-medium">
+              <CardTitle className="text-xs text-fg-muted font-medium">
                 이번 달 지출
               </CardTitle>
             </CardHeader>
             <CardContent className="p-4 pt-0">
-              <p className="text-lg md:text-xl font-bold text-foreground">
-                ₩{monthlyExpense.toLocaleString()}
+              <p className="text-lg md:text-xl font-bold text-fg">
+                {formatCurrency(monthlyExpense)}
               </p>
               <div className="mt-2 space-y-1">
-                <div className="flex justify-between text-xs text-muted-foreground">
+                <div className="flex justify-between text-xs text-fg-muted">
                   <span>예산 대비</span>
                   <span>{usagePercent}%</span>
                 </div>
@@ -148,9 +194,9 @@ export function BudgetClient({
           </Card>
 
           {/* 남은 예산 */}
-          <Card className="bg-card border-border">
+          <Card className="bg-bg-elev border-border">
             <CardHeader className="pb-1 p-4">
-              <CardTitle className="text-xs text-muted-foreground font-medium">
+              <CardTitle className="text-xs text-fg-muted font-medium">
                 {isBudgetExceeded ? "초과 금액" : "남은 예산"}
               </CardTitle>
             </CardHeader>
@@ -158,16 +204,14 @@ export function BudgetClient({
               <p
                 className={cn(
                   "text-lg md:text-xl font-bold",
-                  isBudgetExceeded ? "text-destructive" : "text-foreground"
+                  isBudgetExceeded ? "text-expense" : "text-fg"
                 )}
               >
-                ₩
-                {isBudgetExceeded
-                  ? Math.abs(remainingBudget).toLocaleString()
-                  : remainingBudget.toLocaleString()}
+                {isBudgetExceeded ? "-" : ""}
+                {formatCurrency(Math.abs(remainingBudget))}
               </p>
               <div className="mt-2 space-y-1">
-                <div className="flex justify-between text-xs text-muted-foreground">
+                <div className="flex justify-between text-xs text-fg-muted">
                   <span>남은 비율</span>
                   <span>{isBudgetExceeded ? 0 : remainingPercent}%</span>
                 </div>
@@ -181,12 +225,12 @@ export function BudgetClient({
         </div>
       )}
 
-      {/* 예산 설정 링크 */}
+      {/* 예산 수정 링크 */}
       {hasBudget && (
         <Button
           variant="outline"
           onClick={() => router.push("/settings")}
-          className="w-full rounded-xl text-muted-foreground"
+          className="w-full rounded-xl text-fg-muted"
         >
           <Settings className="w-4 h-4" />
           예산 수정하기

--- a/src/app/(authenticated)/budget/_components/BudgetClient.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetClient.tsx
@@ -87,7 +87,7 @@ export function BudgetClient({
             <Button
               variant="default"
               onClick={() => router.push("/settings")}
-              className="bg-brand-500 text-white hover:opacity-90 transition-opacity"
+              className="gradient-budget text-white shadow-sm hover:opacity-90 transition-opacity"
             >
               <Settings className="w-4 h-4" />
               예산 설정하기

--- a/src/app/(authenticated)/budget/_components/BudgetClient.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetClient.tsx
@@ -242,11 +242,7 @@ export function BudgetClient({
       )}
 
       {/* 카테고리 top 5 */}
-      <BudgetCategoryBars
-        items={categoryItems}
-        budget={budget}
-        monthlyExpense={monthlyExpense}
-      />
+      <BudgetCategoryBars items={categoryItems} budget={budget} />
 
       {/* 예산 수정 링크 */}
       {hasBudget && (

--- a/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
@@ -63,7 +63,6 @@ export function BudgetCumulativeLine({
     expenseByDay.set(day, item.expense);
   }
 
-  // 누적 시퀀스 계산
   const chartData: ChartEntry[] = [];
   let cumulative = 0;
   for (let day = 1; day <= daysInMonth; day++) {

--- a/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { formatCurrency } from "@/lib/utils/format";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface BudgetCumulativeLineProps {
+  dailyExpenses: { date: string; income: number; expense: number }[];
+  budget: number;
+  daysInMonth: number;
+}
+
+interface ChartEntry {
+  day: number;
+  cumulative: number;
+  dailyExpense: number;
+  exceeded: boolean;
+}
+
+interface TooltipPayloadItem {
+  payload: ChartEntry;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}
+
+function CustomTooltip({ active, payload }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div className="bg-bg-elev border border-border shadow-md rounded-md p-2.5 text-xs text-fg">
+      <p className="font-medium mb-1">{d.day}일</p>
+      <p>
+        누적:{" "}
+        <span className="num font-semibold">{formatCurrency(d.cumulative)}</span>
+      </p>
+      <p className="text-fg-muted">
+        일 지출: {formatCurrency(d.dailyExpense)}
+      </p>
+    </div>
+  );
+}
+
+export function BudgetCumulativeLine({
+  dailyExpenses,
+  budget,
+  daysInMonth,
+}: BudgetCumulativeLineProps) {
+  // 일자별 expense 맵 (missing 날은 0 보간)
+  const expenseByDay = new Map<number, number>();
+  for (const item of dailyExpenses) {
+    const day = new Date(item.date).getDate();
+    expenseByDay.set(day, item.expense);
+  }
+
+  // 누적 시퀀스 계산
+  const chartData: ChartEntry[] = [];
+  let cumulative = 0;
+  for (let day = 1; day <= daysInMonth; day++) {
+    const daily = expenseByDay.get(day) ?? 0;
+    cumulative += daily;
+    chartData.push({
+      day,
+      cumulative,
+      dailyExpense: daily,
+      exceeded: cumulative >= budget,
+    });
+  }
+
+  const lastEntry = chartData[chartData.length - 1];
+  const totalCumulative = lastEntry?.cumulative ?? 0;
+  const pct = budget > 0 ? Math.min(Math.round((totalCumulative / budget) * 100), 100) : 0;
+
+  const renderDot = (props: { cx?: number; cy?: number; payload?: ChartEntry; index?: number }) => {
+    const { cx, cy, payload } = props;
+    if (!payload?.exceeded) return <g key={`dot-${props.index}`} />;
+    return (
+      <circle
+        key={`dot-exceeded-${props.index}`}
+        cx={cx}
+        cy={cy}
+        r={4}
+        fill="var(--color-expense)"
+        stroke="var(--color-bg-elev)"
+        strokeWidth={1.5}
+      />
+    );
+  };
+
+  return (
+    <div className="bg-bg-elev border border-border rounded-2xl p-5 md:p-6">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-sm font-semibold text-fg">이번 달 누적 지출</p>
+        <div className="flex items-center gap-3 text-xs text-fg-muted">
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block w-3 h-0.5 rounded"
+              style={{ backgroundColor: "var(--color-brand-500)" }}
+            />
+            누적
+          </span>
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block w-3 border-t border-dashed"
+              style={{ borderColor: "var(--color-brand-700)" }}
+            />
+            예산
+          </span>
+        </div>
+      </div>
+
+      {/* 차트 */}
+      <div className="h-48 md:h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={chartData}
+            margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--color-border)"
+              strokeOpacity={0.5}
+            />
+            <XAxis
+              dataKey="day"
+              interval="preserveStartEnd"
+              tick={{ fill: "var(--color-fg-muted)", fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              tickFormatter={(v: number) => `${Math.round(v / 10000)}만`}
+              tick={{ fill: "var(--color-fg-muted)", fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <ReferenceLine
+              y={budget}
+              stroke="var(--color-brand-700)"
+              strokeDasharray="4 4"
+              strokeWidth={1.5}
+            />
+            <Line
+              type="monotone"
+              dataKey="cumulative"
+              stroke="var(--color-brand-500)"
+              strokeWidth={2.5}
+              dot={renderDot}
+              activeDot={{ r: 5, fill: "var(--color-brand-500)" }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* 하단 요약 */}
+      <p className="mt-3 text-xs text-fg-muted text-right">
+        오늘까지{" "}
+        <span className="num font-semibold text-fg">
+          {formatCurrency(totalCumulative)}
+        </span>{" "}
+        ({pct}%)
+      </p>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
+++ b/src/app/(authenticated)/budget/_components/BudgetCumulativeLine.tsx
@@ -82,7 +82,7 @@ export function BudgetCumulativeLine({
 
   const renderDot = (props: { cx?: number; cy?: number; payload?: ChartEntry; index?: number }) => {
     const { cx, cy, payload } = props;
-    if (!payload?.exceeded) return <g key={`dot-${props.index}`} />;
+    if (cx == null || cy == null || !payload?.exceeded) return <g key={`dot-${props.index}`} />;
     return (
       <circle
         key={`dot-exceeded-${props.index}`}

--- a/src/app/(authenticated)/budget/loading.tsx
+++ b/src/app/(authenticated)/budget/loading.tsx
@@ -1,0 +1,47 @@
+import { Skel } from "@/components/loading/Skel";
+
+export default function BudgetLoading() {
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+      <div className="space-y-2">
+        <Skel w="40%" h={22} />
+        <Skel w="28%" h={13} />
+      </div>
+
+      <div className="bg-bg-elev rounded-2xl p-5 space-y-4">
+        <Skel w="40%" h={11} />
+        <Skel w="65%" h={30} />
+        <Skel h={6} r={4} />
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="bg-bg-elev rounded-xl p-4 space-y-2">
+            <Skel w="70%" h={10} />
+            <Skel w="80%" h={20} />
+            <Skel w="60%" h={9} />
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-bg-elev rounded-2xl p-5 space-y-3">
+        <Skel w="35%" h={14} />
+        <Skel h={192} r={12} />
+      </div>
+
+      <div className="bg-bg-elev rounded-2xl p-5 space-y-4">
+        <Skel w="30%" h={14} />
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Skel w={36} h={36} r={12} className="shrink-0" />
+            <div className="flex-1 space-y-1.5">
+              <Skel w="60%" h={12} />
+              <Skel h={6} r={3} />
+              <Skel w="40%" h={10} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/budget/page.tsx
+++ b/src/app/(authenticated)/budget/page.tsx
@@ -1,8 +1,3 @@
-/**
- * Budget Page - Server Component
- * 예산 관리 전용 페이지
- */
-
 import { getDashboardStatsAction } from "@/actions/dashboard/get-dashboard-stats-action";
 import { getMonthlyCategoryBreakdownAction } from "@/actions/dashboard/get-monthly-category-breakdown-action";
 import { getMonthlyDailyStatsAction } from "@/actions/dashboard/get-monthly-daily-stats-action";

--- a/src/app/(authenticated)/budget/page.tsx
+++ b/src/app/(authenticated)/budget/page.tsx
@@ -4,6 +4,8 @@
  */
 
 import { getDashboardStatsAction } from "@/actions/dashboard/get-dashboard-stats-action";
+import { getMonthlyCategoryBreakdownAction } from "@/actions/dashboard/get-monthly-category-breakdown-action";
+import { getMonthlyDailyStatsAction } from "@/actions/dashboard/get-monthly-daily-stats-action";
 import { BudgetClient } from "@/app/(authenticated)/budget/_components/BudgetClient";
 import { getActionDataOrDefault } from "@/lib/server/action-result-handler";
 import { auth } from "@/lib/server/auth";
@@ -21,15 +23,33 @@ export default async function BudgetPage() {
     redirect("/");
   }
 
-  const statsResult = await getDashboardStatsAction();
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+
+  const [statsResult, dailyResult, breakdownResult] = await Promise.all([
+    getDashboardStatsAction(),
+    getMonthlyDailyStatsAction(year, month),
+    getMonthlyCategoryBreakdownAction(),
+  ]);
+
   const stats = getActionDataOrDefault(statsResult, {
     monthlyExpense: 0,
     monthlyIncome: 0,
     remainingBudget: 0,
     familyMembers: 0,
     budget: 0,
-    year: new Date().getFullYear(),
-    month: new Date().getMonth() + 1,
+    year,
+    month,
+  });
+
+  const daily = getActionDataOrDefault(dailyResult, []);
+
+  const breakdown = getActionDataOrDefault(breakdownResult, {
+    year,
+    month,
+    totalExpense: 0,
+    items: [],
   });
 
   return (
@@ -39,6 +59,8 @@ export default async function BudgetPage() {
       remainingBudget={stats.remainingBudget}
       year={stats.year}
       month={stats.month}
+      dailyExpenses={daily}
+      categoryItems={breakdown.items}
     />
   );
 }

--- a/tasks/plan013-budget-page-redesign/index.json
+++ b/tasks/plan013-budget-page-redesign/index.json
@@ -1,8 +1,9 @@
 {
   "name": "plan013-budget-page-redesign",
   "description": "/budget 페이지를 Dashboard BudgetHeroCard 의 확장 전용 페이지로 재설계. shadcn legacy 토큰 (text-muted-foreground/bg-card/text-destructive) 제거 + Teal 토큰 적용 + 일별 누적 라인 차트 (recharts) + 일 평균/남은 일수/권장 일 예산 통계 단락 + 카테고리 top 5 수평 bar.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
+  "completed_at": "2026-05-18",
   "total_phases": 4,
   "related_docs": [
     "docs/flow.md"
@@ -23,28 +24,32 @@
       "file": "phase-01.md",
       "title": "BudgetClient Hero 카드 토큰 교체 + 통계 단락 (일 평균/남은 일수/권장 일 예산)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed",
+      "completed_at": "2026-05-18"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "BudgetCumulativeLine — 일별 누적 지출 vs 예산 라인 차트 (recharts)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed",
+      "completed_at": "2026-05-18"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "BudgetCategoryBars — 카테고리 top 5 수평 bar + 예산 대비 % 슬롯",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed",
+      "completed_at": "2026-05-18"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "page.tsx 데이터 페칭 통합 + 검증 + completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed",
+      "completed_at": "2026-05-18"
     }
   ]
 }

--- a/tasks/plan013-budget-page-redesign/phase-01.md
+++ b/tasks/plan013-budget-page-redesign/phase-01.md
@@ -24,7 +24,6 @@
 | `bg-card` | `bg-bg-elev` |
 | `bg-muted` | `bg-bg-muted` |
 | `text-destructive` | `text-expense` |
-| `border-border` | `border-border` (유지 — 토큰 이름 동일) |
 
 ### 2. Hero 카드 — Dashboard BudgetHeroCard 와 시각 일치
 

--- a/tasks/plan013-budget-page-redesign/phase-02.md
+++ b/tasks/plan013-budget-page-redesign/phase-02.md
@@ -29,7 +29,7 @@ interface BudgetCumulativeLineProps {
 내부 로직:
 - 일별 누적 시퀀스 계산: `acc[i] = acc[i-1] + expense[i]`
 - 라인 데이터: `[ { day: 1, cumulative: 0 }, ..., { day: daysInMonth, cumulative: total } ]`
-- 예산 수평선: `ReferenceLine y={budget} stroke="brand-700" strokeDasharray="4 4"`
+- 예산 수평선: `ReferenceLine y={budget} stroke="var(--color-brand-700)" strokeDasharray="4 4"`
 - 라인: `stroke="var(--color-brand-500)"`, `strokeWidth={2.5}`, fill area gradient (옵션)
 - 초과 지점: 누적 ≥ 예산 시 빨간 dot
 

--- a/tasks/plan013-budget-page-redesign/phase-02.md
+++ b/tasks/plan013-budget-page-redesign/phase-02.md
@@ -7,7 +7,8 @@
 ## Context (자기완결)
 
 - 데이터: `getMonthlyDailyStatsAction(year, month)` — analytics 페이지에서 이미 사용
-  - 응답: `{ items: { date: string; expense: number; income: number }[] }`
+  - 반환 형: `ActionResult<DailyTransactionSummary[]>` — 배열을 그대로 반환 (`items` 래퍼 없음)
+  - `DailyTransactionSummary = { date: string; income: number; expense: number }` (`src/services/dashboard/dashboard-service.ts` 의 export type)
 - recharts 이미 의존성 설치됨 (`src/components/dashboard/CategoryDistribution.tsx` 의 PieChart 참조)
 - 라인 차트는 budget 페이지 단독 — 재사용 컴포넌트 위치 `src/app/(authenticated)/budget/_components/`
 
@@ -19,8 +20,8 @@
 
 ```ts
 interface BudgetCumulativeLineProps {
-  dailyExpenses: { date: string; expense: number }[];   // 월 전체 일별 지출
-  budget: number;                                       // 월 예산
+  dailyExpenses: { date: string; income: number; expense: number }[];   // DailyTransactionSummary[] 형태 그대로
+  budget: number;                                                       // 월 예산
   daysInMonth: number;
 }
 ```
@@ -67,8 +68,8 @@ pnpm build
 
 test -f src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx
 
-# "use client" 첫 줄
-head -1 src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | grep -q 'use client'
+# "use client" 첫 줄 (따옴표 포함)
+head -1 src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | grep -q '"use client"'
 
 # recharts import + ReferenceLine
 grep -nE 'from "recharts"' src/app/\(authenticated\)/budget/_components/BudgetCumulativeLine.tsx | wc -l   # >= 1

--- a/tasks/plan013-budget-page-redesign/phase-03.md
+++ b/tasks/plan013-budget-page-redesign/phase-03.md
@@ -7,8 +7,9 @@
 ## Context (자기완결)
 
 - 데이터: `getMonthlyCategoryBreakdownAction()` (ADR-F16, Dashboard 에서 이미 사용)
-  - 응답: `{ items: { categoryUuid, categoryName, categoryColor?, totalAmount }[] }`
-- 카테고리 색 토큰: `--color-cat-{tone}-bg` / `--color-cat-{tone}-fg` (plan002 의 8 팔레트)
+  - 반환 형: `ActionResult<MonthlyCategoryBreakdown>` 이며 `MonthlyCategoryBreakdown.items: CategoryBreakdownItem[]`
+  - `CategoryBreakdownItem = { categoryUuid: string; name: string; icon: string; color?: string; totalAmount: number; percentage: number }` (`src/types/dashboard.ts:42-49`)
+- 카테고리 톤 helper: `import { getCategoryTone, getCategoryToneStyle } from "@/lib/utils/category-tone"` — name 문자열을 받아 `{ bg, fg }` (raw OKLCH 문자열) 반환. plan002 의 helper. `var(--color-cat-*)` CSS 변수는 **존재하지 않음** — 사용 금지
 - 수평 bar 는 순수 CSS (Tailwind w-* + bg) 또는 SVG — 본 phase 는 CSS 권장 (recharts 오버킬)
 
 ## 작업 항목
@@ -19,7 +20,7 @@
 
 ```ts
 interface BudgetCategoryBarsProps {
-  items: { categoryUuid: string; categoryName: string; categoryColor?: string; totalAmount: number }[];
+  items: CategoryBreakdownItem[];   // { categoryUuid, name, icon, color?, totalAmount, percentage }
   budget: number;
   monthlyExpense: number;
 }
@@ -36,27 +37,31 @@ interface BudgetCategoryBarsProps {
 - 제목: "카테고리 top 5" (text-fg 14px font-semibold)
 - 부제: "이번 달 지출이 큰 순" (text-fg-muted 12px)
 
-각 row 구조:
+각 row 구조 (helper 리턴값을 inline style 로 주입 — `var(--color-cat-*)` 토큰 없음):
 ```tsx
+const tone = getCategoryTone(item.name);   // { bg, fg } raw OKLCH
+
 <div className="flex items-center gap-3">
   {/* 36px 카테고리 round (tone bg + fg) */}
-  <div className="h-9 w-9 rounded-xl bg-[var(--color-cat-{tone}-bg)] flex items-center justify-center">
-    {/* 카테고리 첫 글자 또는 아이콘 */}
-    <span className="text-[var(--color-cat-{tone}-fg)] text-sm font-bold">{name[0]}</span>
+  <div
+    className="h-9 w-9 rounded-xl flex items-center justify-center"
+    style={{ background: tone.bg }}
+  >
+    {/* 카테고리 첫 글자 또는 icon 문자 */}
+    <span className="text-sm font-bold" style={{ color: tone.fg }}>
+      {item.icon || item.name[0]}
+    </span>
   </div>
   {/* 본문 */}
   <div className="flex-1 min-w-0">
     <div className="flex justify-between items-baseline">
-      <span className="text-fg text-sm font-medium truncate">{categoryName}</span>
-      <span className="num text-fg text-sm font-bold">₩{totalAmount.toLocaleString()}</span>
+      <span className="text-fg text-sm font-medium truncate">{item.name}</span>
+      <span className="num text-fg text-sm font-bold">₩{item.totalAmount.toLocaleString()}</span>
     </div>
     <div className="mt-1.5 h-1.5 rounded-full bg-bg-muted overflow-hidden">
       <div
         className="h-full rounded-full"
-        style={{
-          width: `${barWidthPct}%`,
-          background: `var(--color-cat-${tone}-fg)`,
-        }}
+        style={{ width: `${barWidthPct}%`, background: tone.fg }}
       />
     </div>
     <div className="mt-1 flex justify-between text-xs text-fg-muted">
@@ -73,8 +78,7 @@ interface BudgetCategoryBarsProps {
 
 ### 3. 카테고리 톤 helper 사용
 
-`getCategoryTone(categoryColor)` (plan002 helper) — 카테고리 색 토큰을 8 팔레트 중 하나에 매핑. category-tone helper 위치:
-- `src/lib/client/category-tone.ts` 또는 plan002 의 실제 helper 경로 확인 후 import
+`import { getCategoryTone } from "@/lib/utils/category-tone"` — 카테고리 **이름 문자열** 을 받아 `{ bg, fg }` (raw OKLCH 평면 값) 반환. plan002 helper 그대로 사용 (수정 금지). 호출 위치는 본 컴포넌트 row 렌더링부 (위 코드 참조).
 
 ### 4. 자동 verification
 
@@ -91,8 +95,12 @@ test -f src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx
 # top 5 slice 로직
 grep -nE 'slice\(0,\s*5\)' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1
 
-# 카테고리 톤 토큰
-grep -nE 'var\(--color-cat-' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 2
+# category-tone helper 사용 (@/lib/utils/category-tone)
+grep -nE 'from "@/lib/utils/category-tone"' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1
+grep -nE 'getCategoryTone\(' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1
+
+# var(--color-cat-*) 잔재 0 (존재하지 않는 토큰)
+! grep -nE 'var\(--color-cat-' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx
 
 # 예산 % 계산
 grep -nE 'budgetPct|budget.*100' src/app/\(authenticated\)/budget/_components/BudgetCategoryBars.tsx | wc -l   # >= 1

--- a/tasks/plan013-budget-page-redesign/phase-03.md
+++ b/tasks/plan013-budget-page-redesign/phase-03.md
@@ -30,7 +30,7 @@ interface BudgetCategoryBarsProps {
 - top 5 만 추출: `items.sort((a,b) => b.totalAmount - a.totalAmount).slice(0, 5)`
 - 각 카테고리의 예산 대비 비율: `(totalAmount / budget) * 100`
 - bar 폭: `(totalAmount / max(items[0].totalAmount, budget * 0.5)) * 100%` — top 1 기준 100%
-- category-tone 매핑: `src/lib/client/category-tone.ts` (plan002 의 helper 재사용)
+- category-tone 매핑: `@/lib/utils/category-tone` 의 `getCategoryTone(name)` (plan002 helper 재사용)
 
 카드 wrapper:
 - `bg-bg-elev border-border rounded-2xl p-5 md:p-6`
@@ -124,7 +124,7 @@ grep -nE 'budgetPct|budget.*100' src/app/\(authenticated\)/budget/_components/Bu
 
 | 리스크 | 완화 |
 |---|---|
-| `categoryColor` 가 OKLCH 평면 값이 아닌 hex (legacy) | category-tone helper 가 어떤 입력이든 8 톤 중 매핑하도록 설계됨. plan002 머지된 helper 사용 — 본 phase 가 helper 자체 변경 안 함 |
+| 카테고리 이름이 `NAME_TO_KEY` 미매칭 (영어/기타 한글) | helper 가 fallback 으로 `etc` 톤 반환 — 시각은 회색 톤으로 안전, 의미는 손실. plan002 helper 자체 변경 안 함 |
 | budget=0 시 budgetPct 무한대 | budget > 0 분기로 컴포넌트 자체 미렌더 (page.tsx 측 처리) |
 | 모바일 320px 폭에서 % 라벨 + 금액 줄바꿈 | `truncate` + `flex-shrink-0` 적절히. 수동 smoke 에서 확인 |
 | top 5 너무 적음 (가족 카테고리 3개만) | items.length 만큼만 렌더 (slice 가 자동 처리). 빈 row 미생성 |

--- a/tasks/plan013-budget-page-redesign/phase-04.md
+++ b/tasks/plan013-budget-page-redesign/phase-04.md
@@ -49,7 +49,7 @@ const [stats, daily, breakdown] = await Promise.all([
 ```
 <div className="p-4 md:p-6 space-y-4 md:space-y-6">
   {/* 헤더 */}
-  <BudgetHeader year={month} />
+  <BudgetHeader year={year} month={month} />
 
   {/* Hero + 3-col 통계 단락 — phase 01 결과 (BudgetClient 내부 inline) */}
 

--- a/tasks/plan013-budget-page-redesign/phase-04.md
+++ b/tasks/plan013-budget-page-redesign/phase-04.md
@@ -13,6 +13,11 @@ import { getDashboardStatsAction } from "@/actions/dashboard/get-dashboard-stats
 import { getMonthlyDailyStatsAction } from "@/actions/dashboard/get-monthly-daily-stats-action";
 import { getMonthlyCategoryBreakdownAction } from "@/actions/dashboard/get-monthly-category-breakdown-action";
 
+// year/month 는 stats 결과 의존 없이 server 시점 기준으로 미리 계산 (Promise.all 동시 호출 위해)
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth() + 1;
+
 const [stats, daily, breakdown] = await Promise.all([
   getDashboardStatsAction(),
   getMonthlyDailyStatsAction(year, month),
@@ -20,7 +25,10 @@ const [stats, daily, breakdown] = await Promise.all([
 ]);
 ```
 
-각 Action 결과를 `getActionDataOrDefault` 로 unwrap 후 `BudgetClient` 에 props 전달:
+각 Action 결과를 `getActionDataOrDefault` 로 unwrap 후 `BudgetClient` 에 props 전달.
+**중요 — 반환 형 차이**:
+- `getMonthlyDailyStatsAction` → `ActionResult<DailyTransactionSummary[]>` (배열 그대로, `items` 래퍼 없음)
+- `getMonthlyCategoryBreakdownAction` → `ActionResult<MonthlyCategoryBreakdown>` (`items` 필드 있음)
 
 ```tsx
 <BudgetClient
@@ -29,12 +37,12 @@ const [stats, daily, breakdown] = await Promise.all([
   remainingBudget={...}
   year={...}
   month={...}
-  dailyExpenses={daily.items}
-  categoryItems={breakdown.items}
+  dailyExpenses={daily}              // DailyTransactionSummary[] 그대로
+  categoryItems={breakdown.items}    // CategoryBreakdownItem[]
 />
 ```
 
-`BudgetClient.tsx` 의 props 타입 확장 + 내부에서 `BudgetCumulativeLine` / `BudgetCategoryBars` 컴포넌트 배치.
+`BudgetClient.tsx` 의 props 타입 확장 + 내부에서 `BudgetCumulativeLine` / `BudgetCategoryBars` 컴포넌트 배치. 통계 단락 (일 평균 / 남은 일수 / 권장 일 예산) 은 phase-01 결정대로 `BudgetClient` 내부 inline 으로 유지 (별도 `BudgetDailyStats` 컴포넌트 분리 금지 — phase-01 본문과 일관).
 
 ### 2. 레이아웃 구조
 
@@ -43,17 +51,13 @@ const [stats, daily, breakdown] = await Promise.all([
   {/* 헤더 */}
   <BudgetHeader year={month} />
 
-  {/* Hero — phase 01 결과 */}
-  <BudgetHeroCard ... />
-
-  {/* 3-col 통계 — phase 01 결과 */}
-  <BudgetDailyStats dailyAverage daysRemaining recommended />
+  {/* Hero + 3-col 통계 단락 — phase 01 결과 (BudgetClient 내부 inline) */}
 
   {/* 라인 차트 — phase 02 (budget > 0 시만) */}
-  {hasBudget && <BudgetCumulativeLine dailyExpenses budget daysInMonth />}
+  {hasBudget && <BudgetCumulativeLine dailyExpenses={daily} budget={budget} daysInMonth={daysInMonth} />}
 
   {/* 카테고리 top 5 — phase 03 */}
-  <BudgetCategoryBars items budget monthlyExpense />
+  <BudgetCategoryBars items={breakdown.items} budget={budget} monthlyExpense={monthlyExpense} />
 
   {/* 설정 링크 */}
   <Link href="/settings" />


### PR DESCRIPTION
## Summary

`/budget` 페이지를 Dashboard `BudgetHeroCard` 의 확장 전용 페이지로 재설계.

- **shadcn legacy 토큰 제거** + **Teal OKLCH 토큰** 적용 (`text-muted-foreground` → `text-fg-muted`, `bg-card` → `bg-bg-elev`, `text-destructive` → `text-expense`)
- **Hero 카드**: 큰 숫자 `.num text-4xl md:text-5xl` (Pretendard), 부제 "총 예산 {budget} / {daysRemaining}일 남음", Progress bar
- **3-col 통계 단락 신규**: 일 평균 지출 / 남은 일수 / 권장 일 예산 (`remaining ÷ daysRemaining`)
- **BudgetCumulativeLine** (신규, `use client`): recharts `LineChart` + `ReferenceLine` 예산 수평선 + 초과 dot
- **BudgetCategoryBars** (신규, server component): 카테고리 top 5 수평 bar + 예산 대비 % + 30% 초과 "↑ 많음" 라벨
- **page.tsx**: `Promise.all` 3 Action 병렬 (dashboard / daily / category breakdown)

## Phases

- `c03a320` phase-01: BudgetClient 토큰 교체 + Hero + 통계 단락
- `628213d` phase-02: BudgetCumulativeLine 라인 차트
- `eecbe9a` phase-03: BudgetCategoryBars 카테고리 bar
- `8f510e1` phase-04: page.tsx 통합 + index.json completed
- `f9322a3` code-reviewer FIX 반영 (dead prop 제거 + 매직 넘버 상수화 + AI slop 주석 제거)
- `01bd94b` docs/flow.md minor (BudgetHeroCard 표기 → 인라인 Hero)

## Verification

- `pnpm lint` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ 30 suites / 211 tests pass
- legacy 토큰 0건 (text-muted-foreground / bg-card / text-destructive)
- critic APPROVE (v2 after revise) / code-reviewer PASS / docs-verifier PASS

## Test plan

- [ ] `/budget` 다크 모드 자동 전환 확인
- [ ] 예산 0 EmptyState 표시 (라인 차트 / 카테고리 bar 미표시)
- [ ] 예산 100만 + 지출 80만 → Hero 80% + 라인 80만 + 카테고리 top 5
- [ ] 예산 100만 + 지출 110만 → Hero 초과 톤 + 라인 예산선 위 빨간 dot + ↑많음 라벨
- [ ] 모바일 320px 폭에서 라인/카테고리 카드 레이아웃 자연스러움

🤖 Generated with [Claude Code](https://claude.com/claude-code)