### PR TITLE
feat(invite): /invite/[token] Teal centered card + Zod 검증 (plan015)

### DIFF
--- a/src/__tests__/actions/invitation/accept-invitation-action.test.ts
+++ b/src/__tests__/actions/invitation/accept-invitation-action.test.ts
@@ -1,0 +1,74 @@
+/**
+ * acceptInvitationAction 테스트
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/env/server.env", () => ({
+  serverEnv: {
+    BACKEND_API_URL: "http://localhost:8080",
+    AUTH_URL: "http://localhost:3000",
+  },
+}));
+jest.mock("@/lib/server/auth/auth", () => ({
+  handlers: {},
+  auth: jest.fn(),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+}));
+jest.mock("@/lib/server/auth/auth-helpers");
+jest.mock("@/services/invitation/invitation-service");
+jest.mock("next/cache");
+
+import { acceptInvitationAction } from "@/actions/invitation/accept-invitation-action";
+import { requireAuth } from "@/lib/server/auth/auth-helpers";
+import { acceptInvitation } from "@/services/invitation/invitation-service";
+import { revalidatePath } from "next/cache";
+
+const mockRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
+const mockAcceptInvitation = acceptInvitation as jest.MockedFunction<
+  typeof acceptInvitation
+>;
+const mockRevalidatePath = revalidatePath as jest.MockedFunction<
+  typeof revalidatePath
+>;
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("acceptInvitationAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({} as never);
+  });
+
+  describe("잘못된 토큰 형식", () => {
+    it.each([
+      ["빈 문자열", ""],
+      ["UUID 아닌 문자열", "not-a-uuid"],
+      ["스크립트 주입 시도", "<script>alert(1)</script>"],
+    ])("%s → 에러 반환, acceptInvitation 호출 없음", async (_, token) => {
+      const result = await acceptInvitationAction(token);
+
+      expect(result.success).toBe(false);
+      expect(mockAcceptInvitation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("유효한 UUID → acceptInvitation 호출 + revalidatePath + successResult", async () => {
+    mockAcceptInvitation.mockResolvedValue(undefined);
+
+    const result = await acceptInvitationAction(VALID_UUID);
+
+    expect(result.success).toBe(true);
+    expect(mockAcceptInvitation).toHaveBeenCalledWith(VALID_UUID);
+    expect(mockAcceptInvitation).toHaveBeenCalledTimes(1);
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/");
+  });
+
+  it("service 에러 → 에러 ActionResult 반환", async () => {
+    mockAcceptInvitation.mockRejectedValue(new Error("서비스 오류"));
+
+    const result = await acceptInvitationAction(VALID_UUID);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/__tests__/actions/invitation/accept-invitation-action.test.ts
+++ b/src/__tests__/actions/invitation/accept-invitation-action.test.ts
@@ -22,6 +22,7 @@ jest.mock("next/cache");
 import { acceptInvitationAction } from "@/actions/invitation/accept-invitation-action";
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
 import { acceptInvitation } from "@/services/invitation/invitation-service";
+import type { Session } from "next-auth";
 import { revalidatePath } from "next/cache";
 
 const mockRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
@@ -34,10 +35,17 @@ const mockRevalidatePath = revalidatePath as jest.MockedFunction<
 
 const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
+const mockSession: Session = {
+  user: {
+    userUuid: "user-1",
+  },
+  expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+};
+
 describe("acceptInvitationAction", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockRequireAuth.mockResolvedValue({} as never);
+    mockRequireAuth.mockResolvedValue(mockSession);
   });
 
   describe("잘못된 토큰 형식", () => {

--- a/src/__tests__/actions/invitation/get-invitation-info-action.test.ts
+++ b/src/__tests__/actions/invitation/get-invitation-info-action.test.ts
@@ -1,0 +1,73 @@
+/**
+ * getInvitationInfoAction 테스트
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/env/server.env", () => ({
+  serverEnv: {
+    BACKEND_API_URL: "http://localhost:8080",
+    AUTH_URL: "http://localhost:3000",
+  },
+}));
+jest.mock("@/lib/server/auth/auth", () => ({
+  handlers: {},
+  auth: jest.fn(),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+}));
+jest.mock("@/services/invitation/invitation-service");
+
+import { getInvitationInfoAction } from "@/actions/invitation/get-invitation-info-action";
+import { getInvitationInfo } from "@/services/invitation/invitation-service";
+
+const mockGetInvitationInfo = getInvitationInfo as jest.MockedFunction<
+  typeof getInvitationInfo
+>;
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("getInvitationInfoAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("잘못된 토큰 형식", () => {
+    it.each([
+      ["빈 문자열", ""],
+      ["UUID 아닌 문자열", "not-a-uuid"],
+      ["스크립트 주입 시도", "<script>alert(1)</script>"],
+      ["일반 문자열", "abc123"],
+    ])("%s → 에러 반환, service 호출 없음", async (_, token) => {
+      const result = await getInvitationInfoAction(token);
+
+      expect(result.success).toBe(false);
+      expect(mockGetInvitationInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  it("유효한 UUID → service 호출 후 successResult 반환", async () => {
+    const mockData = {
+      valid: true,
+      familyName: "테스트 가족",
+      expiresAt: new Date("2026-12-31"),
+    };
+    mockGetInvitationInfo.mockResolvedValue(mockData);
+
+    const result = await getInvitationInfoAction(VALID_UUID);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(mockData);
+    }
+    expect(mockGetInvitationInfo).toHaveBeenCalledWith(VALID_UUID);
+    expect(mockGetInvitationInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("service 에러 → 에러 ActionResult 반환", async () => {
+    mockGetInvitationInfo.mockRejectedValue(new Error("서비스 오류"));
+
+    const result = await getInvitationInfoAction(VALID_UUID);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/actions/invitation/_schemas.ts
+++ b/src/actions/invitation/_schemas.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const InvitationTokenSchema = z.object({
+  token: z.string().uuid(),
+});

--- a/src/actions/invitation/accept-invitation-action.ts
+++ b/src/actions/invitation/accept-invitation-action.ts
@@ -1,7 +1,3 @@
-/**
- * 초대 수락 Server Action
- */
-
 "use server";
 
 import {
@@ -12,13 +8,17 @@ import {
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
 import { acceptInvitation } from "@/services/invitation/invitation-service";
 import { revalidatePath } from "next/cache";
+import { InvitationTokenSchema } from "./_schemas";
 
 export async function acceptInvitationAction(
   token: string
 ): Promise<ActionResult<void>> {
   try {
+    // invite 수락은 새 가족에 join 하는 시맨틱 — getSelectedFamilyUuid() 비교 불필요
+    // (update 계열과 달리 join 대상 familyUuid 는 token 으로 서버가 결정)
     await requireAuth();
-    await acceptInvitation(token);
+    const { token: validToken } = InvitationTokenSchema.parse({ token });
+    await acceptInvitation(validToken);
     revalidatePath("/");
     return successResult(undefined);
   } catch (error) {

--- a/src/actions/invitation/get-invitation-info-action.ts
+++ b/src/actions/invitation/get-invitation-info-action.ts
@@ -1,7 +1,3 @@
-/**
- * 초대 정보 조회 (토큰으로) Server Action
- */
-
 "use server";
 
 import {
@@ -13,6 +9,7 @@ import {
   getInvitationInfo,
   type InvitationInfoData,
 } from "@/services/invitation/invitation-service";
+import { InvitationTokenSchema } from "./_schemas";
 
 export type { InvitationInfoData };
 
@@ -22,7 +19,8 @@ export async function getInvitationInfoAction(
   token: string
 ): Promise<ActionResult<InvitationInfoData>> {
   try {
-    const info = await getInvitationInfo(token);
+    const { token: validToken } = InvitationTokenSchema.parse({ token });
+    const info = await getInvitationInfo(validToken);
     return successResult(info);
   } catch (error) {
     return handleActionError(error, "초대 정보를 가져오는데 실패했습니다");

--- a/src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx
+++ b/src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx
@@ -1,7 +1,3 @@
-/**
- * 초대 페이지 Client Component
- */
-
 "use client";
 
 import { useState } from "react";
@@ -19,6 +15,7 @@ import { acceptInvitationAction } from "@/actions/invitation/accept-invitation-a
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { toast } from "sonner";
+import { cn } from "@/lib/client/utils";
 
 interface InvitePageClientProps {
   token: string;
@@ -33,6 +30,10 @@ export function InvitePageClient({
 }: InvitePageClientProps) {
   const router = useRouter();
   const [isAccepting, setIsAccepting] = useState(false);
+
+  const hoursUntilExpire =
+    (new Date(expiresAt).getTime() - Date.now()) / (1000 * 60 * 60);
+  const isExpiringSoon = hoursUntilExpire <= 24;
 
   const handleAccept = async () => {
     setIsAccepting(true);
@@ -59,38 +60,53 @@ export function InvitePageClient({
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 app-background">
-      <Card className="max-w-md w-full border-0 shadow-2xl">
-        <CardHeader className="text-center pb-4">
-          <div className="w-20 h-20 gradient-family rounded-full flex items-center justify-center mx-auto mb-4">
-            <Users className="w-10 h-10 text-white" />
+    <div className="min-h-screen flex items-center justify-center p-5 bg-bg">
+      <Card className="max-w-md w-full bg-bg-elev border-border shadow-default">
+        <CardHeader className="text-center pb-4 pt-8">
+          <div className="w-24 h-24 gradient-family rounded-full flex items-center justify-center mx-auto mb-4">
+            <Users className="w-12 h-12 text-white" />
           </div>
-          <CardTitle className="text-2xl font-bold text-gray-900">
+          <CardTitle className="text-2xl font-bold text-fg tracking-tight">
             가족 초대
           </CardTitle>
-          <CardDescription className="text-base">
-            가계부를 함께 관리하도록 초대받았습니다
+          <CardDescription className="text-base text-fg-muted">
+            가계부를 함께 관리하도록 초대받았어요
           </CardDescription>
         </CardHeader>
 
         <CardContent className="space-y-6">
           {/* 가족 정보 */}
-          <div className="bg-muted rounded-2xl p-6 space-y-3">
-            <div className="flex items-center space-x-3">
-              <Users className="w-5 h-5 text-blue-600" />
-              <div>
-                <p className="text-sm text-gray-600">가족 이름</p>
-                <p className="text-lg font-semibold text-gray-900">
-                  {familyName}
-                </p>
+          <div className="bg-bg-muted rounded-2xl p-5 space-y-4">
+            <div className="flex items-center gap-3">
+              <Users className="w-5 h-5 text-brand-500" />
+              <div className="flex-1">
+                <p className="text-xs text-fg-muted">가족 이름</p>
+                <p className="text-lg font-semibold text-fg">{familyName}</p>
               </div>
             </div>
 
-            <div className="flex items-center space-x-3">
-              <Clock className="w-5 h-5 text-orange-600" />
-              <div>
-                <p className="text-sm text-gray-600">만료 일시</p>
-                <p className="text-lg font-semibold text-gray-900">
+            <div className="flex items-center gap-3">
+              <Clock
+                className={cn(
+                  "w-5 h-5",
+                  isExpiringSoon ? "text-expense" : "text-fg-muted",
+                )}
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-fg-muted">만료 일시</p>
+                  {isExpiringSoon && (
+                    <span className="px-1.5 py-0.5 rounded-md bg-expense/10 text-expense text-[10.5px] font-bold uppercase tracking-wide">
+                      곧 만료
+                    </span>
+                  )}
+                </div>
+                <p
+                  className={cn(
+                    "text-lg font-semibold",
+                    isExpiringSoon ? "text-expense" : "text-fg",
+                  )}
+                >
                   {format(new Date(expiresAt), "M월 d일 (E) HH:mm", {
                     locale: ko,
                   })}
@@ -100,27 +116,27 @@ export function InvitePageClient({
           </div>
 
           {/* 설명 */}
-          <div className="bg-gray-50 rounded-2xl p-4">
-            <p className="text-sm text-gray-700 leading-relaxed">
+          <div className="bg-brand-50 rounded-xl p-4">
+            <p className="text-sm text-brand-700 leading-relaxed">
               초대를 수락하면{" "}
-              <span className="font-semibold text-blue-600">{familyName}</span>
-              의 구성원이 되어 함께 가계부를 작성하고 관리할 수 있습니다.
+              <span className="font-semibold">{familyName}</span>
+              {" "}의 구성원이 되어 함께 가계부를 작성하고 관리할 수 있어요.
             </p>
           </div>
 
           {/* 액션 버튼 */}
-          <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
             <Button
               onClick={handleDecline}
               variant="outline"
-              className="flex-1 rounded-2xl border-2"
+              className="flex-1 rounded-xl"
               disabled={isAccepting}
             >
               거절하기
             </Button>
             <Button
               onClick={handleAccept}
-              className="flex-1 gradient-family hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-200 rounded-2xl text-white"
+              className="flex-1 gradient-family text-white rounded-xl shadow-default hover:opacity-90 transition-opacity"
               disabled={isAccepting}
             >
               {isAccepting ? (

--- a/src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx
+++ b/src/app/(authenticated)/invite/[token]/_components/InvitePageClient.tsx
@@ -20,7 +20,8 @@ import { cn } from "@/lib/client/utils";
 interface InvitePageClientProps {
   token: string;
   familyName: string;
-  expiresAt: Date;
+  // RSC→Client 직렬화 경계에서 string 으로 도착할 수 있어 union 으로 받는다
+  expiresAt: Date | string;
 }
 
 export function InvitePageClient({
@@ -33,7 +34,8 @@ export function InvitePageClient({
 
   const hoursUntilExpire =
     (new Date(expiresAt).getTime() - Date.now()) / (1000 * 60 * 60);
-  const isExpiringSoon = hoursUntilExpire <= 24;
+  const isAlreadyExpired = hoursUntilExpire <= 0;
+  const isExpiringSoon = !isAlreadyExpired && hoursUntilExpire <= 24;
 
   const handleAccept = async () => {
     setIsAccepting(true);

--- a/tasks/plan015-invite-page-redesign/index.json
+++ b/tasks/plan015-invite-page-redesign/index.json
@@ -1,8 +1,9 @@
 {
   "name": "plan015-invite-page-redesign",
   "description": "/invite/[token] 가족 초대 수락 페이지 시각 갱신 + invite Server Action 입력 Zod 검증 (ADR-F06). Auth (signin/signout/error) 와 동일 centered card 톤 + 만료 임박 (24h 이내) 경고 배지 + legacy 토큰 (app-background, text-gray-*, text-blue-600, text-orange-600, bg-muted, bg-gray-50) 제거. inviter/memberCount 추가는 backend #127 + plan016 으로 분리.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
+  "completed_at": "2026-05-19",
   "total_phases": 3,
   "related_docs": [
     "docs/flow.md"
@@ -21,21 +22,21 @@
       "file": "phase-01.md",
       "title": "InvitePageClient 시각 갱신 — centered card + 만료 경고 + legacy 토큰 제거",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "invite Server Action 입력 Zod 검증 보강 (ADR-F06)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "통합 검증 + legacy 잔재 grep + completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan015-invite-page-redesign/phase-01.md
+++ b/tasks/plan015-invite-page-redesign/phase-01.md
@@ -18,6 +18,14 @@
 
 ## 작업 항목
 
+### 0. import 보강
+
+`cn` 유틸이 기존 import 에 없음 — 작업 항목 3 의 className 분기에서 필요. 다음 import 추가:
+
+```ts
+import { cn } from "@/lib/utils";
+```
+
 ### 1. 배경 + 카드 wrapper 교체
 
 ```tsx
@@ -152,7 +160,7 @@ pnpm tsc --noEmit
 pnpm build
 
 # legacy 토큰 잔재 0
-! grep -nE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
+! grep -nE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
   src/app/\(authenticated\)/invite/\[token\]/_components/InvitePageClient.tsx
 
 # 신 토큰 사용

--- a/tasks/plan015-invite-page-redesign/phase-01.md
+++ b/tasks/plan015-invite-page-redesign/phase-01.md
@@ -160,7 +160,7 @@ pnpm tsc --noEmit
 pnpm build
 
 # legacy 토큰 잔재 0
-! grep -nE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
+! grep -nE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|(^|[^-])bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
   src/app/\(authenticated\)/invite/\[token\]/_components/InvitePageClient.tsx
 
 # 신 토큰 사용

--- a/tasks/plan015-invite-page-redesign/phase-03.md
+++ b/tasks/plan015-invite-page-redesign/phase-03.md
@@ -22,7 +22,7 @@ pnpm build
 
 ```bash
 # Invite 영역 전체에서 legacy 토큰 0
-! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
+! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|(^|[^-])bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
   src/app/\(authenticated\)/invite/
 
 # 하드코딩 hex 0

--- a/tasks/plan015-invite-page-redesign/phase-03.md
+++ b/tasks/plan015-invite-page-redesign/phase-03.md
@@ -22,7 +22,7 @@ pnpm build
 
 ```bash
 # Invite 영역 전체에서 legacy 토큰 0
-! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl' \
+! grep -rnE 'app-background|text-gray-|text-blue-600|text-orange-600|bg-gray-50|bg-muted\b|shadow-2xl|shadow-xl|shadow-lg\b' \
   src/app/\(authenticated\)/invite/
 
 # 하드코딩 hex 0


### PR DESCRIPTION
## Summary

- `/invite/[token]` 가족 초대 수락 페이지를 Auth (signin/signout/error) 톤 centered card 패턴으로 리디자인. legacy 토큰 (app-background, text-gray-*, text-blue-600/orange-600, bg-gray-50, bg-muted, shadow-2xl/xl/lg) 전면 제거.
- 만료 임박 (24h 이내) 경고 배지 추가: `text-expense` + `bg-expense/10` "곧 만료" + 빨간 시계 아이콘.
- `getInvitationInfoAction` / `acceptInvitationAction` 입력 토큰을 Zod (`InvitationTokenSchema = z.object({ token: z.string().uuid() })`) 로 런타임 검증 — ADR-F06 준수. 잘못된 형식의 토큰이 service 까지 흘러가지 않도록 차단.
- `_schemas.ts` 분리로 두 action 이 같은 스키마 재사용 (DRY).
- jest.mock 단위 테스트 신규 (잘못된 UUID 3종 + XSS 주입 + happy-path + service 에러).

## 비자명 설계 결정

- `acceptInvitationAction` 은 `requireAuth()` 만 호출 — `getSelectedFamilyUuid()` 비교 생략. invite 시맨틱상 수락자는 아직 그 가족 멤버가 아니므로 token 자체가 join 권한 증명. (코드 주석 명시)
- `z.string().uuid()` 가 RFC 4122 v1~v5 전체 허용. backend 가 v4 발급해도 검증 범위는 충분.

## Build

- `pnpm lint` ✅
- `pnpm tsc --noEmit` ✅
- `pnpm test` — 33 suites, 242 tests PASS
- `pnpm build` ✅

## Test plan

- [ ] `/invite/{valid-token}` 접속 — gradient-family round 헤더 + Auth 톤 centered card 표시
- [ ] 만료 > 24h 토큰 — `text-fg-muted` 시계 + 일반 폰트
- [ ] 만료 ≤ 24h 토큰 — `text-expense` 빨간 시계 + "곧 만료" 배지
- [ ] 만료된 토큰 — `/?error=invalid_invitation` redirect
- [ ] "초대 수락하기" 클릭 → 성공 toast + `/` redirect
- [ ] 잘못된 형식 토큰 (`/invite/not-a-uuid`) — service 호출 0회 + 에러 처리
- [ ] Dark mode 자연스러운 톤
- [ ] 모바일 (320px) + 데스크톱 (1280px) max-w-md 카드 가운데 정렬

## Out of Scope

- inviter / memberCount 표시 — plan016 + backend #127
- 거절 시 token 무효화 API
- 인증 안 한 사용자 미리보기 (현재 callbackUrl 흐름 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)