### PR TITLE
docs(plan020): Toast/AlertDialog Teal 토큰 통일 task

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -365,3 +365,15 @@
 - **트레이드오프**: 토큰 수 증가 (현재 expense-fg 만 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
 - **적용 범위**: `src/app/globals.css` (`--color-expense-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
 
+---
+
+## ADR-F24: sonner richColors OFF + Teal 토큰 직접 매핑 (2026-05-19)
+
+- **결정**: `Toaster` 의 `richColors` 옵션을 끄고, toast 타입별 색을 OKLCH 토큰으로 직접 매핑한다. success=`--color-brand-500` (Teal h=188), error=`--color-expense`, warning=`--color-warning`, info=`--color-brand-400`. 컨테이너 톤은 `bg-bg-elev` / `border-border` / `text-fg`. `AlertDialog` 도 동일 원칙으로 overlay=`bg-fg/60`, content=`bg-bg-elev`, description=`text-fg-muted` 로 통일.
+- **맥락**: sonner `richColors=true` 의 자동 success(green h≈140)/error(red)/warning(amber)/info(blue) 가 plan001 Teal 시스템 (brand h=188) 과 충돌. 특히 success green 이 income (h=152) 과도 가까워 시맨틱 혼동 가능. AlertDialog 의 `bg-white` / `bg-black/80` / `text-muted-foreground` 잔재는 shadcn v3 legacy 로 dark mode 미지원.
+- **대안 기각**:
+  - `richColors` 유지 + 컨테이너만 토큰화: success green 이 brand Teal 과 충돌 + income 시맨틱 혼동 잔존. 가장 적은 변경이지만 핵심 문제 미해결.
+  - richColors OFF + 단색 (popover-only): success/error 시각 강도 차이 사라져 critical 액션 ↔ confirmation 구분 약화. 토스트 본연의 즉시 인지 가치 손실.
+- **트레이드오프**: 토큰 직접 매핑은 sonner 업데이트 시 className target (`[data-sonner-toast][data-type=...]`) 시그니처 변경 영향 받음 — 단 sonner 가 안정적 API 이고 toast 사용처가 20+ 곳이라 일관성 이득이 큼.
+- **적용 범위**: `src/components/ui/sonner.tsx` + `src/app/providers.tsx` + `src/components/ui/alert-dialog.tsx`. AlertDialog 파괴적 Action (Delete*Dialog 4 호출처) 은 호출처에서 `variant="destructive"` 명시 (`buttonVariants({ variant: "destructive" })` 가 이미 expense 토큰으로 매핑됨).
+

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -432,6 +432,29 @@ Dashboard BudgetHeroCard 의 확장 전용 페이지. 분석은 /analytics, 예�
 
 ---
 
+## 14-4. Toast / AlertDialog 시각 시스템 (plan020)
+
+sonner Toaster + Radix AlertDialog 의 색 토큰을 plan001 OKLCH 시스템 (ADR-F24) 으로 통일.
+
+```
+Toast 타입 매핑 (richColors OFF — 토큰 직접):
+    success  → brand-500 (Teal h=188)
+    error    → expense
+    warning  → warning
+    info     → brand-400
+
+AlertDialog:
+    overlay   → bg-fg/60 (light=검은 톤, dark=흰 톤 자동)
+    content   → bg-bg-elev + border-border
+    title     → text-fg
+    description → text-fg-muted
+    Action    기본=brand / 파괴적 호출처는 variant="destructive" (= expense)
+```
+
+파괴적 AlertDialog 호출처 (4): `DeleteExpenseDialog` / `IncomeItem` 삭제 / `RecurringExpenseItem` 삭제 / `DeleteCategoryDialog`. 각 `<AlertDialogAction>` 에 destructive variant 명시.
+
+---
+
 ## 14. 대시보드 고정비 카드
 
 ```

--- a/tasks/plan020-toast-alertdialog-polish/index.json
+++ b/tasks/plan020-toast-alertdialog-polish/index.json
@@ -1,0 +1,51 @@
+{
+  "name": "plan020-toast-alertdialog-polish",
+  "description": "sonner Toaster + Radix AlertDialog 의 색 토큰을 plan001 OKLCH 시스템 (ADR-F24) 으로 통일. richColors OFF + brand/expense/warning 직접 매핑. AlertDialog overlay=bg-fg/60, content=bg-bg-elev. 파괴적 호출처 4 곳에 destructive variant 명시.",
+  "status": "pending",
+  "created_at": "2026-05-19",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/adr.md",
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration"
+  ],
+  "prerequisites": [
+    "plan001 머지 (brand/expense/warning + bg-elev/border/fg 토큰) ✅",
+    "globals.css 의 --destructive 가 --color-expense 로 매핑됨 ✅ (line 127)"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "sonner Toaster richColors OFF + 타입별 토큰 매핑 + providers.tsx classNames 갱신",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "AlertDialog overlay/content/description 토큰 갱신 + 파괴적 호출처 4 곳 destructive variant 명시",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증 + 8단계 체크리스트 + index.json status=completed 마킹 commit",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "sonner / radix-alert-dialog 모두 기존 의존성. className override 만으로 충족. richColors OFF 시 sonner 가 data-type 속성 노출 → CSS selector 로 타입별 톤 적용 검증됨.",
+    "2_tech_stack": "변경 없음. sonner / @radix-ui/react-alert-dialog / Tailwind v4 유지.",
+    "3_user_flow": "토스트 표시 / 삭제 confirm 다이얼로그 — 동작 변경 없음. 시각 톤만 Teal 시스템 일관화.",
+    "4_ui": "Toast: success=brand-500, error=expense, warning=warning, info=brand-400. Dialog: overlay=bg-fg/60, content=bg-bg-elev, title=text-fg, description=text-fg-muted. Destructive Action=expense (= var(--destructive)).",
+    "5_api": "변경 없음.",
+    "6_arch": "ui/sonner.tsx + providers.tsx + ui/alert-dialog.tsx 3 파일 컴포넌트 수정. 호출처는 Delete*Dialog 4 곳만 (`variant=destructive` className 추가).",
+    "7_adr": "ADR-F24 신설 — richColors OFF + 토큰 직접 매핑 결정 근거 (Teal h=188 vs sonner 자동 green/red/amber 충돌, income h=152 와 success green 시맨틱 혼동 회피).",
+    "8_docs": "adr.md ADR-F24 신설 + flow.md §14-4 신규 (Toast 매핑 표 + AlertDialog 토큰 표 + 파괴적 호출처 목록)."
+  }
+}

--- a/tasks/plan020-toast-alertdialog-polish/phase-01.md
+++ b/tasks/plan020-toast-alertdialog-polish/phase-01.md
@@ -1,0 +1,161 @@
+# Phase 01 — sonner Toaster 토큰 마이그레이션 + richColors OFF + 타입별 매핑
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `src/components/ui/sonner.tsx` 의 legacy popover 토큰 제거 + `src/app/providers.tsx` 의 richColors OFF + toastOptions classNames 를 brand/expense/warning 직접 매핑. plan001 Teal 시스템 (ADR-F24) 과 일관.
+
+## Context (자기완결)
+
+- 현재 `src/components/ui/sonner.tsx` (25 줄):
+  - `--normal-bg: var(--popover)` / `--normal-text: var(--popover-foreground)` / `--normal-border: var(--border)` — shadcn v3 legacy 토큰
+- 현재 `src/app/providers.tsx`:
+  - L13: `richColors` ON → sonner 자동 success(green h≈140) / error(red) / warning(amber) / info(blue) → Teal 시스템 + income (h=152) 와 충돌
+  - L18-20: `bg-popover` / `text-popover-foreground` / `text-muted-foreground` — legacy
+- OKLCH 토큰 (globals.css):
+  - `--color-brand-{50..900}` (Teal h=188), `--color-expense`, `--color-warning`, `--color-income`
+  - `--color-bg-elev`, `--color-border`, `--color-fg`, `--color-fg-muted`
+- toast 사용처 ≥ 20곳 — **호출 코드 변경 없음** (컴포넌트만 수정)
+
+## 작업 항목
+
+### 1. `src/components/ui/sonner.tsx` 토큰 마이그레이션
+
+```tsx
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--color-bg-elev)",
+          "--normal-text": "var(--color-fg)",
+          "--normal-border": "var(--color-border)",
+          "--success-bg": "var(--color-bg-elev)",
+          "--success-text": "var(--color-fg)",
+          "--success-border": "var(--color-brand-500)",
+          "--error-bg": "var(--color-bg-elev)",
+          "--error-text": "var(--color-fg)",
+          "--error-border": "var(--color-expense)",
+          "--warning-bg": "var(--color-bg-elev)",
+          "--warning-text": "var(--color-fg)",
+          "--warning-border": "var(--color-warning)",
+          "--info-bg": "var(--color-bg-elev)",
+          "--info-text": "var(--color-fg)",
+          "--info-border": "var(--color-brand-400)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }
+```
+
+토큰만 교체. 구조 유지. CSS variable 명명은 sonner 가 인식하는 표준 (`--{type}-bg/text/border`) — `richColors` 없이도 sonner 가 toast type 별 본 변수 사용.
+
+### 2. `src/app/providers.tsx` richColors OFF + classNames 갱신
+
+```tsx
+"use client";
+
+import { Toaster } from "@/components/ui/sonner";
+import { SessionProvider } from "next-auth/react";
+import { ThemeProvider } from "next-themes";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="data-theme" defaultTheme="system" enableSystem>
+      <SessionProvider>
+        {children}
+        <Toaster
+          position="top-center"
+          expand={true}
+          closeButton
+          toastOptions={{
+            classNames: {
+              toast: "bg-bg-elev border border-border shadow-lg text-fg",
+              title: "text-fg font-medium",
+              description: "text-fg-muted",
+              actionButton: "bg-brand-500 text-white",
+              cancelButton: "bg-bg-muted text-fg-muted",
+            },
+            style: {
+              zIndex: 100,
+            },
+          }}
+          style={{
+            zIndex: 100,
+          }}
+        />
+      </SessionProvider>
+    </ThemeProvider>
+  );
+}
+```
+
+변경:
+- L16 `richColors` 제거
+- L19-21 `bg-popover` → `bg-bg-elev`, `text-popover-foreground` → `text-fg`, `text-muted-foreground` → `text-fg-muted`
+- `actionButton` / `cancelButton` classNames 추가 (Teal brand 액션 / 중립 cancel)
+- 타입별 border 색은 sonner 가 sonner.tsx 의 `--{type}-border` CSS 변수에서 자동 적용 → richColors 없이도 success/error/warning/info 좌측 border tint 유지
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan020-toast-alertdialog-polish
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 0 (sonner)
+! grep -nE '--popover|popover-foreground|text-muted-foreground' \
+  src/components/ui/sonner.tsx src/app/providers.tsx
+
+# richColors OFF
+! grep -n 'richColors' src/app/providers.tsx
+
+# 신 토큰 사용
+grep -nE 'color-bg-elev|color-fg|color-border|color-brand-500|color-expense|color-warning' \
+  src/components/ui/sonner.tsx | wc -l   # >= 6
+
+grep -nE 'bg-bg-elev|text-fg|text-fg-muted|border-border' \
+  src/app/providers.tsx | wc -l   # >= 4
+```
+
+수동 smoke:
+- 카테고리 생성 → success toast → 좌측 Teal border + 본문 텍스트 가독성
+- 카테고리 생성 실패 (중복 이름) → error toast → 좌측 expense red border
+- Dark mode 토글 → toast 본문 bg/text 자연 전환
+- toast.warning / toast.info 가 사용처에 있으면 호출 시 톤 확인
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/ui/sonner.tsx` | legacy 토큰 → OKLCH, 타입별 border 변수 추가 |
+| `src/app/providers.tsx` | richColors OFF + classNames OKLCH 토큰 |
+
+## Out of Scope
+
+- toast 호출처 (`toast.success(...)`) 의 메시지/문구 — 변경 없음
+- sonner 패키지 업그레이드 — 현재 버전 유지
+- toast 위치 (top-center) — 변경 없음
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `--{type}-border` CSS 변수가 sonner 가 미인식 → 타입별 색 안 보임 | sonner v1.x 표준 변수 — 실패 시 `data-[type=success]:border-brand-500` 형태로 Tailwind arbitrary selector 폴백 |
+| `actionButton` classNames 가 sonner 내부 div 시그니처와 불일치 | toastOptions.classNames API 표준 — 미작동 시 phase-03 검증에서 발견되면 제거 가능 (action 버튼 사용 toast 없음) |
+| Dark mode 에서 bg-bg-elev 가 너무 어두워 toast 시인성 ↓ | smoke 수동 확인. 필요 시 `bg-bg-elev` → `bg-neutral-900/95` 등 미세 조정 |

--- a/tasks/plan020-toast-alertdialog-polish/phase-02.md
+++ b/tasks/plan020-toast-alertdialog-polish/phase-02.md
@@ -1,0 +1,135 @@
+# Phase 02 — AlertDialog 토큰 마이그레이션 + 파괴적 호출처 destructive variant 명시
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `src/components/ui/alert-dialog.tsx` 의 legacy 토큰 (`bg-black/80`, `bg-white`, `text-muted-foreground`) 을 plan001 OKLCH 시스템으로 통일. overlay=`bg-fg/60`, content=`bg-bg-elev`, description=`text-fg-muted`. 파괴적 호출처 4 곳의 `AlertDialogAction` 에 `variant="destructive"` 명시.
+
+## Context (자기완결)
+
+- 현재 `src/components/ui/alert-dialog.tsx` (141 줄):
+  - L21 overlay: `bg-black/80` 하드코딩 (light/dark 동일)
+  - L39 content: `bg-white p-6` (dark mode 미지원)
+  - L94 description: `text-muted-foreground` (legacy shadcn)
+  - L107 `AlertDialogAction`: `buttonVariants()` 기본 = brand → 파괴적 호출처에서도 brand 톤
+- `--destructive` 토큰: globals.css L127 에서 `var(--color-expense)` 로 매핑됨 → `variant="destructive"` 가 자동으로 expense 톤
+- 파괴적 AlertDialog 호출처 (4):
+  - `src/components/expenses/dialogs/DeleteExpenseDialog.tsx` L82-88
+  - `src/components/incomes/list/IncomeItem.tsx` L203-213
+  - `src/components/recurring-expense/RecurringExpenseItem.tsx` L183-189
+  - `src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx` L42-48
+
+## 작업 항목
+
+### 1. `src/components/ui/alert-dialog.tsx` 토큰 마이그레이션
+
+```tsx
+// L19-22 AlertDialogOverlay className
+className={cn(
+  "fixed inset-0 z-50 bg-fg/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+  className
+)}
+```
+
+```tsx
+// L36-43 AlertDialogContent className — bg-white → bg-bg-elev
+className={cn(
+  "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-bg-elev p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+  className
+)}
+```
+
+```tsx
+// L94 AlertDialogDescription className
+className={cn("text-sm text-fg-muted", className)}
+```
+
+`bg-fg/60` alpha 변형은 Tailwind v4 가 OKLCH 토큰 + alpha 자동 지원. light=어두운 fg 톤, dark=밝은 fg 톤 자동 전환. 미작동 시 `globals.css` 의 `@theme` 블록 외부에 `.bg-alert-overlay { background: color-mix(in srgb, var(--color-fg) 60%, transparent); }` 추가 (ADR-F13: inline style 금지).
+
+### 2. 파괴적 호출처 4 곳에 `variant="destructive"` 명시
+
+각 호출처의 `<AlertDialogAction ...>` 에 `className={cn(buttonVariants({ variant: "destructive" }))}` 추가 — `AlertDialogAction` 의 기본 `buttonVariants()` 를 override.
+
+```tsx
+// before
+<AlertDialogAction onClick={handleDelete}>삭제</AlertDialogAction>
+
+// after
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/client/utils";
+
+<AlertDialogAction
+  onClick={handleDelete}
+  className={cn(buttonVariants({ variant: "destructive" }))}
+>
+  삭제
+</AlertDialogAction>
+```
+
+대상 4 파일:
+
+| 파일 | 라인 | onClick 패턴 |
+|---|---|---|
+| `src/components/expenses/dialogs/DeleteExpenseDialog.tsx` | L82 | 기존 onClick 보존, className 만 추가 |
+| `src/components/incomes/list/IncomeItem.tsx` | L203 | 동일 |
+| `src/components/recurring-expense/RecurringExpenseItem.tsx` | L183 | 동일 |
+| `src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx` | L42 | 동일 |
+
+기존 props (onClick, disabled, asChild 등) 는 보존. `className` 만 추가.
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan020-toast-alertdialog-polish
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 0 (alert-dialog)
+! grep -nE 'bg-black/|bg-white|text-muted-foreground' \
+  src/components/ui/alert-dialog.tsx
+
+# 신 토큰 사용
+grep -nE 'bg-fg/60|bg-bg-elev|border-border|text-fg-muted' \
+  src/components/ui/alert-dialog.tsx | wc -l   # >= 3
+
+# 파괴적 호출처 4 곳 모두 destructive variant
+grep -l 'variant: "destructive"' \
+  src/components/expenses/dialogs/DeleteExpenseDialog.tsx \
+  src/components/incomes/list/IncomeItem.tsx \
+  src/components/recurring-expense/RecurringExpenseItem.tsx \
+  'src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx' \
+  | wc -l   # == 4
+```
+
+수동 smoke:
+- 카테고리 삭제 confirm → overlay 어두운 톤 + content 카드 자연스럽게 표시 + "삭제" 버튼 expense red
+- 지출 삭제 confirm → 동일 패턴
+- Dark mode → overlay 밝은 톤 (fg=흰색 계열 60%) + content bg-bg-elev 다크 톤
+- 모바일 (< 768px) → SheetContent 가 아닌 AlertDialog 중앙 표시 유지 (반응형 무관)
+- 비파괴적 confirm (현재 없으면 N/A) → variant 미지정 → brand 톤
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/ui/alert-dialog.tsx` | overlay + content + description 토큰 |
+| `src/components/expenses/dialogs/DeleteExpenseDialog.tsx` | Action variant destructive |
+| `src/components/incomes/list/IncomeItem.tsx` | Action variant destructive |
+| `src/components/recurring-expense/RecurringExpenseItem.tsx` | Action variant destructive |
+| `src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx` | Action variant destructive |
+
+## Out of Scope
+
+- AlertDialog 의 애니메이션 / 슬라이드 방향 — 변경 없음
+- AlertDialog → Sheet (모바일 bottom) 마이그레이션 — 별도 plan 후보
+- 비파괴적 confirm 다이얼로그 추가 — 현재 사용처 모두 파괴적
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `bg-fg/60` alpha 변형이 Tailwind v4 자동 처리 안 됨 | smoke 확인. 실패 시 `.bg-alert-overlay` 커스텀 클래스 정의 |
+| 4 호출처 중 일부에 import (`buttonVariants`, `cn`) 누락으로 빌드 실패 | tsc 검증 + 각 파일마다 import 확인 |
+| `variant="destructive"` 의 `bg-destructive` 가 expense 토큰 미매핑 (회귀) | globals.css L127 `--destructive: var(--color-expense)` 확인됨 — 변경 금지 |

--- a/tasks/plan020-toast-alertdialog-polish/phase-03.md
+++ b/tasks/plan020-toast-alertdialog-polish/phase-03.md
@@ -1,0 +1,81 @@
+# Phase 03 — 통합 검증 + 8단계 체크리스트 + status="completed" 마킹
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase-01 + phase-02 통합 검증. 빌드/타입/lint 통과 + legacy 토큰 잔재 0 + Teal 시스템 일관. 마지막에 `index.json` 의 `status` 를 `"completed"` 로 변경하고 commit.
+
+## 작업 항목
+
+### 1. 통합 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan020-toast-alertdialog-polish
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test:ci
+
+# legacy 토큰 0 (전체)
+! grep -nE '--popover|popover-foreground|text-muted-foreground' \
+  src/components/ui/sonner.tsx src/app/providers.tsx
+! grep -nE 'bg-black/|bg-white|text-muted-foreground' \
+  src/components/ui/alert-dialog.tsx
+
+# richColors OFF
+! grep -n 'richColors' src/app/providers.tsx
+
+# 파괴적 호출처 4 곳 모두 destructive variant
+grep -l 'variant: "destructive"' \
+  src/components/expenses/dialogs/DeleteExpenseDialog.tsx \
+  src/components/incomes/list/IncomeItem.tsx \
+  src/components/recurring-expense/RecurringExpenseItem.tsx \
+  'src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx' \
+  | wc -l   # == 4
+```
+
+### 2. 수동 smoke (구현자 책임)
+
+- 카테고리 생성 → success toast 좌측 Teal border
+- 카테고리 생성 중복 이름 → error toast 좌측 expense border
+- 카테고리 삭제 → AlertDialog overlay 자연스러움 + "삭제" 버튼 expense red
+- 지출 삭제 / 수입 삭제 / 반복지출 삭제 → 동일 패턴
+- Dark mode 토글 → toast / dialog 모두 자연 전환
+
+### 3. 8단계 체크리스트 자체 점검
+
+| 단계 | 확인 |
+|---|---|
+| 1 구현가능성 | sonner CSS 변수 표준 + radix className override 모두 호환 |
+| 2 기술스택 | 변경 없음 ✅ |
+| 3 사용자흐름 | 동작 변경 없음, 시각만 통일 ✅ |
+| 4 UI | 토큰 매핑 일관 + 파괴적 톤 명시 ✅ |
+| 5 API | 변경 없음 ✅ |
+| 6 아키텍처 | UI 컴포넌트만 수정 + 호출처 4 곳 override ✅ |
+| 7 ADR | ADR-F24 신설 (richColors OFF 결정 근거) ✅ |
+| 8 docs | flow.md §14-4 신규 + ADR-F24 ✅ |
+
+### 4. `index.json` status 마킹 + commit
+
+```bash
+# index.json 의 "status": "pending" → "completed" 변경
+# Edit tool 로 수정
+
+git add tasks/plan020-toast-alertdialog-polish/index.json
+git commit -m "chore(plan020): mark task completed"
+git push
+```
+
+PR 본문 갱신 (구현 PR 의 description) — 이번 plan 의 변경 요약 + verification 결과 첨부.
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan020-toast-alertdialog-polish/index.json` | status=completed |
+
+## Out of Scope
+
+- 다른 plan task 의 상태 변경
+- 새 ADR 추가


### PR DESCRIPTION
## Summary

sonner Toaster + Radix AlertDialog 의 색 토큰을 plan001 OKLCH 시스템 (ADR-F23) 으로 일관화하는 plan 의 docs + task 파일.

### 핵심 결정 (ADR-F23)

- sonner `richColors` OFF — 자동 success(green h≈140)/error(red)/warning(amber)/info(blue) 가 Teal h=188 brand 와 충돌 + income h=152 와 success green 시맨틱 혼동
- 타입별 토큰 직접 매핑: success=brand-500, error=expense, warning=warning, info=brand-400
- AlertDialog overlay=`bg-fg/60`, content=`bg-bg-elev`, description=`text-fg-muted`
- 파괴적 호출처 4 곳 (Delete\*Dialog) 에 `variant="destructive"` 명시 — `--destructive` 가 이미 `var(--color-expense)` 매핑됨

### docs 변경

- `docs/adr.md` — ADR-F23 신설
- `docs/flow.md` — §14-4 Toast/AlertDialog 시각 시스템

### task 파일

- `tasks/plan020-toast-alertdialog-polish/index.json`
- phase-01: sonner 토큰 마이그레이션 + richColors OFF + 타입별 매핑
- phase-02: alert-dialog 토큰 + 파괴적 호출처 4 곳 destructive variant
- phase-03: 통합 검증 + status=completed

## Test plan

구현 PR 검증 항목:

- [ ] \`pnpm lint\` / \`pnpm tsc --noEmit\` / \`pnpm build\` / \`pnpm test:ci\` 통과
- [ ] sonner.tsx / providers.tsx / alert-dialog.tsx 에 legacy 토큰 (\`--popover\`, \`bg-black/\`, \`bg-white\`, \`text-muted-foreground\`) 0
- [ ] richColors 옵션 제거 확인
- [ ] 파괴적 호출처 4 곳 모두 \`variant="destructive"\` 명시
- [ ] 카테고리 생성 success toast — Teal border / 실패 error toast — expense border
- [ ] 삭제 confirm AlertDialog — overlay 자연 + Action 버튼 expense red
- [ ] Dark mode 토글 — toast / dialog 모두 자연 전환