### PR TITLE
feat(layout): Header Teal 토큰 통일 + 모바일 가족 전환 Sheet (plan019)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -413,8 +413,8 @@
   - `text-white` 유지: ADR-F13 의 "globals.css `@theme` 외부에서 hex/rgb/hsl/named 색 금지" 원칙 위반. 디자인 토큰 단일 소스 깨짐.
   - `text-bg` (surface foreground): light/dark 가 반전되는 토큰이라 강조 배경 위 가독성 일관성 깨짐 (dark mode 에서 어두운 색 → expense 빨강 위 contrast 약화).
   - 인라인 `style={{ color: "white" }}`: ADR-F13 위반 + CLAUDE.md "인라인 style 최소화" 위반.
-- **트레이드오프**: 토큰 수 증가 (현재 expense-fg 만 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
-- **적용 범위**: `src/app/globals.css` (`--color-expense-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
+- **트레이드오프**: 토큰 수 증가 (현재 expense-fg + brand-fg 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
+- **적용 범위**: `src/app/globals.css` (`--color-expense-fg`, `--color-brand-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`) + `src/components/layout/Header.tsx` (`text-brand-fg` — 로고 아이콘 + AvatarFallback). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
 
 ---
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -368,7 +368,7 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
             ├─ NotificationBell (Popover trigger — plan017)
             └─ Avatar dropdown
                     ├─ 프로필 (이름 + 이메일)
-                    ├─ [모바일 전용] 가족 전환 → FamilySelector Sheet
+                    ├─ [모바일 전용] 가족 전환 → Sheet bottom + FamilySelectorList
                     ├─ 설정 → /settings
                     └─ 로그아웃 (text-expense — variant=destructive 폐기)
 ```
@@ -378,6 +378,7 @@ helper: `services/transaction/transaction-service.ts` 의 `groupTransactionsWith
 - `border-border` (하드 회색 폐기)
 - `ring-brand-100` Avatar (`ring-blue-100` 폐기)
 - `text-fg-muted` 보조 텍스트 (`text-muted-foreground` 폐기)
+- `text-brand-fg` 로고 아이콘 + AvatarFallback (`text-white` 폐기, ADR-F23)
 
 ---
 

--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -32,6 +32,14 @@ jest.mock("@/components/families/FamilySelectorDropdown", () => ({
   ),
 }));
 
+jest.mock("@/components/families/FamilySelectorList", () => ({
+  FamilySelectorList: () => <div data-testid="family-selector-list" />,
+}));
+
+jest.mock("@/actions/family/get-families-action", () => ({
+  getFamiliesAction: jest.fn(() => Promise.resolve({ success: true, data: [] })),
+}));
+
 jest.mock("@/components/notifications/NotificationBell", () => ({
   NotificationBell: ({ familyUuid }: { familyUuid: string }) => (
     <div data-testid="notification-bell">Notification {familyUuid}</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,7 @@
   --color-expense: oklch(0.620 0.180 25);
   --color-warning: oklch(0.760 0.150 78);
   --color-expense-fg: oklch(0.985 0.003 230);
+  --color-brand-fg: oklch(0.985 0.003 188); /* brand-500 위 near-white. hue=188 (brand) */
 
   /* ── neutral (cool gray, h=230) ─────────────── */
   --color-neutral-0:   oklch(1 0 0);

--- a/src/components/families/FamilySelectorDropdown.tsx
+++ b/src/components/families/FamilySelectorDropdown.tsx
@@ -87,7 +87,7 @@ export function FamilySelectorDropdown() {
 
   if (loading) {
     return (
-      <div className="w-32 md:w-40 h-8 md:h-9 bg-gray-100 animate-pulse rounded-md"></div>
+      <div className="w-32 md:w-40 h-8 md:h-9 bg-bg-muted animate-pulse rounded-md"></div>
     );
   }
 

--- a/src/components/families/FamilySelectorList.tsx
+++ b/src/components/families/FamilySelectorList.tsx
@@ -4,6 +4,7 @@ import { selectFamilyAction } from "@/actions/family/select-family-action";
 import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 interface FamilySelectorListProps {
   families: Family[];
@@ -27,7 +28,7 @@ export function FamilySelectorList({
       router.refresh();
       onSelected?.(familyUuid);
     } else {
-      console.error("Failed to select family:", result.error.message);
+      toast.error("가족 전환에 실패했습니다.");
     }
   };
 

--- a/src/components/families/FamilySelectorList.tsx
+++ b/src/components/families/FamilySelectorList.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { selectFamilyAction } from "@/actions/family/select-family-action";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
+import type { Family } from "@/types/family";
+import { useRouter } from "next/navigation";
+
+interface FamilySelectorListProps {
+  families: Family[];
+  selectedFamilyUuid: string;
+  /** select 성공 후 호출자에게 알림 — Sheet close 등 후속 UI 정리용 */
+  onSelected?: (familyUuid: string) => void;
+}
+
+export function FamilySelectorList({
+  families,
+  selectedFamilyUuid,
+  onSelected,
+}: FamilySelectorListProps) {
+  const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
+
+  const handleSelect = async (familyUuid: string) => {
+    const result = await selectFamilyAction(familyUuid);
+    if (result.success) {
+      await refreshSession();
+      router.refresh();
+      onSelected?.(familyUuid);
+    } else {
+      console.error("Failed to select family:", result.error.message);
+    }
+  };
+
+  return (
+    <ul className="flex flex-col gap-1 py-2">
+      {families.map((family) => (
+        <li key={family.uuid}>
+          <button
+            type="button"
+            onClick={() => handleSelect(family.uuid)}
+            className={`w-full px-3 py-2 text-left text-sm rounded-md transition-colors ${
+              family.uuid === selectedFamilyUuid
+                ? "bg-brand-50 text-brand-700 font-medium"
+                : "text-fg hover:bg-bg-muted"
+            }`}
+          >
+            {family.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ import { signOutAction } from "@/actions/auth/signout-action";
 import { getFamiliesAction } from "@/actions/family/get-families-action";
 import { FamilySelectorList } from "@/components/families/FamilySelectorList";
 import type { Family } from "@/types/family";
+import { toast } from "sonner";
 
 interface HeaderProps {
   session: Session;
@@ -52,8 +53,12 @@ export function Header({ session, selectedFamilyUuid }: HeaderProps) {
 
   const handleOpenFamilySheet = async () => {
     const result = await getFamiliesAction();
-    if (result.success && result.data) setSheetFamilies(result.data);
-    setFamilySheetOpen(true);
+    if (result.success && result.data) {
+      setSheetFamilies(result.data);
+      setFamilySheetOpen(true);
+    } else {
+      toast.error("가족 목록을 불러오지 못했습니다.");
+    }
   };
 
   return (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,12 +11,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { LogOut, User, Wallet } from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { LogOut, User, Users, Wallet } from "lucide-react";
 import { Session } from "next-auth";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { signOutAction } from "@/actions/auth/signout-action";
+import { getFamiliesAction } from "@/actions/family/get-families-action";
+import { FamilySelectorList } from "@/components/families/FamilySelectorList";
+import type { Family } from "@/types/family";
 
 interface HeaderProps {
   session: Session;
@@ -42,79 +47,108 @@ const NotificationBell = dynamic(
 
 export function Header({ session, selectedFamilyUuid }: HeaderProps) {
   const router = useRouter();
+  const [familySheetOpen, setFamilySheetOpen] = useState(false);
+  const [sheetFamilies, setSheetFamilies] = useState<Family[]>([]);
+
+  const handleOpenFamilySheet = async () => {
+    const result = await getFamiliesAction();
+    if (result.success && result.data) setSheetFamilies(result.data);
+    setFamilySheetOpen(true);
+  };
 
   return (
-    <header className="sticky top-0 z-50 backdrop-blur-xl bg-white/80 border-b border-gray-200/50 shadow-sm">
-      <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-14 md:h-16">
-          <Link
-            href="/dashboard"
-            className="flex items-center space-x-2 md:space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
-          >
-            <div className="w-8 h-8 md:w-10 md:h-10 gradient-primary rounded-xl md:rounded-2xl flex items-center justify-center shadow-lg">
-              <Wallet className="w-4 h-4 md:w-5 md:h-5 text-white" />
-            </div>
-            <div>
-              <h1 className="text-base md:text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
+    <>
+      <header className="sticky top-0 z-50 backdrop-blur-xl bg-bg-elev/95 border-b border-border shadow-sm">
+        <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-14 md:h-16">
+            <Link
+              href="/dashboard"
+              className="flex items-center space-x-2 md:space-x-3 cursor-pointer hover:opacity-80 transition-opacity"
+            >
+              <div className="w-8 h-8 md:w-10 md:h-10 bg-brand-500 rounded-xl flex items-center justify-center">
+                <Wallet className="w-4 h-4 md:w-5 md:h-5 text-brand-fg" />
+              </div>
+              <h1 className="text-base md:text-xl font-bold text-fg tracking-tight">
                 우리집 가계부
               </h1>
-            </div>
-          </Link>
+            </Link>
 
-          <div className="flex items-center space-x-1.5 md:space-x-3">
-            <div className="hidden md:block">
-              <FamilySelectorDropdown />
+            <div className="flex items-center space-x-1.5 md:space-x-3">
+              <div className="hidden md:block">
+                <FamilySelectorDropdown />
+              </div>
+              {selectedFamilyUuid && (
+                <NotificationBell familyUuid={selectedFamilyUuid} />
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="w-8 h-8 md:w-9 md:h-9 p-0 rounded-full"
+                  >
+                    <Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-brand-100">
+                      <AvatarImage src={session.user?.image || ""} />
+                      <AvatarFallback className="bg-brand-500 text-brand-fg font-semibold text-xs md:text-sm">
+                        {session.user?.name?.[0] || "U"}
+                      </AvatarFallback>
+                    </Avatar>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56 bg-bg-elev border-border">
+                  <DropdownMenuLabel>
+                    <div className="flex flex-col space-y-1">
+                      <p className="text-sm font-medium text-fg leading-none">
+                        {session.user?.name}
+                      </p>
+                      <p className="text-xs text-fg-muted leading-none">
+                        {session.user?.email}
+                      </p>
+                    </div>
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+
+                  {/* 모바일 전용 — 가족 전환 진입점 */}
+                  <DropdownMenuItem className="md:hidden" onClick={handleOpenFamilySheet}>
+                    <Users className="mr-2 h-4 w-4" />
+                    <span>가족 전환</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator className="md:hidden" />
+
+                  <DropdownMenuItem onClick={() => router.push("/settings")}>
+                    <User className="mr-2 h-4 w-4" />
+                    <span>설정</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem className="text-expense focus:text-expense" asChild>
+                    <form action={signOutAction}>
+                      <button
+                        type="submit"
+                        className="flex items-center w-full"
+                      >
+                        <LogOut className="mr-2 h-4 w-4" />
+                        <span>로그아웃</span>
+                      </button>
+                    </form>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
-            {selectedFamilyUuid && (
-              <NotificationBell familyUuid={selectedFamilyUuid} />
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="w-8 h-8 md:w-9 md:h-9 p-0 rounded-full"
-                >
-                  <Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-blue-100">
-                    <AvatarImage src={session.user?.image || ""} />
-                    <AvatarFallback className="gradient-primary text-white font-semibold text-xs md:text-sm">
-                      {session.user?.name?.[0] || "U"}
-                    </AvatarFallback>
-                  </Avatar>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel>
-                  <div className="flex flex-col space-y-1">
-                    <p className="text-sm font-medium leading-none">
-                      {session.user?.name}
-                    </p>
-                    <p className="text-xs leading-none text-muted-foreground">
-                      {session.user?.email}
-                    </p>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => router.push("/settings")}>
-                  <User className="mr-2 h-4 w-4" />
-                  <span>설정</span>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem variant="destructive" asChild>
-                  <form action={signOutAction}>
-                    <button
-                      type="submit"
-                      className="flex items-center w-full"
-                    >
-                      <LogOut className="mr-2 h-4 w-4" />
-                      <span>로그아웃</span>
-                    </button>
-                  </form>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
         </div>
-      </div>
-    </header>
+      </header>
+
+      <Sheet open={familySheetOpen} onOpenChange={setFamilySheetOpen}>
+        <SheetContent side="bottom" className="h-auto bg-bg-elev">
+          <SheetHeader>
+            <SheetTitle>가족 전환</SheetTitle>
+          </SheetHeader>
+          <FamilySelectorList
+            families={sheetFamilies}
+            selectedFamilyUuid={selectedFamilyUuid ?? ""}
+            onSelected={() => setFamilySheetOpen(false)}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }

--- a/tasks/plan019-header-redesign/index.json
+++ b/tasks/plan019-header-redesign/index.json
@@ -1,8 +1,9 @@
 {
   "name": "plan019-header-redesign",
   "description": "Header.tsx 시각 통일 + 모바일 가족 전환 진입점 추가. legacy 토큰 (bg-white/80, border-gray-200/50, from-gray-900 to-gray-700 텍스트 그라디언트, gradient-primary, ring-blue-100, text-muted-foreground, variant=destructive, bg-gray-100 skeleton) 제거 + --color-brand-fg 토큰 신설 (ADR-F23 준수) + FamilySelectorList 추출 (책임: selectFamilyAction + refreshSession + router.refresh) + Avatar dropdown 에 '가족 전환' 항목 (모바일 전용 Sheet 진입점).",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-11",
+  "completed_at": "2026-05-19",
   "total_phases": 2,
   "related_docs": [
     "docs/flow.md"
@@ -23,14 +24,14 @@
       "file": "phase-01.md",
       "title": "Header 토큰 일관화 + brand-fg 신설 + FamilySelectorList 추출 + 모바일 가족 전환 Sheet",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "통합 검증 + 8단계 체크리스트 + completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "planning_checklist": {

--- a/tasks/plan019-header-redesign/index.json
+++ b/tasks/plan019-header-redesign/index.json
@@ -1,6 +1,6 @@
 {
   "name": "plan019-header-redesign",
-  "description": "Header.tsx 시각 통일 + 모바일 가족 전환 진입점 추가. legacy 토큰 (bg-white/80, border-gray-200/50, from-gray-900 to-gray-700 텍스트 그라디언트, gradient-primary, ring-blue-100, text-muted-foreground, variant=destructive) 제거 + Avatar dropdown 에 '가족 전환' 항목 (모바일 전용).",
+  "description": "Header.tsx 시각 통일 + 모바일 가족 전환 진입점 추가. legacy 토큰 (bg-white/80, border-gray-200/50, from-gray-900 to-gray-700 텍스트 그라디언트, gradient-primary, ring-blue-100, text-muted-foreground, variant=destructive, bg-gray-100 skeleton) 제거 + --color-brand-fg 토큰 신설 (ADR-F23 준수) + FamilySelectorList 추출 (책임: selectFamilyAction + refreshSession + router.refresh) + Avatar dropdown 에 '가족 전환' 항목 (모바일 전용 Sheet 진입점).",
   "status": "pending",
   "created_at": "2026-05-11",
   "total_phases": 2,
@@ -21,7 +21,7 @@
     {
       "number": 1,
       "file": "phase-01.md",
-      "title": "Header 토큰 일관화 + 로고 단색 + dropdown '가족 전환' (모바일 Sheet)",
+      "title": "Header 토큰 일관화 + brand-fg 신설 + FamilySelectorList 추출 + 모바일 가족 전환 Sheet",
       "model": "sonnet",
       "status": "pending"
     },

--- a/tasks/plan019-header-redesign/phase-01.md
+++ b/tasks/plan019-header-redesign/phase-01.md
@@ -1,25 +1,42 @@
-# Phase 01 — Header 토큰 일관화 + 로고 단색 + 모바일 '가족 전환'
+# Phase 01 — Header 토큰 일관화 + brand-fg 신설 + 모바일 '가족 전환'
 
 **Model**: sonnet
 **Status**: pending
-**Goal**: `Header.tsx` 의 legacy 토큰 제거 + 로고 텍스트 그라디언트 → text-fg 단색 + Avatar dropdown 안에 모바일 전용 "가족 전환" 항목 추가 (Sheet 형태 진입점).
+**Goal**: `Header.tsx` 의 legacy 토큰 제거 + 로고 텍스트 그라디언트 → text-fg 단색 + `--color-brand-fg` 토큰 신설 (ADR-F23 준수) + Avatar dropdown 안에 모바일 전용 "가족 전환" 항목 (Sheet 진입점) + `FamilySelectorList` 추출.
 
 ## Context (자기완결)
 
-- 현재: `src/components/layout/Header.tsx` (115 줄). `(authenticated)/layout.tsx` 에서 호출 → 전 인증 페이지 일관 표시.
+- 변경 대상: `src/components/layout/Header.tsx` (115줄). `(authenticated)/layout.tsx` 에서 호출 → 전 인증 페이지 일관 표시.
 - legacy 잔재:
   - `bg-white/80 border-gray-200/50` — dark mode 미지원
   - `from-gray-900 to-gray-700 bg-clip-text text-transparent` — 텍스트 그라디언트
-  - `gradient-primary` (구 brand 토큰?)
+  - `gradient-primary` (구 brand 토큰)
   - `ring-blue-100` Avatar
   - `text-muted-foreground` shadcn legacy
   - `variant="destructive"` DropdownMenuItem
 - 구조 약점: `<div className="hidden md:block"><FamilySelectorDropdown /></div>` — 모바일에서 FamilySelector 진입 불가
 - 데이터: session prop + selectedFamilyUuid prop (server 측 결정)
+- 부수 정리: `FamilySelectorDropdown.tsx` 의 loading skeleton `bg-gray-100` 도 legacy → 본 phase 의 grep 범위 포함
 
-## 작업 항목
+## 사전 조건 — `--color-brand-fg` 신설 (ADR-F23 준수)
 
-### 1. 헤더 외곽 토큰 교체
+현재 `globals.css` 의 `@theme` 블록에 `--color-expense-fg` 만 정의돼 있고 `--color-brand-fg` 가 없다. `bg-brand-500` 위 텍스트 색을 `text-white` 로 하드코딩하면 ADR-F23 (강조 배경 위 텍스트 색은 시맨틱 foreground 토큰) 위반.
+
+`src/app/globals.css` 의 `@theme` 블록 (line 22 부근, `--color-expense-fg` 아래) 에 추가:
+
+```css
+--color-brand-fg: oklch(0.985 0.003 188); /* brand-500 위 near-white. hue=188 (brand) */
+```
+
+이 토큰이 정의되면 Tailwind v4 가 `text-brand-fg` 유틸리티를 자동 생성. AvatarFallback / 로고 Wallet 아이콘 모두 `text-brand-fg` 로 통일.
+
+## 작업 항목 (5 items)
+
+### 1. globals.css 토큰 추가 + Header 외곽 토큰 교체
+
+`src/app/globals.css` 의 `@theme` 에 `--color-brand-fg` 추가 (위 사전 조건 참조).
+
+`src/components/layout/Header.tsx`:
 
 ```tsx
 // 변경 전
@@ -29,9 +46,9 @@
 <header className="sticky top-0 z-50 backdrop-blur-xl bg-bg-elev/95 border-b border-border shadow-sm">
 ```
 
-`bg-bg-elev/95` alpha 변형 작동 확인 — plan001 의 OKLCH 토큰 + Tailwind v4 가 자동 alpha 변형 지원. 미작동 시 `globals.css` 의 `@theme` 블록 외부에 `.bg-header { background: color-mix(in srgb, var(--color-bg-elev) 95%, transparent); }` 커스텀 클래스를 추가해 사용한다. **inline `style={{ ... }}` 작성 금지** (ADR-F13 / CLAUDE.md OKLCH 토큰 규칙 — 토큰 외부 하드코딩 차단).
+`bg-bg-elev/95` alpha 변형은 Tailwind v4 의 OKLCH 토큰 자동 alpha 변형으로 작동. **객관 검증**: phase 완료 시 `pnpm build` 후 `find .next -name "*.css" | xargs grep -l "bg-elev\|color-mix"` 로 emit 확인. 미emit 시 `globals.css` 외부에 커스텀 클래스 추가 fallback. **inline `style={{ ... }}` 작성 금지** (ADR-F13).
 
-### 2. 로고 단색 + brand 아이콘
+### 2. 로고/아이콘 토큰 (brand 단색 + brand-fg)
 
 ```tsx
 // 변경 전
@@ -46,32 +63,30 @@
 
 // 변경 후
 <div className="w-8 h-8 md:w-10 md:h-10 bg-brand-500 rounded-xl flex items-center justify-center">
-  <Wallet className="w-4 h-4 md:w-5 md:h-5 text-white" />
+  <Wallet className="w-4 h-4 md:w-5 md:h-5 text-brand-fg" />
 </div>
 <h1 className="text-base md:text-xl font-bold text-fg tracking-tight">
   우리집 가계부
 </h1>
 ```
 
-`gradient-primary` 폐기 — plan001 의 brand-500 단색이 대체. `shadow-lg` 도 제거 (sticky header 그림자만 유지).
+- `gradient-primary` → `bg-brand-500` 단색
+- Wallet 아이콘 색: `text-white` 금지 (ADR-F23) → `text-brand-fg`
+- 로고 텍스트: 그라디언트 → `text-fg` 단색
+- `shadow-lg` 제거 (sticky header 그림자만 유지)
 
-### 3. Avatar ring 토큰
+### 3. Avatar + Dropdown 본문 토큰 + '가족 전환' 항목 (모바일)
 
 ```tsx
-// 변경 전
-<Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-blue-100">
-
-// 변경 후
+// Avatar trigger
 <Avatar className="w-8 h-8 md:w-9 md:h-9 ring-2 ring-brand-100">
+  <AvatarImage src={session.user?.image || ""} />
+  <AvatarFallback className="bg-brand-500 text-brand-fg font-semibold text-xs md:text-sm">
+    {session.user?.name?.[0] || "U"}
+  </AvatarFallback>
+</Avatar>
 
-// AvatarFallback
-className="bg-brand-500 text-white font-semibold text-xs md:text-sm"
-// (기존 gradient-primary → bg-brand-500 단색)
-```
-
-### 4. Dropdown 본문 토큰 + '가족 전환' 항목
-
-```tsx
+// Dropdown 본문
 <DropdownMenuContent align="end" className="w-56 bg-bg-elev border-border">
   <DropdownMenuLabel>
     <div className="flex flex-col space-y-1">
@@ -82,10 +97,7 @@ className="bg-brand-500 text-white font-semibold text-xs md:text-sm"
   <DropdownMenuSeparator />
 
   {/* 모바일 전용 — 가족 전환 진입점 */}
-  <DropdownMenuItem
-    className="md:hidden"
-    onClick={() => setFamilySheetOpen(true)}
-  >
+  <DropdownMenuItem className="md:hidden" onClick={() => setFamilySheetOpen(true)}>
     <Users className="mr-2 h-4 w-4" />
     <span>가족 전환</span>
   </DropdownMenuItem>
@@ -107,93 +119,189 @@ className="bg-brand-500 text-white font-semibold text-xs md:text-sm"
 </DropdownMenuContent>
 ```
 
-`variant="destructive"` → `text-expense focus:text-expense` 명시 (시맨틱 토큰).
+- AvatarFallback: `bg-brand-500 text-brand-fg` (ADR-F23 준수, `text-white` 금지)
+- Avatar ring: `ring-blue-100` → `ring-brand-100`
+- DropdownMenuContent: `bg-bg-elev border-border` 명시
+- Label 텍스트: `text-fg` / `text-fg-muted` (shadcn `text-muted-foreground` 제거)
+- 로그아웃: `variant="destructive"` → `text-expense focus:text-expense`
 
-### 5. 모바일 가족 전환 Sheet
+### 4. FamilySelectorList 신설 (pure refactor — 책임 명확)
+
+`src/components/families/FamilySelectorList.tsx` 신설. **책임**: `FamilySelectorList` 가 `selectFamilyAction` + `refreshSession` + `router.refresh` 까지 모두 내부에서 수행한다. `onSelected` 는 success 후 호출자 알림용 (Sheet close 등). 호출자 (Dropdown / Sheet) 는 trigger UI + 닫기 콜백만 책임.
+
+```tsx
+"use client";
+
+import { selectFamilyAction } from "@/actions/family/select-family-action";
+import { useSessionRefresh } from "@/lib/client/use-session-refresh";
+import type { Family } from "@/types/family";
+import { useRouter } from "next/navigation";
+
+interface FamilySelectorListProps {
+  families: Family[];
+  selectedFamilyUuid: string;
+  /** select 성공 후 호출자에게 알림 — Sheet close 등 후속 UI 정리용 */
+  onSelected?: (familyUuid: string) => void;
+}
+
+export function FamilySelectorList({ families, selectedFamilyUuid, onSelected }: FamilySelectorListProps) {
+  const router = useRouter();
+  const { refreshSession } = useSessionRefresh();
+
+  const handleSelect = async (familyUuid: string) => {
+    const result = await selectFamilyAction(familyUuid);
+    if (result.success) {
+      await refreshSession();
+      router.refresh();
+      onSelected?.(familyUuid);
+    } else {
+      console.error("Failed to select family:", result.error.message);
+    }
+  };
+
+  // 가족 목록 렌더 (간단한 버튼 list — 현재 Dropdown 의 SelectItem 과 동등한 시각)
+  return (
+    <ul className="flex flex-col gap-1 py-2">
+      {families.map((family) => (
+        <li key={family.uuid}>
+          <button
+            type="button"
+            onClick={() => handleSelect(family.uuid)}
+            className={`w-full px-3 py-2 text-left text-sm rounded-md transition-colors ${
+              family.uuid === selectedFamilyUuid
+                ? "bg-brand-50 text-brand-700 font-medium"
+                : "text-fg hover:bg-bg-muted"
+            }`}
+          >
+            {family.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`FamilySelectorDropdown.tsx` 는 가족 목록 fetch + 첫 가족 자동 선택 책임만 유지하고 list 렌더는 `FamilySelectorList` 위임. 기존 `loadInitialData` 의 가족 1개 자동 선택 + 쿠키 저장 + refreshSession 로직은 그대로 유지 (회귀 방지). 또한 **loading skeleton `bg-gray-100` → `bg-bg-muted`** 로 함께 토큰화.
+
+### 5. 모바일 Sheet 통합 + Header import 정비 + 테스트 갱신
+
+Header.tsx import 추가:
+
+```tsx
+import { useState } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Users } from "lucide-react";
+import { FamilySelectorList } from "@/components/families/FamilySelectorList";
+import { getFamiliesAction } from "@/actions/family/get-families-action";
+import type { Family } from "@/types/family";
+```
+
+Sheet 통합 — Header 본문 마지막에 추가:
 
 ```tsx
 const [familySheetOpen, setFamilySheetOpen] = useState(false);
+const [sheetFamilies, setSheetFamilies] = useState<Family[]>([]);
 
-// Header 본문 마지막에 추가:
+const handleOpenFamilySheet = async () => {
+  // 가족 목록 lazy fetch — 모바일 열 때만
+  const result = await getFamiliesAction();
+  if (result.success && result.data) setSheetFamilies(result.data);
+  setFamilySheetOpen(true);
+};
+
+// dropdown 의 '가족 전환' onClick → handleOpenFamilySheet
+
 <Sheet open={familySheetOpen} onOpenChange={setFamilySheetOpen}>
   <SheetContent side="bottom" className="h-auto bg-bg-elev">
     <SheetHeader>
       <SheetTitle>가족 전환</SheetTitle>
     </SheetHeader>
-    {/* FamilySelectorDropdown 의 list 부분만 inline — 또는 별도 FamilySelectorList 컴포넌트로 추출 */}
-    <FamilySelectorList onSelected={(_familyUuid) => setFamilySheetOpen(false)} />
+    <FamilySelectorList
+      families={sheetFamilies}
+      selectedFamilyUuid={selectedFamilyUuid ?? ""}
+      onSelected={() => setFamilySheetOpen(false)}
+    />
   </SheetContent>
 </Sheet>
 ```
 
-`FamilySelectorList` 가 별도 추출 안 되어있으면 phase 시작 시 `src/components/families/FamilySelectorDropdown.tsx` 의 내부 list 부분을 분리 (가족 목록 렌더 + select handler):
+**Sheet close 타이밍**: `FamilySelectorList` 가 `router.refresh()` 호출 후 `onSelected` 콜백을 호출 → Sheet close. 즉 refresh 트랜지션 시작 후 close 라 UX 안정적 (router.refresh 는 비동기 server fetch 트리거이고 close 는 즉시 client state).
 
-```ts
-// src/components/families/FamilySelectorList.tsx (신규)
-interface FamilySelectorListProps {
-  /** 선택된 가족 UUID 를 호출자에게 명시적으로 전달 — 호출자가 분기 처리 가능 */
-  onSelected?: (familyUuid: string) => void;
-}
-```
+테스트 갱신 — `src/__tests__/components/layout/Header.test.tsx`:
+- `jest.mock("@/components/families/FamilySelectorList", () => ({ FamilySelectorList: () => <div data-testid="family-selector-list" /> }))` 추가
+- `jest.mock("@/actions/family/get-families-action", () => ({ getFamiliesAction: jest.fn(() => Promise.resolve({ success: true, data: [] })) }))` 추가
+- 기존 expect 는 legacy 토큰을 expect 하지 않으므로 mobile dropdown item ("가족 전환") 표시 확인 케이스만 1건 추가 (선택)
 
-`FamilySelectorDropdown` 의 dropdown content 안에서도 `FamilySelectorList` 재사용 — 데스크톱 / 모바일 단일 책임.
-
-### 6. 자동 verification
+## Verification (mechanical)
 
 ```bash
-# cwd: /Users/nhn/personal/fos-accountbook
-# branch: plan/019-header-redesign
+# cwd: /Users/nhn/personal/fos-accountbook/.claude/worktrees/plan019
 
 pnpm lint
 pnpm tsc --noEmit
+pnpm test --passWithNoTests
 pnpm build
 
-# legacy 토큰 0
-! grep -nE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground' \
-  src/components/layout/Header.tsx
+# legacy 토큰 0 — Header + FamilySelector 전 영역
+! grep -rnE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground|bg-gray-100' \
+  src/components/layout/Header.tsx \
+  src/components/families/FamilySelectorDropdown.tsx \
+  src/components/families/FamilySelectorList.tsx
 
 # variant="destructive" 0
 ! grep -n 'variant="destructive"' src/components/layout/Header.tsx
 
-# 신 토큰 사용
-grep -nE 'bg-bg-elev|border-border|bg-brand-500|ring-brand-100|text-fg|text-fg-muted|text-expense' \
-  src/components/layout/Header.tsx | wc -l   # >= 4
+# ADR-F23 — text-white / text-black 0 (Header)
+! grep -nE 'text-white|text-black' src/components/layout/Header.tsx
 
-# 모바일 가족 전환 항목
-grep -nE 'md:hidden.*가족 전환|가족 전환.*md:hidden|familySheetOpen' \
-  src/components/layout/Header.tsx | wc -l   # >= 1
+# 신 토큰 사용 (Header 최소 5개)
+grep -cE 'bg-bg-elev|border-border|bg-brand-500|ring-brand-100|text-fg|text-brand-fg|text-expense' \
+  src/components/layout/Header.tsx   # >= 5
 
-# FamilySelectorList 존재
+# 모바일 가족 전환 진입점
+grep -nE 'md:hidden.*가족 전환|familySheetOpen|FamilySelectorList' src/components/layout/Header.tsx | wc -l   # >= 2
+
+# globals.css 토큰 정의 확인
+grep -n 'color-brand-fg' src/app/globals.css   # >= 1
+
+# FamilySelectorList 신규 + 책임 (selectFamilyAction)
 test -f src/components/families/FamilySelectorList.tsx
+grep -n 'selectFamilyAction\|router.refresh' src/components/families/FamilySelectorList.tsx
 ```
 
-수동 smoke:
+## 수동 smoke
+
 - 데스크톱 (>= 768px) → FamilySelectorDropdown 우상단 표시 + Avatar dropdown 에 '가족 전환' 항목 미표시
 - 모바일 (< 768px) → FamilySelectorDropdown 숨김 + Avatar 클릭 → dropdown → '가족 전환' → Sheet bottom 표시
-- Sheet 에서 가족 선택 → Sheet 닫힘 + 페이지 갱신
-- Dark mode → 모든 톤 자연스러움
-- 가족 1개뿐인 사용자 → FamilySelector 표시 유지 (가족명 + 관리 진입점)
+- Sheet 에서 가족 선택 → 페이지 갱신 후 Sheet 닫힘
+- Dark mode → 모든 톤 자연스러움 (특히 brand-500 위 brand-fg 가독성)
+- 가족 1개뿐인 사용자 → FamilySelector 표시 유지
 
 ## Critical Files
 
 | 파일 | 상태 |
 |---|---|
+| `src/app/globals.css` | `--color-brand-fg` 토큰 추가 |
 | `src/components/layout/Header.tsx` | 토큰 + 로고 + dropdown + Sheet |
-| `src/components/families/FamilySelectorList.tsx` | 신규 (Dropdown 의 list 분리) |
-| `src/components/families/FamilySelectorDropdown.tsx` | FamilySelectorList 호출하도록 갱신 |
+| `src/components/families/FamilySelectorList.tsx` | 신규 (책임: select + refresh + onSelected) |
+| `src/components/families/FamilySelectorDropdown.tsx` | loading skeleton 토큰화 (`bg-gray-100` → `bg-bg-muted`) |
+| `src/__tests__/components/layout/Header.test.tsx` | mock 추가 (FamilySelectorList, getFamiliesAction) |
 
 ## Out of Scope
 
 - 페이지별 헤더 보조 정보 (예: "이번 달 5월" 라벨 일관 표시) — 후속 plan
-- 가족 관리 페이지 신규 (현재 /families 디렉터리 검토 필요) — 별도
+- 가족 관리 페이지 신규 — 별도
 - 로그아웃 확인 dialog — 현재 즉시 처리 유지
 - 다국어 (en/ja) — 한국어만
+- `FamilySelectorDropdown` 의 Select trigger 자체 디자인 변경 — 본 plan 범위 외 (loading skeleton 만 토큰화)
 
 ## Risks
 
 | 리스크 | 완화 |
 |---|---|
-| `bg-bg-elev/95` 가 backdrop-blur 와 어울려 dark mode 너무 어두움 | 수동 smoke + 필요 시 `bg-bg-elev/90` 으로 alpha 조정 |
-| FamilySelectorList 추출 시 기존 FamilySelectorDropdown 회귀 | dropdown 사용처 (Header md+) 동작 확인. 추출 = pure refactor 로 동작 변경 없음 |
-| dynamic import (ssr: false) 의 Avatar Sheet trigger 가 hydration 미스매치 | Sheet 자체는 useState 만 — server 무관. 단 가족 list 페칭은 client side |
-| 모바일 dropdown 에 '가족 전환' 추가로 메뉴 4 항목 — 클릭 영역 좁아짐 | h-11 patch — touch target 44px 이상 유지. 수동 smoke 에서 모바일 클릭 확인 |
+| `bg-bg-elev/95` 가 backdrop-blur 와 어울려 dark mode 너무 어두움 | 수동 smoke + 필요 시 `bg-bg-elev/90` alpha 조정 |
+| FamilySelectorList 추출 시 기존 Dropdown 회귀 (refreshSession 누락 등) | List 가 select + refresh 모두 책임. Dropdown 은 lazy fetch 만. 수동 smoke 에서 데스크톱 가족 전환 동작 확인 |
+| `--color-brand-fg` 값이 brand-500 위 contrast 불충분 | `oklch(0.985 0.003 188)` 은 near-white, brand-500 (oklch 0.640) 과 충분 대비. 의심 시 plan001 contrast 표 재확인 |
+| dynamic ssr:false 의 Avatar Sheet trigger 가 hydration 미스매치 | Sheet 자체는 useState 만 — server 무관 |
+| 모바일 dropdown 4 항목 + 클릭 영역 좁아짐 | shadcn DropdownMenuItem 기본 h-9, touch target 36px+ 유지 |

--- a/tasks/plan019-header-redesign/phase-02.md
+++ b/tasks/plan019-header-redesign/phase-02.md
@@ -9,8 +9,7 @@
 ### 1. 통합 빌드/린트/테스트
 
 ```bash
-# cwd: /Users/nhn/personal/fos-accountbook
-# branch: plan/019-header-redesign
+# cwd: /Users/nhn/personal/fos-accountbook/.claude/worktrees/plan019
 
 pnpm lint
 pnpm tsc --noEmit
@@ -18,22 +17,25 @@ pnpm test --passWithNoTests
 pnpm build
 ```
 
-기존 `src/__tests__/components/layout/Header.test.tsx` 가 새 구조에서 통과하는지 확인. 깨지면 본 phase 내에서 갱신 (또는 phase 01 에 포함). 깨진 expectation:
-- text 그라디언트 → 단색 text 변경
-- variant=destructive 클래스 → text-expense
-- 모바일 가족 전환 항목 신규 — 모바일 viewport 시뮬레이션 필요
+테스트는 phase-01 에서 mock 갱신 완료된 상태. 본 phase 는 통과 확인만.
 
-### 2. legacy 잔재 0 최종
+### 2. legacy 잔재 0 + ADR-F23 최종
 
 ```bash
-# Header 영역 + FamilySelector 영역 legacy 토큰 0
-! grep -rnE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground' \
+# Header + FamilySelector 영역 legacy 토큰 0 (bg-gray-100 포함)
+! grep -rnE 'bg-white/|border-gray-|from-gray-|to-gray-|gradient-primary|ring-blue-|text-muted-foreground|bg-gray-100' \
   src/components/layout/Header.tsx \
   src/components/families/FamilySelectorDropdown.tsx \
   src/components/families/FamilySelectorList.tsx 2>/dev/null
 
 # variant="destructive" 0
 ! grep -rn 'variant="destructive"' src/components/layout/Header.tsx
+
+# ADR-F23 — text-white/text-black 0
+! grep -nE 'text-white|text-black' src/components/layout/Header.tsx src/components/families/FamilySelectorList.tsx
+
+# globals.css 의 brand-fg 토큰 정의
+grep -n 'color-brand-fg' src/app/globals.css
 ```
 
 ### 3. 8단계 체크리스트 명시 확인
@@ -60,12 +62,9 @@ jq '.planning_checklist | to_entries | map(select(.value == "" or .value == null
 
 phase + 최상위 status → `"completed"` + `completed_at`.
 
-### 6. 최종 커밋
+### 6. 최종 커밋 (team-lead 가 통합 검증 후 처리 — executor 는 commit 금지)
 
-```bash
-git add tasks/plan019-header-redesign/index.json
-git commit -m "chore(plan019): mark completed"
-```
+team-lead 가 phase-02 검증 결과 + index.json 갱신 + 통합 commit 1건으로 처리한다.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Summary

- `Header.tsx` 의 legacy 토큰 (gradient-primary, ring-blue-100, text-muted-foreground, variant=destructive, bg-white/80, border-gray-200/50, from-gray-900 to-gray-700 텍스트 그라디언트) 제거 + Teal OKLCH 토큰 통일
- ADR-F23 준수 — `--color-brand-fg: oklch(0.985 0.003 188)` 신설. 로고 Wallet 아이콘과 AvatarFallback 의 `text-white` → `text-brand-fg`
- 모바일 가족 전환 진입점 추가 — Avatar dropdown 안 "가족 전환" 항목 → bottom Sheet
- `FamilySelectorList` 신규 컴포넌트 — `selectFamilyAction + refreshSession + router.refresh` 모두 내부 책임. `onSelected` 는 success 후 호출자 알림 (Sheet close 용도)
- `FamilySelectorDropdown` loading skeleton `bg-gray-100` → `bg-bg-muted` 토큰화

## Changes

| 파일 | 변경 |
|---|---|
| `src/app/globals.css` | `--color-brand-fg` 토큰 정의 (+1 line) |
| `src/components/layout/Header.tsx` | 토큰 일관화 + Sheet 통합 + import 정비 |
| `src/components/families/FamilySelectorList.tsx` | 신규 (List + select + refresh) |
| `src/components/families/FamilySelectorDropdown.tsx` | skeleton 토큰화 |
| `src/__tests__/components/layout/Header.test.tsx` | mock 갱신 |
| `docs/adr.md` | ADR-F23 적용 범위 확장 (brand-fg + Header.tsx) |
| `docs/flow.md` | §14-1 text-brand-fg 토큰 매핑 + FamilySelectorList 명시 |
| `tasks/plan019-header-redesign/index.json` | status=completed |

## Pipeline (build-with-teams 정식 5-agent)

- critic: APPROVE (v1 REVISE → v2 보강 → v2 APPROVE)
- executor: phase-01 통과 — lint / tsc / test (242 pass) / build 전 통과
- code-reviewer: PASS (MEDIUM 2건은 차기 이슈 권장 — getFamiliesAction 실패 시 빈 Sheet, FamilySelectorList rollback 부재)
- docs-verifier: PASS (코드 ADR 위반 0건) + UPDATE_NEEDED 3건 → 본 PR 에 반영

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test` 242 pass
- [x] `pnpm build` 통과 (15 static pages)
- [x] legacy 토큰 grep 0 (Header + FamilySelector)
- [x] ADR-F23 grep 0 (text-white|text-black in Header)
- [ ] 수동 smoke: 데스크톱 FamilySelector + 모바일 Avatar dropdown → '가족 전환' → Sheet → 가족 선택 → refresh
- [ ] Dark mode 톤 자연스러움 확인

## Related

- task: `tasks/plan019-header-redesign/`
- planning PR: #259 (이미 머지)
- depends on: plan001 (Teal OKLCH), plan010 (FamilySelectorDropdown), plan017 (NotificationBell — 미머지 시에도 독립)

🤖 Generated with [Claude Code](https://claude.com/claude-code)