### PR TITLE
docs(plan021): /settings 페이지 Teal 리디자인 task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -456,6 +456,42 @@ AlertDialog:
 
 ---
 
+## 15. /settings 페이지 구조 (plan021)
+
+```
+[/settings (server)]
+    ├─ getUserProfileAction() → { defaultFamilyUuid, name, email }
+    └─ getFamiliesAction() → Family[]
+        │
+        └─ SettingsPageClient (use client)
+                │
+                ├─ SettingsHero (Teal gradient)
+                │   ├─ 사용자 이름 + email
+                │   ├─ 현재 기본 가족명
+                │   └─ 월 예산 / 이번 달 지출 요약 (Dashboard 톤)
+                │
+                ├─ [기본 가족 설정 카드] — radio 선택 + "현재 기본" 배지만
+                │   └─ Save → setDefaultFamilyAction
+                │
+                ├─ [가족별 예산 카드]
+                │   └─ 각 row "수정" 클릭 → BudgetEditDialog (responsive)
+                │           ├─ mobile: Sheet bottom
+                │           └─ md+:    Dialog centered
+                │       Amount input + 빠른 입력 칩 (+10만/+50만/+100만)
+                │       저장 → updateFamilyAction({ monthlyBudget })
+                │
+                └─ [내 가족 목록 카드] — 멤버/카테고리/지출 통계
+                        └─ "관리" → /families/{uuid}
+```
+
+핵심 변경:
+- `gradient-primary` (plan019 폐기 토큰) → `bg-brand-500` 단색
+- DollarSign → Wallet (한국 원화 페이지 일관성)
+- inline budget edit (Edit2/Save/X 3 버튼) → BudgetEditDialog (plan014 responsive 패턴 재사용)
+- 기본 가족 카드 ↔ 내 가족 목록 카드 정보 분리 (radio vs 통계)
+
+---
+
 ## 14. 대시보드 고정비 카드
 
 ```

--- a/tasks/plan021-settings-redesign/index.json
+++ b/tasks/plan021-settings-redesign/index.json
@@ -1,0 +1,53 @@
+{
+  "name": "plan021-settings-redesign",
+  "description": "/settings 페이지 Teal 리디자인. SettingsHero 신설 + legacy gradient-primary 제거 + DollarSign→Wallet + 가족별 예산 inline edit → BudgetEditDialog (responsive Sheet/Dialog, plan014 패턴 재사용). 카드 정보 중복 해소.",
+  "status": "pending",
+  "created_at": "2026-05-19",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan014-transaction-dialog-unification",
+    "plan019-header-redesign"
+  ],
+  "prerequisites": [
+    "plan001 머지 (brand-500 토큰) ✅",
+    "plan014 머지 (responsive Sheet/Dialog 패턴) ✅",
+    "plan019 머지 (gradient-primary 폐기 결정 ADR-F23 참조 가능) — plan020 머지 후"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "SettingsHero 신설 + legacy 토큰 제거 (gradient-primary, DollarSign)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "BudgetEditDialog 신설 + inline edit → Dialog 트리거 마이그레이션",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "카드 정보 분리 + 통합 검증 + 8단계 체크리스트 + status=completed",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "기존 데이터 (UserProfile + Family[]) 그대로 사용. 신규 backend API 불필요. SettingsHero / BudgetEditDialog 모두 기존 컴포넌트 패턴 재사용 (DashboardHero, plan014 responsive Dialog).",
+    "2_tech_stack": "변경 없음. shadcn Sheet/Dialog + sonner toast + Server Action 유지.",
+    "3_user_flow": "기본 가족 변경: 동일. 예산 편집: inline (Edit/Save/X 토글) → Dialog (수정 버튼 → Dialog 열림 → BudgetInput + 빠른 입력 칩 → 저장 → toast → router.refresh). UX 일관성 ↑, 모바일 터치 영역 ↑.",
+    "4_ui": "SettingsHero: 사용자 이름·email + 현재 기본 가족명 + 월 예산 / 이번 달 지출 요약 (Dashboard BudgetHeroCard 톤). gradient-primary 제거 (bg-brand-500). DollarSign → Wallet. 기본 가족 카드: radio + '현재 기본' 배지. 내 가족 목록 카드: 멤버/카테고리/지출 통계.",
+    "5_api": "변경 없음. setDefaultFamilyAction / updateFamilyAction 기존 유지. getDashboardStatsAction 은 SettingsHero 의 이번 달 지출 표시 시 호출 (선택적).",
+    "6_arch": "SettingsHero.tsx (src/components/settings/) + BudgetEditDialog.tsx (src/components/settings/) 신설. SettingsPageClient 가 두 컴포넌트 호출. page.tsx 는 SettingsHero 용 추가 데이터 (이번 달 지출) 페치 옵션 검토.",
+    "7_adr": "skip — 모두 기존 패턴 재사용. plan019 (gradient-primary 폐기) / plan014 (responsive Dialog) 따름.",
+    "8_docs": "flow.md §15 신규 (/settings 구조 + 핵심 변경 4 가지)."
+  }
+}

--- a/tasks/plan021-settings-redesign/phase-01.md
+++ b/tasks/plan021-settings-redesign/phase-01.md
@@ -1,0 +1,222 @@
+# Phase 01 — SettingsHero 신설 + legacy 토큰 제거
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `SettingsHero` 컴포넌트를 신설해 `/settings` 상단에 Teal gradient hero 카드 (사용자 이름·email + 현재 기본 가족명 + 월 예산 요약) 표시. `SettingsPageClient.tsx` 의 `gradient-primary` (plan019 폐기) → `bg-brand-500` 단색 교체. DollarSign 아이콘 → Wallet 교체.
+
+## Context (자기완결)
+
+- 현재 `src/app/(authenticated)/settings/page.tsx` (28 줄): `getUserProfileAction` + `getFamiliesAction` 만 페치. SettingsPageClient 에 직접 전달.
+- 현재 `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` (305 줄):
+  - L13 `DollarSign` import — 한국 원화 페이지에 부적합
+  - L108-114: 단순 h1 + p 헤더 ("설정 / 가족 · 예산 · 알림 관리")
+  - L180: `gradient-primary` — plan019 (Header) 에서 폐기. brand-500 단색으로 대체 결정
+  - L189: `<SettingsCard icon={DollarSign} title="가족별 예산 설정" ...>` — Wallet 으로 변경
+- 대시보드 hero 참고: `src/components/dashboard/BudgetHeroCard.tsx` 의 gradient + 흰 텍스트 패턴
+
+## 작업 항목
+
+### 1. `src/components/settings/SettingsHero.tsx` 신설
+
+```tsx
+import { Card } from "@/components/ui/card";
+import type { Family } from "@/types/family";
+import { Users, Wallet } from "lucide-react";
+
+interface SettingsHeroProps {
+  userName: string | null;
+  userEmail: string | null;
+  defaultFamily: Family | null;
+}
+
+export function SettingsHero({ userName, userEmail, defaultFamily }: SettingsHeroProps) {
+  return (
+    <Card className="overflow-hidden border-0 gradient-budget text-white">
+      <div className="p-5 md:p-6">
+        <p className="text-xs md:text-sm text-white/80 mb-1">설정</p>
+        <h1 className="text-xl md:text-2xl font-bold mb-3">
+          {userName ?? "사용자"}
+          <span className="block text-sm md:text-base font-normal text-white/80 mt-0.5">
+            {userEmail ?? ""}
+          </span>
+        </h1>
+
+        {defaultFamily ? (
+          <div className="mt-4 flex flex-wrap items-center gap-3 md:gap-5 text-sm md:text-base">
+            <div className="flex items-center gap-2">
+              <Users className="w-4 h-4 text-white/80" />
+              <span className="font-medium">{defaultFamily.name}</span>
+              <span className="text-xs text-white/70">기본 가족</span>
+            </div>
+            {defaultFamily.monthlyBudget > 0 ? (
+              <div className="flex items-center gap-2">
+                <Wallet className="w-4 h-4 text-white/80" />
+                <span className="font-num font-medium tabular-nums">
+                  ₩{defaultFamily.monthlyBudget.toLocaleString()}
+                </span>
+                <span className="text-xs text-white/70">월 예산</span>
+              </div>
+            ) : (
+              <span className="text-xs text-white/70">월 예산 미설정</span>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-white/80 mt-3">기본 가족이 설정되지 않았습니다.</p>
+        )}
+      </div>
+    </Card>
+  );
+}
+```
+
+`gradient-budget` 시맨틱 클래스 사용 (plan001). Dashboard `BudgetHeroCard` 와 톤 일관.
+
+### 2. `SettingsPageClient.tsx` 갱신
+
+변경 1 — import 정리:
+```tsx
+import { Check, Edit2, Save, Users, Wallet, X } from "lucide-react";
+// DollarSign 제거, Wallet 추가
+import { SettingsHero } from "@/components/settings/SettingsHero";
+```
+
+변경 2 — 컴포넌트 시그니처에 user/profile 추가:
+```tsx
+interface SettingsPageClientProps {
+  families: Family[];
+  defaultFamilyUuid: string | null;
+  userName: string | null;
+  userEmail: string | null;
+}
+```
+
+변경 3 — 헤더 영역 (L108-114) 교체:
+```tsx
+// 변경 전
+<div>
+  <h1 className="text-2xl md:text-3xl font-bold text-fg mb-2">설정</h1>
+  <p className="text-sm md:text-base text-fg-muted">
+    가족 · 예산 · 알림 관리
+  </p>
+</div>
+
+// 변경 후
+<SettingsHero
+  userName={userName}
+  userEmail={userEmail}
+  defaultFamily={
+    families.find((f) => f.uuid === currentDefaultFamily) ?? null
+  }
+/>
+```
+
+변경 4 — gradient-primary 제거 (L180):
+```tsx
+// 변경 전
+<Button
+  onClick={handleSaveDefaultFamily}
+  disabled={...}
+  className="gradient-primary hover:opacity-90 text-white"
+>
+
+// 변경 후
+<Button
+  onClick={handleSaveDefaultFamily}
+  disabled={...}
+  className="bg-brand-500 hover:bg-brand-600 text-white"
+>
+```
+
+변경 5 — DollarSign → Wallet (L189):
+```tsx
+<SettingsCard
+  icon={Wallet}   // DollarSign → Wallet
+  title="가족별 예산 설정"
+  ...
+>
+```
+
+### 3. `page.tsx` 갱신 — userName / userEmail 전달
+
+```tsx
+import { getServerSession } from "@/lib/server/auth-helpers"; // 또는 기존 세션 helper
+
+export default async function SettingsPage() {
+  const profile = await requireActionSuccess(await getUserProfileAction(), {
+    fallbackErrorType: "profile",
+  });
+
+  const families = await requireActionSuccess(await getFamiliesAction(), {
+    fallbackRedirect: "/families/create",
+  });
+
+  // 세션에서 user.name / user.email 가져오기 — 기존 페이지 패턴 참고
+  // (Header.tsx 의 session prop 패턴 또는 auth() 직접 호출)
+  const session = await auth();
+
+  return (
+    <SettingsPageClient
+      families={families}
+      defaultFamilyUuid={profile.defaultFamilyUuid}
+      userName={session?.user?.name ?? null}
+      userEmail={session?.user?.email ?? null}
+    />
+  );
+}
+```
+
+`auth()` 호출은 `@/lib/server/auth` 또는 NextAuth v5 표준 패턴 (`Header.tsx` 호출처 확인). 페이지 자체가 이미 `dynamic = "force-dynamic"` 이라 세션 페치 추가 비용 없음.
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan021-settings-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# legacy 토큰 0
+! grep -nE 'gradient-primary|DollarSign' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx
+
+# SettingsHero 사용
+grep -n 'SettingsHero' src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | head -2
+
+# SettingsHero 파일 존재
+test -f src/components/settings/SettingsHero.tsx
+
+# 신 토큰 사용 (SettingsHero)
+grep -nE 'gradient-budget|text-white|font-num' src/components/settings/SettingsHero.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+- /settings 접속 → 상단 Teal gradient hero 카드 (사용자명 + email + 기본 가족명 + 월 예산)
+- 기본 가족 없는 사용자 → "기본 가족이 설정되지 않았습니다" 안내
+- 월 예산 0 → "월 예산 미설정"
+- 모바일 (< 768px) → 폰트/padding 줄어들지만 정보 유지
+- Dark mode → gradient-budget 어두운 톤 자연
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/settings/SettingsHero.tsx` | 신규 |
+| `src/app/(authenticated)/settings/page.tsx` | session 페치 + userName/userEmail prop |
+| `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` | SettingsHero 렌더 + gradient-primary 제거 + DollarSign → Wallet |
+
+## Out of Scope
+
+- BudgetEditDialog 신설 — phase-02
+- 카드 정보 분리 (기본 가족 ↔ 내 가족 목록) — phase-03
+- 알림 설정 / 테마 토글 — 별도 plan
+- SettingsHero 안에 이번 달 지출 / 진행률 표시 — 추가 데이터 페치 비용. 추후 검토
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `auth()` import 경로가 페이지마다 다름 | Header.tsx 또는 dashboard/page.tsx 의 import 패턴 따름. 발견 못 하면 기존 페치된 profile 에 name/email 추가 (UserProfile 타입에 포함되면 page.tsx 에서 profile.name / profile.email 사용) |
+| `gradient-budget` 클래스가 globals.css 에 없음 | grep 으로 확인. 없으면 `gradient-primary` 대체 클래스 사용 (단 brand-500/700 단색 fallback) |
+| Family 타입에 `monthlyBudget` 필드 없음 | `@/types/family` 확인. 기존 코드에서 `family.monthlyBudget > 0` 이미 사용 (L225) → 존재 보장 |

--- a/tasks/plan021-settings-redesign/phase-02.md
+++ b/tasks/plan021-settings-redesign/phase-02.md
@@ -1,0 +1,302 @@
+# Phase 02 — BudgetEditDialog 신설 + inline edit → Dialog 트리거 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `BudgetEditDialog.tsx` 신설 (responsive Sheet bottom on mobile / Dialog center on md+, plan014 패턴 재사용). `SettingsPageClient.tsx` 의 가족별 예산 inline edit (Edit2/Save/X 3 버튼 토글) 을 Dialog 트리거로 마이그레이션. 빠른 입력 칩 (+10만 / +50만 / +100만) 포함.
+
+## Context (자기완결)
+
+- 현재 inline edit (L188-266): `editingBudget` state + `budgetValues` Record + Input + Save/X 버튼 3 토글. 모바일 좁음
+- plan014 `AddTransactionDialog` 패턴: `useMediaQuery("(min-width: 768px)")` → Dialog vs Sheet 선택. `src/components/transactions/dialogs/AddTransactionDialog.tsx` 참고
+- 빠른 입력 칩 패턴: plan014 `AmountInput` 의 +1k/+5k/+10k 패턴 — 본 plan 은 +10만/+50만/+100만 (예산 규모)
+- 기존 Server Action: `updateFamilyAction(familyUuid, { name, monthlyBudget })` — 변경 없음
+
+## 작업 항목
+
+### 1. `src/components/settings/BudgetEditDialog.tsx` 신설
+
+```tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { updateFamilyAction } from "@/actions/family/update-family-action";
+import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+
+interface BudgetEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  familyUuid: string;
+  familyName: string;
+  currentBudget: number;
+}
+
+const QUICK_AMOUNTS = [
+  { label: "+10만", value: 100_000 },
+  { label: "+50만", value: 500_000 },
+  { label: "+100만", value: 1_000_000 },
+];
+
+export function BudgetEditDialog({
+  open,
+  onOpenChange,
+  familyUuid,
+  familyName,
+  currentBudget,
+}: BudgetEditDialogProps) {
+  const router = useRouter();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [value, setValue] = useState(currentBudget.toString());
+  const [isSaving, setIsSaving] = useState(false);
+
+  // open 될 때마다 currentBudget 으로 리셋
+  useEffect(() => {
+    if (open) {
+      setValue(currentBudget.toString());
+    }
+  }, [open, currentBudget]);
+
+  const handleQuickAdd = (delta: number) => {
+    const cur = parseFloat(value) || 0;
+    setValue(String(cur + delta));
+  };
+
+  const handleSave = async () => {
+    const budget = parseFloat(value);
+    if (isNaN(budget) || budget < 0) {
+      toast.error("올바른 예산 금액을 입력해주세요");
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const result = await updateFamilyAction(familyUuid, {
+        name: familyName,
+        monthlyBudget: budget,
+      });
+      if (result.success) {
+        toast.success("월 예산이 설정되었습니다");
+        onOpenChange(false);
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    } catch {
+      toast.error("예산 설정에 실패했습니다");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const body = (
+    <div className="space-y-4 pt-2">
+      <div>
+        <p className="text-sm text-fg-muted">가족</p>
+        <p className="text-base font-semibold text-fg">{familyName}</p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-fg mb-2">월 예산 (원)</label>
+        <Input
+          type="number"
+          min="0"
+          step="10000"
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="font-num tabular-nums text-lg"
+          autoFocus
+        />
+        <div className="flex flex-wrap gap-2 mt-3">
+          {QUICK_AMOUNTS.map((q) => (
+            <button
+              key={q.value}
+              type="button"
+              onClick={() => handleQuickAdd(q.value)}
+              className="px-3 py-1.5 rounded-full bg-bg-muted text-fg text-xs font-medium hover:bg-brand-50 hover:text-brand-700 transition-colors"
+            >
+              {q.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setValue("0")}
+            className="px-3 py-1.5 rounded-full bg-bg-muted text-fg-muted text-xs font-medium hover:bg-bg-muted transition-colors"
+          >
+            초기화
+          </button>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          취소
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={isSaving}
+          className="bg-brand-500 hover:bg-brand-600 text-white"
+        >
+          {isSaving ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>월 예산 수정</DialogTitle>
+          </DialogHeader>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-auto">
+        <SheetHeader>
+          <SheetTitle>월 예산 수정</SheetTitle>
+        </SheetHeader>
+        {body}
+      </SheetContent>
+    </Sheet>
+  );
+}
+```
+
+`useMediaQuery` 훅 경로는 기존 plan014 사용처 (`src/hooks/use-media-query.ts` 또는 `@/hooks/use-media-query`) 따름. 없으면 `AddTransactionDialog.tsx` 의 import 확인 후 동일 경로.
+
+### 2. `SettingsPageClient.tsx` — inline edit 제거 + Dialog 트리거
+
+변경 1 — state 정리 (L34-35):
+```tsx
+// 변경 전
+const [editingBudget, setEditingBudget] = useState<string | null>(null);
+const [budgetValues, setBudgetValues] = useState<Record<string, string>>({});
+
+// 변경 후
+const [budgetDialogFamily, setBudgetDialogFamily] = useState<Family | null>(null);
+```
+
+변경 2 — handleEditBudget / handleCancelBudget / handleSaveBudget 함수 제거 (L63-104) — Dialog 내부로 이전
+
+변경 3 — 가족별 예산 카드 본문 (L188-266) 단순화:
+```tsx
+<SettingsCard
+  icon={Wallet}
+  title="가족별 예산 설정"
+  subtitle="이번 달 목표 예산을 입력하세요"
+>
+  <div className="flex flex-col">
+    {families.map((family, i) => (
+      <div
+        key={family.uuid}
+        className={cn(
+          "flex items-center justify-between px-5 py-3",
+          i > 0 && "border-t border-border"
+        )}
+      >
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium text-fg text-sm truncate">{family.name}</h3>
+          <p className="text-xs text-fg-muted mt-0.5 font-num tabular-nums">
+            {family.monthlyBudget > 0
+              ? `월 예산: ₩${family.monthlyBudget.toLocaleString()}`
+              : "예산 미설정"}
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setBudgetDialogFamily(family)}
+        >
+          <Edit2 className="w-4 h-4 mr-1" />
+          수정
+        </Button>
+      </div>
+    ))}
+  </div>
+</SettingsCard>
+```
+
+변경 4 — Dialog 마운트 (컴포넌트 본문 끝):
+```tsx
+{budgetDialogFamily && (
+  <BudgetEditDialog
+    open={!!budgetDialogFamily}
+    onOpenChange={(open) => !open && setBudgetDialogFamily(null)}
+    familyUuid={budgetDialogFamily.uuid}
+    familyName={budgetDialogFamily.name}
+    currentBudget={budgetDialogFamily.monthlyBudget}
+  />
+)}
+```
+
+변경 5 — import 정리:
+- `Input` / `Save` / `X` 제거 (가족별 예산 카드에서만 사용했으면)
+- `BudgetEditDialog` 추가
+- `Family` 타입 import 유지
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan021-settings-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# BudgetEditDialog 파일 존재
+test -f src/components/settings/BudgetEditDialog.tsx
+
+# inline edit state 제거
+! grep -n 'editingBudget\|budgetValues' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx
+
+# Dialog 트리거
+grep -n 'setBudgetDialogFamily\|BudgetEditDialog' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 2
+
+# 빠른 입력 칩
+grep -nE '\+10만|\+50만|\+100만' src/components/settings/BudgetEditDialog.tsx | wc -l   # >= 3
+```
+
+수동 smoke:
+- 모바일 (< 768px) → "수정" 탭 → Sheet bottom 슬라이드 업 → 입력 + 빠른 입력 칩 → 저장 → toast + Sheet 닫힘
+- 데스크톱 (>= 768px) → Dialog center → 동일 동작
+- 빠른 입력 칩 (+10만) → 입력값 100,000 추가
+- 초기화 칩 → 0 으로
+- 빈 값 / 음수 / NaN → "올바른 예산 금액" toast
+- 저장 실패 (네트워크 차단) → error toast + Dialog 유지
+- 다음 가족 row 수정 클릭 → 직전 Dialog 닫힘 + 새 Dialog 열림 (currentBudget 새 값으로 reset)
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/settings/BudgetEditDialog.tsx` | 신규 (responsive Sheet/Dialog) |
+| `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` | inline edit 제거 + Dialog 트리거 |
+
+## Out of Scope
+
+- 다른 inline edit UI (가족 이름 등) — 본 plan 범위 아님
+- 예산 히스토리 / 변경 로그 — 별도 plan
+- 다중 화폐 지원 — 한국 원화만
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `useMediaQuery` 훅 경로 / signature 가 plan014 와 다름 | plan014 의 `AddTransactionDialog.tsx` import 확인 후 동일 경로 사용. 없으면 hooks 디렉터리 통째로 grep |
+| Dialog `open` 토글 시 동일 컴포넌트 mount → currentBudget reset 안 됨 | useEffect 로 open 변화 시 setValue(currentBudget) 명시 (위 코드 반영됨) |
+| Sheet bottom 가 모바일 키보드와 겹침 | iOS Safari 키보드 위로 Sheet 본문 자동 push — shadcn Sheet 기본 동작. 미작동 시 `h-auto` → `max-h-[80vh] overflow-y-auto` 폴백 |
+| 빠른 입력 칩 누적 시 매우 큰 수 발생 | input type=number max 옵션 없이 자유 입력. updateFamilyAction 의 backend 검증에 위임 (현재 검증 범위는 Family 도메인 결정) |

--- a/tasks/plan021-settings-redesign/phase-02.md
+++ b/tasks/plan021-settings-redesign/phase-02.md
@@ -9,9 +9,52 @@
 - 현재 inline edit (L188-266): `editingBudget` state + `budgetValues` Record + Input + Save/X 버튼 3 토글. 모바일 좁음
 - plan014 `AddTransactionDialog` 패턴: `useMediaQuery("(min-width: 768px)")` → Dialog vs Sheet 선택. `src/components/transactions/dialogs/AddTransactionDialog.tsx` 참고
 - 빠른 입력 칩 패턴: plan014 `AmountInput` 의 +1k/+5k/+10k 패턴 — 본 plan 은 +10만/+50만/+100만 (예산 규모)
-- 기존 Server Action: `updateFamilyAction(familyUuid, { name, monthlyBudget })` — 변경 없음
+- 기존 Server Action: `updateFamilyAction(familyUuid, { name, monthlyBudget })` — 권한 검증 강화 필요 (아래 0번)
 
 ## 작업 항목
+
+### 0. `updateFamilyAction` 권한 검증 강화 (사전 보강)
+
+**배경**: 현재 `updateFamilyAction(familyUuid, data)` 은 `requireAuth()` 만 수행 → 클라이언트가 본인이 속하지 않은 다른 가족의 UUID 를 주입하면 그 가족 정보 수정 가능 (권한 상승). CLAUDE.md "금지사항" 의 권한 식별자 정책 위반. BudgetEditDialog 가 familyUuid 를 prop 으로 받아 호출하는 구조라 backend-trust 강화가 선행되어야 안전.
+
+`src/services/family/family-service.ts` 의 `selectFamily` 패턴 (`getFamilies() + includes`) 을 재사용:
+
+```ts
+// src/actions/family/update-family-action.ts
+import { getFamilies } from "@/services/family/family-service";
+
+export async function updateFamilyAction(
+  familyUuid: string,
+  data: UpdateFamilyRequest
+): Promise<ActionResult<Family>> {
+  try {
+    await requireAuth();
+
+    if (!familyUuid) {
+      throw ActionError.invalidInput("가족 UUID", familyUuid, "UUID는 필수입니다");
+    }
+
+    // 권한 검증: 사용자가 해당 family 멤버인지 확인 (백엔드가 세션 token 기준으로 본인 가족만 반환)
+    const families = await getFamilies();
+    if (!families.some((f) => f.uuid === familyUuid)) {
+      throw ActionError.entityNotFound("가족", familyUuid);
+    }
+
+    const family = await updateFamily(familyUuid, data);
+    revalidatePath("/");
+    revalidatePath("/settings");
+    revalidatePath(`/families/${familyUuid}`);
+    return successResult(family);
+  } catch (error) {
+    return handleActionError(error, "가족 정보 수정에 실패했습니다");
+  }
+}
+```
+
+자동 verification (`src/actions/family/update-family-action.ts`):
+```bash
+grep -n 'getFamilies\|entityNotFound' src/actions/family/update-family-action.ts | wc -l   # >= 2
+```
 
 ### 1. `src/components/settings/BudgetEditDialog.tsx` 신설
 
@@ -283,6 +326,7 @@ grep -nE '\+10만|\+50만|\+100만' src/components/settings/BudgetEditDialog.tsx
 
 | 파일 | 상태 |
 |---|---|
+| `src/actions/family/update-family-action.ts` | 권한 검증 강화 (getFamilies + includes) |
 | `src/components/settings/BudgetEditDialog.tsx` | 신규 (responsive Sheet/Dialog) |
 | `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` | inline edit 제거 + Dialog 트리거 |
 

--- a/tasks/plan021-settings-redesign/phase-03.md
+++ b/tasks/plan021-settings-redesign/phase-03.md
@@ -1,0 +1,115 @@
+# Phase 03 — 카드 정보 분리 + 통합 검증 + status="completed"
+
+**Model**: haiku
+**Status**: pending
+**Goal**: "기본 가족 설정" 카드와 "내 가족 목록" 카드의 정보 중복 해소. 통합 검증 후 `index.json` 의 `status` 를 `"completed"` 로 마킹.
+
+## Context (자기완결)
+
+현재 양 카드 모두 "구성원 N명 · 지출 N건" 동일 정보를 표시 (L161-164, L286-289).
+
+**역할 분리**:
+- **기본 가족 설정 카드**: radio + 가족명 + "현재 기본" 배지만 (선택 UX 집중)
+- **내 가족 목록 카드**: 멤버수 / 카테고리수 / 지출수 / "관리" 진입 (통계 + 관리 진입 집중)
+
+## 작업 항목
+
+### 1. 기본 가족 설정 카드 (L116-186) — 통계 정보 제거
+
+```tsx
+// 변경 전 L161-164
+<span className="text-xs text-fg-muted mt-0.5">
+  구성원 {family.members?.length || 0}명 · 지출{" "}
+  {family.expenseCount || 0}건
+</span>
+
+// 변경 후 — 통계 제거, 월 예산만 보조 표시
+<span className="text-xs text-fg-muted mt-0.5 font-num tabular-nums">
+  {family.monthlyBudget > 0
+    ? `월 예산 ₩${family.monthlyBudget.toLocaleString()}`
+    : "월 예산 미설정"}
+</span>
+```
+
+선택 시점에서 사용자가 알고 싶은 것은 "어느 가족이 기본인지" 와 "그 가족의 예산은 얼마인지". 멤버/지출 통계는 "내 가족 목록" 에서 표시.
+
+### 2. 내 가족 목록 카드 (L269-301) — 변경 없음 (이미 통계 표시)
+
+기존 표시 유지: `구성원 N명 · 카테고리 N개 · 지출 N건`.
+
+### 3. 통합 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan021-settings-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test:ci
+
+# legacy 토큰 0 (전체)
+! grep -nE 'gradient-primary|DollarSign' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx \
+  src/components/settings/
+
+# 신규 컴포넌트 존재
+test -f src/components/settings/SettingsHero.tsx
+test -f src/components/settings/BudgetEditDialog.tsx
+
+# inline edit 잔재 0
+! grep -n 'editingBudget\|budgetValues' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx
+
+# 정보 중복 해소: 기본 가족 카드의 "구성원 N명 · 지출 N건" 제거
+! grep -n '구성원.*명 · 지출' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | \
+  head -1 || echo "OK: 중복 제거됨 또는 1곳만 (내 가족 목록 카드)"
+
+# 내 가족 목록 카드는 카테고리 통계 유지
+grep -n '카테고리.*개' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 1
+```
+
+### 4. 수동 smoke (구현자 책임)
+
+- 기본 가족 설정 카드: 가족명 + 월 예산 (구성원/지출 통계 미표시)
+- 내 가족 목록 카드: 구성원 / 카테고리 / 지출 통계 유지
+- 정보 중복 해소 (한 화면 안에 "구성원 N명" 이 한 곳에만 표시)
+- 모바일 / 데스크톱 모두 자연
+- Dark mode 자연 전환
+
+### 5. 8단계 체크리스트 자체 점검
+
+| 단계 | 확인 |
+|---|---|
+| 1 구현가능성 | 기존 데이터 그대로 사용 ✅ |
+| 2 기술스택 | 변경 없음 ✅ |
+| 3 사용자흐름 | 예산 편집 inline → Dialog, 정보 중복 해소 ✅ |
+| 4 UI | Hero + 토큰 정리 + Dialog UX + 카드 역할 분리 ✅ |
+| 5 API | 변경 없음 ✅ |
+| 6 아키텍처 | SettingsHero / BudgetEditDialog 신규 + Client 정리 ✅ |
+| 7 ADR | skip (기존 패턴 재사용) ✅ |
+| 8 docs | flow.md §15 신규 ✅ |
+
+### 6. `index.json` status 마킹 + commit
+
+```bash
+# index.json 의 "status": "pending" → "completed" 변경 (Edit tool)
+
+git add tasks/plan021-settings-redesign/index.json
+git commit -m "chore(plan021): mark task completed"
+git push
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/settings/_components/SettingsPageClient.tsx` | 기본 가족 카드 정보 변경 |
+| `tasks/plan021-settings-redesign/index.json` | status=completed |
+
+## Out of Scope
+
+- 다른 plan task 의 상태 변경
+- 새 ADR 추가


### PR DESCRIPTION
## Summary

/settings 페이지 Teal 시스템 정착 + UX 개선 plan 의 docs + task 파일.

### 핵심 결정

- SettingsHero 신설 (Teal gradient + 사용자명·email + 현재 기본 가족 + 월 예산 요약) — Dashboard 톤 일관
- legacy 토큰 제거: \`gradient-primary\` → \`bg-brand-500\`, DollarSign → Wallet
- 가족별 예산 inline edit (Edit2/Save/X 3 버튼 토글) → BudgetEditDialog (responsive Sheet bottom on mobile / Dialog center on md+, plan014 패턴 재사용) + 빠른 입력 칩 (+10만/+50만/+100만)
- 기본 가족 카드 ↔ 내 가족 목록 카드 정보 분리 — radio 선택 카드는 가족명 + 월 예산, 목록 카드는 멤버/카테고리/지출 통계
- 알림 설정 / 테마 토글은 본 plan 제외 (별도)

### docs 변경

- \`docs/flow.md\` — §15 신규 (/settings 구조)

### task 파일

- \`tasks/plan021-settings-redesign/index.json\`
- phase-01: SettingsHero 신설 + legacy 토큰 제거
- phase-02: BudgetEditDialog 신설 + inline edit 마이그레이션
- phase-03: 카드 정보 분리 + 통합 검증 + status=completed

## Test plan

구현 PR 검증 항목:

- [ ] \`pnpm lint\` / \`pnpm tsc --noEmit\` / \`pnpm build\` / \`pnpm test:ci\` 통과
- [ ] SettingsPageClient.tsx 에 \`gradient-primary\` / \`DollarSign\` 잔재 0
- [ ] SettingsHero / BudgetEditDialog 두 파일 존재
- [ ] inline edit state (\`editingBudget\`, \`budgetValues\`) 제거
- [ ] 모바일 (< 768px) → 수정 → Sheet bottom / 데스크톱 → Dialog center 표시
- [ ] 빠른 입력 칩 3 종 (+10만/+50만/+100만) + 초기화 정상 동작
- [ ] 기본 가족 카드: 가족명 + 월 예산만 (구성원/지출 통계 미표시)
- [ ] 내 가족 목록 카드: 구성원/카테고리/지출 통계 유지
- [ ] Dark mode 자연 전환