### PR TITLE
feat(toast/dialog): Toast + AlertDialog Teal 토큰 통일 (plan020)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -413,8 +413,8 @@
   - `text-white` 유지: ADR-F13 의 "globals.css `@theme` 외부에서 hex/rgb/hsl/named 색 금지" 원칙 위반. 디자인 토큰 단일 소스 깨짐.
   - `text-bg` (surface foreground): light/dark 가 반전되는 토큰이라 강조 배경 위 가독성 일관성 깨짐 (dark mode 에서 어두운 색 → expense 빨강 위 contrast 약화).
   - 인라인 `style={{ color: "white" }}`: ADR-F13 위반 + CLAUDE.md "인라인 style 최소화" 위반.
-- **트레이드오프**: 토큰 수 증가 (현재 expense-fg + brand-fg 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
-- **적용 범위**: `src/app/globals.css` (`--color-expense-fg`, `--color-brand-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`) + `src/components/layout/Header.tsx` (`text-brand-fg` — 로고 아이콘 + AvatarFallback). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
+- **트레이드오프**: 토큰 수 증가 (현재 brand-fg / expense-fg 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
+- **적용 범위**: `src/app/globals.css` (`--color-brand-fg` / `--color-expense-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`) + `src/components/layout/Header.tsx` (`text-brand-fg` — 로고 아이콘 + AvatarFallback) + `src/app/providers.tsx` (`text-brand-fg` — sonner actionButton). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
 
 ---
 

--- a/src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx
+++ b/src/app/(authenticated)/categories/_components/DeleteCategoryDialog.tsx
@@ -10,6 +10,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/client/utils";
 
 interface DeleteCategoryDialogProps {
   open: boolean;
@@ -42,7 +44,7 @@ export function DeleteCategoryDialog({
           <AlertDialogAction
             onClick={onConfirm}
             disabled={isDeleting}
-            className="bg-red-500 hover:bg-red-600"
+            className={cn(buttonVariants({ variant: "destructive" }))}
           >
             {isDeleting ? "삭제 중..." : "삭제"}
           </AlertDialogAction>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -12,13 +12,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
         <Toaster
           position="top-center"
           expand={true}
-          richColors
           closeButton
           toastOptions={{
             classNames: {
-              toast: "bg-popover border border-border shadow-lg",
-              title: "text-popover-foreground font-medium",
-              description: "text-muted-foreground",
+              toast: "bg-bg-elev border border-border shadow-lg text-fg",
+              title: "text-fg font-medium",
+              description: "text-fg-muted",
+              actionButton: "bg-brand-500 text-white",
+              cancelButton: "bg-bg-muted text-fg-muted",
             },
             style: {
               zIndex: 100,

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -18,7 +18,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
               toast: "bg-bg-elev border border-border shadow-lg text-fg",
               title: "text-fg font-medium",
               description: "text-fg-muted",
-              actionButton: "bg-brand-500 text-primary-foreground",
+              actionButton: "bg-brand-500 text-brand-fg",
               cancelButton: "bg-bg-muted text-fg-muted",
             },
             style: {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -18,7 +18,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
               toast: "bg-bg-elev border border-border shadow-lg text-fg",
               title: "text-fg font-medium",
               description: "text-fg-muted",
-              actionButton: "bg-brand-500 text-white",
+              actionButton: "bg-brand-500 text-primary-foreground",
               cancelButton: "bg-bg-muted text-fg-muted",
             },
             style: {

--- a/src/components/expenses/dialogs/DeleteExpenseDialog.tsx
+++ b/src/components/expenses/dialogs/DeleteExpenseDialog.tsx
@@ -15,6 +15,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/client/utils";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -82,7 +84,7 @@ export function DeleteExpenseDialog({
           <AlertDialogAction
             onClick={handleDelete}
             disabled={isDeleting}
-            className="bg-red-600 hover:bg-red-700"
+            className={cn(buttonVariants({ variant: "destructive" }))}
           >
             {isDeleting ? "삭제 중..." : "삭제"}
           </AlertDialogAction>

--- a/src/components/incomes/list/IncomeItem.tsx
+++ b/src/components/incomes/list/IncomeItem.tsx
@@ -8,7 +8,8 @@ import { useState } from "react";
 import { EditTransactionDialog } from "@/components/transactions/dialogs/EditTransactionDialog";
 import { deleteIncomeAction } from "@/actions/income/delete-income-action";
 import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/client/utils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -207,7 +208,7 @@ export function IncomeItem({
                 if (success) setIsDeleteDialogOpen(false);
               }}
               disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              className={cn(buttonVariants({ variant: "destructive" }))}
             >
               {isDeleting ? "삭제 중..." : "삭제"}
             </AlertDialogAction>

--- a/src/components/recurring-expense/RecurringExpenseItem.tsx
+++ b/src/components/recurring-expense/RecurringExpenseItem.tsx
@@ -10,7 +10,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/client/utils";
 import { deleteRecurringExpenseAction } from "@/actions/recurring-expense";
 import type { RecurringExpense } from "@/types/recurring-expense";
 import { CheckCircle, Circle, Pencil, Trash2 } from "lucide-react";
@@ -183,7 +184,7 @@ export function RecurringExpenseItem({
             <AlertDialogAction
               onClick={handleDelete}
               disabled={isDeleting}
-              className="bg-destructive hover:bg-destructive/90"
+              className={cn(buttonVariants({ variant: "destructive" }))}
             >
               {isDeleting ? "종료 중..." : "종료"}
             </AlertDialogAction>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -18,7 +18,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-fg/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-bg-elev p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -91,7 +91,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-fg-muted", className)}
     {...props}
   />
 ));

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -12,9 +12,21 @@ const Toaster = ({ ...props }: ToasterProps) => {
       className="toaster group"
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
+          "--normal-bg": "var(--color-bg-elev)",
+          "--normal-text": "var(--color-fg)",
+          "--normal-border": "var(--color-border)",
+          "--success-bg": "var(--color-bg-elev)",
+          "--success-text": "var(--color-fg)",
+          "--success-border": "var(--color-brand-500)",
+          "--error-bg": "var(--color-bg-elev)",
+          "--error-text": "var(--color-fg)",
+          "--error-border": "var(--color-expense)",
+          "--warning-bg": "var(--color-bg-elev)",
+          "--warning-text": "var(--color-fg)",
+          "--warning-border": "var(--color-warning)",
+          "--info-bg": "var(--color-bg-elev)",
+          "--info-text": "var(--color-fg)",
+          "--info-border": "var(--color-brand-400)",
         } as React.CSSProperties
       }
       {...props}

--- a/tasks/plan020-toast-alertdialog-polish/index.json
+++ b/tasks/plan020-toast-alertdialog-polish/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan020-toast-alertdialog-polish",
   "description": "sonner Toaster + Radix AlertDialog 의 색 토큰을 plan001 OKLCH 시스템 (ADR-F24) 으로 통일. richColors OFF + brand/expense/warning 직접 매핑. AlertDialog overlay=bg-fg/60, content=bg-bg-elev. 파괴적 호출처 4 곳에 destructive variant 명시.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-19",
   "total_phases": 3,
   "related_docs": [
@@ -21,21 +21,21 @@
       "file": "phase-01.md",
       "title": "sonner Toaster richColors OFF + 타입별 토큰 매핑 + providers.tsx classNames 갱신",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "AlertDialog overlay/content/description 토큰 갱신 + 파괴적 호출처 4 곳 destructive variant 명시",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "통합 검증 + 8단계 체크리스트 + index.json status=completed 마킹 commit",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "planning_checklist": {


### PR DESCRIPTION
## Summary

- sonner Toaster `richColors` OFF + 타입별 CSS 변수 (`--success-border` 등) 를 OKLCH brand/expense/warning 토큰에 직접 매핑
- AlertDialog overlay `bg-black/80` → `bg-fg/60`, content `bg-white` → `bg-bg-elev border-border`, description `text-fg-muted`
- 파괴적 호출처 4곳 (`DeleteExpense` / `DeleteIncome` / `DeleteRecurringExpense` / `DeleteCategory`) 의 `AlertDialogAction` 에 `cn(buttonVariants({ variant: "destructive" }))` 명시 — `--destructive=expense` 매핑 활용
- `--color-brand-fg` 토큰 신설 (모드 독립적 near-white, expense-fg 와 동일 패턴) — ADR-F23 위반 해소

## ADR

- **ADR-F24** (신설) — sonner `richColors` OFF + 토큰 직접 매핑 결정 근거: Teal h=188 vs sonner 자동 green/red/amber 충돌, income h=152 vs success green 시맨틱 혼동 회피
- **ADR-F23** (갱신) — 시맨틱 foreground 토큰 목록에 `brand-fg` 추가

## Phase 진행

- phase-01 (430e559) — sonner Toaster 토큰 마이그레이션
- phase-02 (8dc701f) — AlertDialog 토큰 + destructive variant 호출처 4곳
- phase-03 (eeaeae7) — index.json status=completed
- ADR-F23 fix (c25bdd4 → d13e3c7) — text-white → text-brand-fg

## Build / Verification

- pnpm lint: 0 errors, 1 pre-existing warning (coverage 자동 생성 파일)
- pnpm tsc --noEmit: 0 errors
- pnpm test:ci: 242 passed / 33 suites
- pnpm build: ✓ Compiled successfully

## Review 통과 이력

- critic: APPROVE (계획 + 실제 코드 일치 + 누락 없음)
- code-reviewer: PASS (LOW 1건 = ADR-F23 위반, fix 완료)
- docs-verifier: VIOLATION → VIOLATION (재) → PASS (brand-fg 토큰 신설로 해소)

## Test plan

- [ ] 카테고리 생성 → success toast 좌측 Teal border
- [ ] 카테고리 중복 → error toast 좌측 expense red border
- [ ] 카테고리 삭제 confirm → overlay 어두운 톤 + "삭제" 버튼 expense red
- [ ] 지출/수입/반복지출 삭제 confirm 모두 동일 패턴
- [ ] Dark mode 토글 → toast / dialog 모두 자연 전환