### PR TITLE
feat(settings): /settings Teal 리디자인 (plan021)

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -468,7 +468,7 @@ AlertDialog:
                 ├─ SettingsHero (Teal gradient)
                 │   ├─ 사용자 이름 + email
                 │   ├─ 현재 기본 가족명
-                │   └─ 월 예산 / 이번 달 지출 요약 (Dashboard 톤)
+                │   └─ 월 예산
                 │
                 ├─ [기본 가족 설정 카드] — radio 선택 + "현재 기본" 배지만
                 │   └─ Save → setDefaultFamilyAction

--- a/src/__tests__/actions/family/update-family-action.test.ts
+++ b/src/__tests__/actions/family/update-family-action.test.ts
@@ -11,6 +11,11 @@ jest.mock("@/lib/server/api/client", () => ({
   serverApiPut: jest.fn(),
 }));
 
+jest.mock("@/services/family/family-service", () => ({
+  ...jest.requireActual("@/services/family/family-service"),
+  getFamilies: jest.fn().mockResolvedValue([{ uuid: "family-123" }]),
+}));
+
 jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
 }));

--- a/src/__tests__/components/settings/SettingsPageClient.test.tsx
+++ b/src/__tests__/components/settings/SettingsPageClient.test.tsx
@@ -25,6 +25,10 @@ jest.mock("@/lib/client/use-session-refresh", () => ({
     refreshSession: jest.fn().mockResolvedValue(undefined),
   }),
 }));
+// useMediaQuery 훅 모킹 (BudgetEditDialog 에서 사용, window.matchMedia 없는 jsdom 환경)
+jest.mock("@/hooks/useMediaQuery", () => ({
+  useMediaQuery: jest.fn().mockReturnValue(true),
+}));
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(() => ({
@@ -118,6 +122,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-2"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -130,7 +136,7 @@ describe("SettingsPageClient", () => {
 
     it("defaultFamilyUuid가 null이면 아무것도 선택되지 않는다", () => {
       render(
-        <SettingsPageClient families={mockFamilies} defaultFamilyUuid={null} />
+        <SettingsPageClient families={mockFamilies} defaultFamilyUuid={null} userName={null} userEmail={null} />
       );
 
       // 모든 라디오 버튼이 선택되지 않은 상태인지 확인
@@ -145,6 +151,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -157,6 +165,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -178,6 +188,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -204,6 +216,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -216,7 +230,7 @@ describe("SettingsPageClient", () => {
 
     it("가족을 선택하지 않으면 저장 버튼이 비활성화된다", () => {
       render(
-        <SettingsPageClient families={mockFamilies} defaultFamilyUuid={null} />
+        <SettingsPageClient families={mockFamilies} defaultFamilyUuid={null} userName={null} userEmail={null} />
       );
 
       const saveButton = screen.getByRole("button", {
@@ -232,21 +246,25 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
-      expect(screen.getByText("월 예산: 1,000,000원")).toBeInTheDocument();
-      expect(screen.getByText("월 예산: 2,000,000원")).toBeInTheDocument();
+      expect(screen.getByText("월 예산: ₩1,000,000")).toBeInTheDocument();
+      expect(screen.getByText("월 예산: ₩2,000,000")).toBeInTheDocument();
       expect(screen.getByText("예산 미설정")).toBeInTheDocument();
     });
 
-    it("예산 수정 버튼을 클릭하면 입력 필드가 표시된다", async () => {
+    it("예산 수정 버튼을 클릭하면 BudgetEditDialog 가 열린다", async () => {
       const user = userEvent.setup();
 
       render(
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -254,8 +272,8 @@ describe("SettingsPageClient", () => {
       const editButtons = screen.getAllByRole("button", { name: /수정/i });
       await user.click(editButtons[0]);
 
-      // 입력 필드가 표시되는지 확인
-      const input = screen.getByPlaceholderText("월 예산 입력");
+      // Dialog 안의 입력 필드 (type=number spinbutton) 가 표시되는지 확인
+      const input = screen.getByRole("spinbutton");
       expect(input).toBeInTheDocument();
       expect(input).toHaveValue(1000000);
     });
@@ -282,28 +300,23 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
-      // 수정 버튼 클릭
+      // 수정 버튼 클릭 → BudgetEditDialog 열림
       const editButtons = screen.getAllByRole("button", { name: /수정/i });
       await user.click(editButtons[0]);
 
-      // 예산 입력
-      const input = screen.getByPlaceholderText("월 예산 입력");
+      // Dialog 안의 입력 필드에 새 값 입력
+      const input = screen.getByRole("spinbutton");
       await user.clear(input);
       await user.type(input, "1500000");
 
-      // 저장 버튼 클릭 (Save 아이콘 버튼 찾기 - 취소 버튼 이후의 버튼)
-      const allIconButtons = screen.getAllByRole("button");
-      const saveButton = allIconButtons.find((btn) => {
-        const svg = btn.querySelector("svg.lucide-save");
-        return svg !== null;
-      });
-
-      if (saveButton) {
-        await user.click(saveButton);
-      }
+      // "저장" 버튼 클릭
+      const saveButton = screen.getByRole("button", { name: /^저장$/ });
+      await user.click(saveButton);
 
       // API 호출 확인
       await waitFor(() => {
@@ -321,6 +334,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 
@@ -335,6 +350,8 @@ describe("SettingsPageClient", () => {
         <SettingsPageClient
           families={mockFamilies}
           defaultFamilyUuid="family-1"
+          userName={null}
+          userEmail={null}
         />
       );
 

--- a/src/actions/family/update-family-action.ts
+++ b/src/actions/family/update-family-action.ts
@@ -11,7 +11,7 @@ import {
   type ActionResult,
 } from "@/lib/errors";
 import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { updateFamily } from "@/services/family/family-service";
+import { getFamilies, updateFamily } from "@/services/family/family-service";
 import type { Family, UpdateFamilyRequest } from "@/types/family";
 import { revalidatePath } from "next/cache";
 
@@ -28,6 +28,12 @@ export async function updateFamilyAction(
         familyUuid,
         "UUID는 필수입니다"
       );
+    }
+
+    // 권한 검증: 사용자가 해당 family 멤버인지 확인 (백엔드가 세션 토큰 기준으로 본인 가족만 반환)
+    const families = await getFamilies();
+    if (!families.some((f) => f.uuid === familyUuid)) {
+      throw ActionError.entityNotFound("가족", familyUuid);
     }
 
     const family = await updateFamily(familyUuid, data);

--- a/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
+++ b/src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { updateFamilyAction } from "@/actions/family/update-family-action";
 import { setDefaultFamilyAction } from "@/actions/user/set-default-family-action";
 import { SettingsCard } from "@/components/layout/SettingsCard";
+import { BudgetEditDialog } from "@/components/settings/BudgetEditDialog";
+import { SettingsHero } from "@/components/settings/SettingsHero";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { cn } from "@/lib/client/utils";
 import { useSessionRefresh } from "@/lib/client/use-session-refresh";
 import type { Family } from "@/types/family";
-import { Check, DollarSign, Edit2, Save, Users, X } from "lucide-react";
+import { Check, Edit2, Users, Wallet } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -18,11 +18,15 @@ import { toast } from "sonner";
 interface SettingsPageClientProps {
   families: Family[];
   defaultFamilyUuid: string | null;
+  userName: string | null;
+  userEmail: string | null;
 }
 
 export function SettingsPageClient({
   families,
   defaultFamilyUuid,
+  userName,
+  userEmail,
 }: SettingsPageClientProps) {
   const router = useRouter();
   const { refreshSession } = useSessionRefresh();
@@ -31,8 +35,9 @@ export function SettingsPageClient({
     defaultFamilyUuid || ""
   );
   const [isSaving, setIsSaving] = useState(false);
-  const [editingBudget, setEditingBudget] = useState<string | null>(null);
-  const [budgetValues, setBudgetValues] = useState<Record<string, string>>({});
+  const [budgetDialogFamily, setBudgetDialogFamily] = useState<Family | null>(
+    null
+  );
 
   const handleSaveDefaultFamily = async () => {
     if (!selectedFamily) {
@@ -60,58 +65,17 @@ export function SettingsPageClient({
     }
   };
 
-  const handleEditBudget = (familyUuid: string, currentBudget: number) => {
-    setEditingBudget(familyUuid);
-    setBudgetValues({
-      ...budgetValues,
-      [familyUuid]: currentBudget.toString(),
-    });
-  };
-
-  const handleCancelBudget = (familyUuid: string) => {
-    setEditingBudget(null);
-    const newBudgetValues = { ...budgetValues };
-    delete newBudgetValues[familyUuid];
-    setBudgetValues(newBudgetValues);
-  };
-
-  const handleSaveBudget = async (familyUuid: string, familyName: string) => {
-    const budgetStr = budgetValues[familyUuid];
-    const budget = parseFloat(budgetStr);
-
-    if (isNaN(budget) || budget < 0) {
-      toast.error("올바른 예산 금액을 입력해주세요");
-      return;
-    }
-
-    try {
-      const result = await updateFamilyAction(familyUuid, {
-        name: familyName,
-        monthlyBudget: budget,
-      });
-
-      if (result.success) {
-        toast.success("월 예산이 설정되었습니다");
-        setEditingBudget(null);
-        router.refresh();
-      } else {
-        toast.error(result.error.message);
-      }
-    } catch (error) {
-      console.error("Failed to update budget:", error);
-      toast.error("예산 설정에 실패했습니다");
-    }
-  };
-
   return (
+    <>
     <div className="max-w-4xl mx-auto space-y-6">
       {/* 헤더 */}
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold text-fg mb-2">설정</h1>
-        <p className="text-sm md:text-base text-fg-muted">
-          가족 · 예산 · 알림 관리
-        </p>
-      </div>
+      <SettingsHero
+        userName={userName}
+        userEmail={userEmail}
+        defaultFamily={
+          families.find((f) => f.uuid === currentDefaultFamily) ?? null
+        }
+      />
 
       <div className="grid gap-4 md:grid-cols-2">
         {/* 기본 가족 설정 — full width */}
@@ -158,9 +122,10 @@ export function SettingsPageClient({
                             </span>
                           )}
                         </span>
-                        <span className="text-xs text-fg-muted mt-0.5">
-                          구성원 {family.members?.length || 0}명 · 지출{" "}
-                          {family.expenseCount || 0}건
+                        <span className="text-xs text-fg-muted mt-0.5 font-num tabular-nums">
+                          {family.monthlyBudget > 0
+                            ? `월 예산 ₩${family.monthlyBudget.toLocaleString()}`
+                            : "월 예산 미설정"}
                         </span>
                       </div>
                     </Label>
@@ -177,7 +142,7 @@ export function SettingsPageClient({
                   !selectedFamily ||
                   selectedFamily === currentDefaultFamily
                 }
-                className="gradient-primary hover:opacity-90 text-white"
+                className="bg-brand-500 hover:bg-brand-600 text-white"
               >
                 {isSaving ? "저장 중..." : "기본 가족으로 설정"}
               </Button>
@@ -187,7 +152,7 @@ export function SettingsPageClient({
 
         {/* 월 예산 설정 */}
         <SettingsCard
-          icon={DollarSign}
+          icon={Wallet}
           title="가족별 예산 설정"
           subtitle="이번 달 목표 예산을 입력하세요"
         >
@@ -200,66 +165,24 @@ export function SettingsPageClient({
                   i > 0 && "border-t border-border"
                 )}
               >
-                <div className="flex-1">
-                  <h3 className="font-medium text-fg text-sm">{family.name}</h3>
-                  {editingBudget === family.uuid ? (
-                    <div className="flex items-center gap-2 mt-2">
-                      <Input
-                        type="number"
-                        min="0"
-                        step="1000"
-                        value={budgetValues[family.uuid] || ""}
-                        onChange={(e) =>
-                          setBudgetValues({
-                            ...budgetValues,
-                            [family.uuid]: e.target.value,
-                          })
-                        }
-                        placeholder="월 예산 입력"
-                        className="w-36"
-                      />
-                      <span className="text-xs text-fg-muted">원</span>
-                    </div>
-                  ) : (
-                    <p className="text-xs text-fg-muted mt-0.5">
-                      {family.monthlyBudget > 0
-                        ? `월 예산: ${family.monthlyBudget.toLocaleString()}원`
-                        : "예산 미설정"}
-                    </p>
-                  )}
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-medium text-fg text-sm truncate">
+                    {family.name}
+                  </h3>
+                  <p className="text-xs text-fg-muted mt-0.5 font-num tabular-nums">
+                    {family.monthlyBudget > 0
+                      ? `월 예산: ₩${family.monthlyBudget.toLocaleString()}`
+                      : "예산 미설정"}
+                  </p>
                 </div>
-                <div className="flex items-center gap-2">
-                  {editingBudget === family.uuid ? (
-                    <>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleCancelBudget(family.uuid)}
-                      >
-                        <X className="w-4 h-4" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={() =>
-                          handleSaveBudget(family.uuid, family.name)
-                        }
-                      >
-                        <Save className="w-4 h-4" />
-                      </Button>
-                    </>
-                  ) : (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() =>
-                        handleEditBudget(family.uuid, family.monthlyBudget)
-                      }
-                    >
-                      <Edit2 className="w-4 h-4 mr-1" />
-                      수정
-                    </Button>
-                  )}
-                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setBudgetDialogFamily(family)}
+                >
+                  <Edit2 className="w-4 h-4 mr-1" />
+                  수정
+                </Button>
               </div>
             ))}
           </div>
@@ -301,5 +224,16 @@ export function SettingsPageClient({
         </SettingsCard>
       </div>
     </div>
+
+    {budgetDialogFamily && (
+      <BudgetEditDialog
+        open={!!budgetDialogFamily}
+        onOpenChange={(open) => !open && setBudgetDialogFamily(null)}
+        familyUuid={budgetDialogFamily.uuid}
+        familyName={budgetDialogFamily.name}
+        currentBudget={budgetDialogFamily.monthlyBudget}
+      />
+    )}
+    </>
   );
 }

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -1,7 +1,8 @@
 import { getFamiliesAction } from "@/actions/family/get-families-action";
 import { getUserProfileAction } from "@/actions/user/get-user-profile-action";
-import { SettingsPageClient } from "./_components/SettingsPageClient";
+import { auth } from "@/lib/server/auth";
 import { requireActionSuccess } from "@/lib/server/action-result-handler";
+import { SettingsPageClient } from "./_components/SettingsPageClient";
 
 // 쿠키를 사용하므로 동적 렌더링 필요
 export const dynamic = "force-dynamic";
@@ -19,10 +20,15 @@ export default async function SettingsPage() {
     fallbackRedirect: "/families/create",
   });
 
+  // 3. 세션에서 사용자 이름/이메일 조회
+  const session = await auth();
+
   return (
     <SettingsPageClient
       families={families}
       defaultFamilyUuid={profile.defaultFamilyUuid}
+      userName={session?.user?.name ?? null}
+      userEmail={session?.user?.email ?? null}
     />
   );
 }

--- a/src/components/settings/BudgetEditDialog.tsx
+++ b/src/components/settings/BudgetEditDialog.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { updateFamilyAction } from "@/actions/family/update-family-action";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+interface BudgetEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  familyUuid: string;
+  familyName: string;
+  currentBudget: number;
+}
+
+const QUICK_AMOUNTS = [
+  { label: "+10만", value: 100_000 },
+  { label: "+50만", value: 500_000 },
+  { label: "+100만", value: 1_000_000 },
+];
+
+export function BudgetEditDialog({
+  open,
+  onOpenChange,
+  familyUuid,
+  familyName,
+  currentBudget,
+}: BudgetEditDialogProps) {
+  const router = useRouter();
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [value, setValue] = useState(currentBudget.toString());
+  const [isSaving, setIsSaving] = useState(false);
+
+  // open 될 때마다 currentBudget 으로 리셋
+  useEffect(() => {
+    if (open) {
+      setValue(currentBudget.toString());
+    }
+  }, [open, currentBudget]);
+
+  const handleQuickAdd = (delta: number) => {
+    const cur = parseFloat(value) || 0;
+    setValue(String(cur + delta));
+  };
+
+  const handleSave = async () => {
+    const budget = parseFloat(value);
+    if (isNaN(budget) || budget < 0) {
+      toast.error("올바른 예산 금액을 입력해주세요");
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const result = await updateFamilyAction(familyUuid, {
+        name: familyName,
+        monthlyBudget: budget,
+      });
+      if (result.success) {
+        toast.success("월 예산이 설정되었습니다");
+        onOpenChange(false);
+        router.refresh();
+      } else {
+        toast.error(result.error.message);
+      }
+    } catch {
+      toast.error("예산 설정에 실패했습니다");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const body = (
+    <div className="space-y-4 pt-2">
+      <div>
+        <p className="text-sm text-fg-muted">가족</p>
+        <p className="text-base font-semibold text-fg">{familyName}</p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-fg mb-2">
+          월 예산 (원)
+        </label>
+        <Input
+          type="number"
+          min="0"
+          step="10000"
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="font-num tabular-nums text-lg"
+          autoFocus
+        />
+        <div className="flex flex-wrap gap-2 mt-3">
+          {QUICK_AMOUNTS.map((q) => (
+            <button
+              key={q.value}
+              type="button"
+              onClick={() => handleQuickAdd(q.value)}
+              className="px-3 py-1.5 rounded-full bg-bg-muted text-fg text-xs font-medium hover:bg-brand-50 hover:text-brand-700 transition-colors"
+            >
+              {q.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setValue("0")}
+            className="px-3 py-1.5 rounded-full bg-bg-muted text-fg-muted text-xs font-medium hover:bg-bg-muted transition-colors"
+          >
+            초기화
+          </button>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button
+          variant="outline"
+          onClick={() => onOpenChange(false)}
+          disabled={isSaving}
+        >
+          취소
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={isSaving}
+          className="bg-brand-500 hover:bg-brand-600 text-white"
+        >
+          {isSaving ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (isDesktop) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>월 예산 수정</DialogTitle>
+          </DialogHeader>
+          {body}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="h-auto">
+        <SheetHeader>
+          <SheetTitle>월 예산 수정</SheetTitle>
+        </SheetHeader>
+        {body}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/settings/BudgetEditDialog.tsx
+++ b/src/components/settings/BudgetEditDialog.tsx
@@ -137,7 +137,7 @@ export function BudgetEditDialog({
         <Button
           onClick={handleSave}
           disabled={isSaving}
-          className="bg-brand-500 hover:bg-brand-600 text-white"
+          className="bg-brand-500 hover:bg-brand-600 text-brand-fg"
         >
           {isSaving ? "저장 중..." : "저장"}
         </Button>

--- a/src/components/settings/SettingsHero.tsx
+++ b/src/components/settings/SettingsHero.tsx
@@ -1,0 +1,54 @@
+import { Card } from "@/components/ui/card";
+import type { Family } from "@/types/family";
+import { Users, Wallet } from "lucide-react";
+
+interface SettingsHeroProps {
+  userName: string | null;
+  userEmail: string | null;
+  defaultFamily: Family | null;
+}
+
+export function SettingsHero({
+  userName,
+  userEmail,
+  defaultFamily,
+}: SettingsHeroProps) {
+  return (
+    <Card className="overflow-hidden border-0 gradient-budget text-white">
+      <div className="p-5 md:p-6">
+        <p className="text-xs md:text-sm text-white/80 mb-1">설정</p>
+        <h1 className="text-xl md:text-2xl font-bold mb-3">
+          {userName ?? "사용자"}
+          <span className="block text-sm md:text-base font-normal text-white/80 mt-0.5">
+            {userEmail ?? ""}
+          </span>
+        </h1>
+
+        {defaultFamily ? (
+          <div className="mt-4 flex flex-wrap items-center gap-3 md:gap-5 text-sm md:text-base">
+            <div className="flex items-center gap-2">
+              <Users className="w-4 h-4 text-white/80" />
+              <span className="font-medium">{defaultFamily.name}</span>
+              <span className="text-xs text-white/70">기본 가족</span>
+            </div>
+            {defaultFamily.monthlyBudget > 0 ? (
+              <div className="flex items-center gap-2">
+                <Wallet className="w-4 h-4 text-white/80" />
+                <span className="font-num font-medium tabular-nums">
+                  ₩{defaultFamily.monthlyBudget.toLocaleString()}
+                </span>
+                <span className="text-xs text-white/70">월 예산</span>
+              </div>
+            ) : (
+              <span className="text-xs text-white/70">월 예산 미설정</span>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-white/80 mt-3">
+            기본 가족이 설정되지 않았습니다.
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/tasks/plan021-settings-redesign/index.json
+++ b/tasks/plan021-settings-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan021-settings-redesign",
   "description": "/settings 페이지 Teal 리디자인. SettingsHero 신설 + legacy gradient-primary 제거 + DollarSign→Wallet + 가족별 예산 inline edit → BudgetEditDialog (responsive Sheet/Dialog, plan014 패턴 재사용). 카드 정보 중복 해소.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-19",
   "total_phases": 3,
   "related_docs": [
@@ -23,21 +23,21 @@
       "file": "phase-01.md",
       "title": "SettingsHero 신설 + legacy 토큰 제거 (gradient-primary, DollarSign)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "BudgetEditDialog 신설 + inline edit → Dialog 트리거 마이그레이션",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "카드 정보 분리 + 통합 검증 + 8단계 체크리스트 + status=completed",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "planning_checklist": {

--- a/tasks/plan021-settings-redesign/phase-02.md
+++ b/tasks/plan021-settings-redesign/phase-02.md
@@ -65,7 +65,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { useMediaQuery } from "@/hooks/use-media-query";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { updateFamilyAction } from "@/actions/family/update-family-action";
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
@@ -216,7 +216,7 @@ export function BudgetEditDialog({
 }
 ```
 
-`useMediaQuery` 훅 경로는 기존 plan014 사용처 (`src/hooks/use-media-query.ts` 또는 `@/hooks/use-media-query`) 따름. 없으면 `AddTransactionDialog.tsx` 의 import 확인 후 동일 경로.
+`useMediaQuery` 훅은 `@/hooks/useMediaQuery` (camelCase, `src/hooks/useMediaQuery.ts`). plan014 `AddTransactionDialog.tsx` L23 동일 경로 사용.
 
 ### 2. `SettingsPageClient.tsx` — inline edit 제거 + Dialog 트리거
 
@@ -340,7 +340,7 @@ grep -nE '\+10만|\+50만|\+100만' src/components/settings/BudgetEditDialog.tsx
 
 | 리스크 | 완화 |
 |---|---|
-| `useMediaQuery` 훅 경로 / signature 가 plan014 와 다름 | plan014 의 `AddTransactionDialog.tsx` import 확인 후 동일 경로 사용. 없으면 hooks 디렉터리 통째로 grep |
+| `useMediaQuery` 훅 경로 (`@/hooks/useMediaQuery` camelCase) 오타 가능 | plan014 `AddTransactionDialog.tsx` L23 과 동일 — 위 본문 코드 정정됨. ts 빌드로 검증 |
 | Dialog `open` 토글 시 동일 컴포넌트 mount → currentBudget reset 안 됨 | useEffect 로 open 변화 시 setValue(currentBudget) 명시 (위 코드 반영됨) |
 | Sheet bottom 가 모바일 키보드와 겹침 | iOS Safari 키보드 위로 Sheet 본문 자동 push — shadcn Sheet 기본 동작. 미작동 시 `h-auto` → `max-h-[80vh] overflow-y-auto` 폴백 |
 | 빠른 입력 칩 누적 시 매우 큰 수 발생 | input type=number max 옵션 없이 자유 입력. updateFamilyAction 의 backend 검증에 위임 (현재 검증 범위는 Family 도메인 결정) |

--- a/tasks/plan021-settings-redesign/phase-03.md
+++ b/tasks/plan021-settings-redesign/phase-03.md
@@ -61,10 +61,15 @@ test -f src/components/settings/BudgetEditDialog.tsx
 ! grep -n 'editingBudget\|budgetValues' \
   src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx
 
-# 정보 중복 해소: 기본 가족 카드의 "구성원 N명 · 지출 N건" 제거
-! grep -n '구성원.*명 · 지출' \
-  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | \
-  head -1 || echo "OK: 중복 제거됨 또는 1곳만 (내 가족 목록 카드)"
+# 정보 중복 해소: "구성원 N명 · 지출 N건" 표기는 내 가족 목록 카드에만 1회 등장
+# (기본 가족 카드에서는 제거되고 "월 예산 ₩" / "월 예산 미설정" 으로 대체)
+COUNT=$(grep -cE '구성원 \{?[^}]*\}?명 · 지출' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx)
+test "$COUNT" = "1" || { echo "FAIL: '구성원 N명 · 지출' 등장 $COUNT 회 (기대: 1, 내 가족 목록 카드만)"; exit 1; }
+
+# 기본 가족 카드에 신규 마커 (월 예산 ₩ 또는 월 예산 미설정) 존재
+grep -nE '월 예산 ₩|월 예산 미설정' \
+  src/app/\(authenticated\)/settings/_components/SettingsPageClient.tsx | wc -l   # >= 1
 
 # 내 가족 목록 카드는 카테고리 통계 유지
 grep -n '카테고리.*개' \


### PR DESCRIPTION
## Summary

`/settings` 페이지 Teal 시스템 정착 + UX 개선 (plan021).

- **SettingsHero 신설** — Teal gradient hero (사용자명·email + 현재 기본 가족 + 월 예산)
- **legacy 토큰 제거** — `gradient-primary` → `bg-brand-500`, `DollarSign` → `Wallet`
- **가족별 예산 inline edit → BudgetEditDialog** — responsive Sheet bottom (mobile) / Dialog center (md+), plan014 패턴 재사용. 빠른 입력 칩 (+10만 / +50만 / +100만)
- **카드 정보 분리** — 기본 가족 카드 (radio + 월 예산) ↔ 내 가족 목록 카드 (멤버/카테고리/지출 통계). 정보 중복 해소
- **updateFamilyAction 권한 검증 강화** — `getFamilies + includes` 멤버십 검증 추가 (formData 권한 식별자 주입 방어, CLAUDE.md 금지사항 부합)

## Test plan

- [x] `pnpm lint` (coverage 외 0 error)
- [x] `pnpm tsc --noEmit` (0 errors)
- [x] `pnpm build` (/settings ƒ Dynamic)
- [x] `pnpm test:ci` (33 suites, 242 tests pass)
- [ ] /settings 모바일 (< 768px) — Hero 폰트 / Sheet bottom 슬라이드 / 빠른 입력 칩
- [ ] /settings 데스크톱 (>= 768px) — Dialog center
- [ ] dark mode — gradient-budget / Sheet 톤 자연
- [ ] 기본 가족 변경 → toast + revalidate
- [ ] 다른 가족 UUID 주입 시도 → entityNotFound

## docs

- `docs/flow.md` §15 SettingsHero 표기 정정 (이번 달 지출 요약 제거 — 미구현)

## 후속 plan 예정

- **plan022 zod-validation-backfill**: `update-family-action.ts` Zod 검증 추가 (ADR-F06, pre-existing 결함). plan021 권한 검증 phase 가 같은 파일 건드린 김에 docs-verifier 가 발견. scope creep 회피 위해 별도 plan 분리.

## 파이프라인

- critic APPROVE (v2)
- executor 3 phases 완료
- code-reviewer PASS
- docs-verifier PASS (v2)

🤖 Generated with Claude Agent Teams (plan021 / build-with-teams)