### PR TITLE
docs(plan023): Server Action 권한 검증 3-패턴 표준화 task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Page (app/) → Action (actions/) → Service (services/) → lib/server/api
 - `console.log` 프로덕션 코드에 남기지 않기
 - `any` 타입 사용 금지
 - `NEXT_PUBLIC_` 없는 환경 변수를 클라이언트 번들에 노출 금지
-- Server Action 에서 `familyUuid` 같은 권한 식별자는 항상 `getSelectedFamilyUuid()` 등 세션 기반 helper 로만 결정. `formData.get("familyUuid")` 직접 사용 금지 — 클라이언트가 다른 가족 UUID 를 주입할 수 있어 권한 상승 위험. update 계열은 session vs formData 비교 검증으로 처리 (`updateExpenseAction` / `updateIncomeAction` 패턴 참조)
+- Server Action 권한 검증은 ADR-F25 의 3 패턴 중 하나로 명시. (a) **Single-family**: `getSelectedFamilyUuid()` + 입력 familyUuid 가 있으면 session 비교 (`updateExpenseAction` 패턴) (b) **Multi-family**: `assertFamilyAccess(familyUuid)` helper (`updateFamilyAction` 패턴) (c) **Entity ownership**: entity 의 familyUuid 가 본인 소속인지 확인 (`deleteInvitationAction` 패턴). `formData.get("familyUuid")` 단순 신뢰 금지 — 클라이언트 주입 시 권한 상승 위험. 신규 Action 작성 시 3 패턴 분류 자체 점검 필수
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,12 @@ Page (app/) → Action (actions/) → Service (services/) → lib/server/api
 - `console.log` 프로덕션 코드에 남기지 않기
 - `any` 타입 사용 금지
 - `NEXT_PUBLIC_` 없는 환경 변수를 클라이언트 번들에 노출 금지
-- Server Action 권한 검증은 ADR-F25 의 3 패턴 중 하나로 명시. (a) **Single-family**: `getSelectedFamilyUuid()` + 입력 familyUuid 가 있으면 session 비교 (`updateExpenseAction` 패턴) (b) **Multi-family**: `assertFamilyAccess(familyUuid)` helper (`updateFamilyAction` 패턴) (c) **Entity ownership**: entity 의 familyUuid 가 본인 소속인지 확인 (`deleteInvitationAction` 패턴). `formData.get("familyUuid")` 단순 신뢰 금지 — 클라이언트 주입 시 권한 상승 위험. 신규 Action 작성 시 3 패턴 분류 자체 점검 필수
+- Server Action 권한 검증은 ADR-F25 의 3 패턴 중 하나로 명시한다.
+  - (a) **Single-family**: `getSelectedFamilyUuid()` + 입력 familyUuid 가 있으면 session 비교 (`updateExpenseAction` 패턴)
+  - (b) **Multi-family**: `assertFamilyAccess(familyUuid)` helper (`updateFamilyAction` 패턴)
+  - (c) **Entity ownership**: entity 의 familyUuid 가 본인 소속인지 확인 (`deleteInvitationAction` 패턴)
+  - `formData.get("familyUuid")` 단순 신뢰 금지 — 클라이언트 주입 시 권한 상승 위험
+  - 신규 Action 작성 시 3 패턴 분류 자체 점검 필수
 
 ---
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -428,3 +428,16 @@
 - **트레이드오프**: 토큰 직접 매핑은 sonner 업데이트 시 className target (`[data-sonner-toast][data-type=...]`) 시그니처 변경 영향 받음 — 단 sonner 가 안정적 API 이고 toast 사용처가 20+ 곳이라 일관성 이득이 큼.
 - **적용 범위**: `src/components/ui/sonner.tsx` + `src/app/providers.tsx` + `src/components/ui/alert-dialog.tsx`. AlertDialog 파괴적 Action (Delete*Dialog 4 호출처) 은 호출처에서 `variant="destructive"` 명시 (`buttonVariants({ variant: "destructive" })` 가 이미 expense 토큰으로 매핑됨).
 
+## ADR-F25: Server Action 권한 검증 3-패턴 표준화 (2026-05-20)
+
+- **결정**: 가족 식별자를 다루는 모든 Server Action 은 아래 3 패턴 중 하나로 권한 검증을 명시한다.
+  - **A. Single-family** (현재 선택 가족만 다룸): `getSelectedFamilyUuid()` + 입력 `familyUuid` 가 있으면 session 과 비교. expense/income/category 의 update/delete + create.
+  - **B. Multi-family** (settings 처럼 본인 속한 여러 가족 다룸): `assertFamilyAccess(familyUuid)` helper. `family/update`.
+  - **C. Entity ownership** (entity UUID 로부터 family 유추): entity 의 familyUuid 가 본인 소속인지 확인. `invitation/delete`.
+- **맥락**: PR #271 (plan021) 리뷰에서 `updateFamilyAction` 이 `requireAuth()` 만 수행 → 클라이언트가 본인이 속하지 않은 다른 가족 UUID 주입 시 권한 상승 가능 지적. 감사 결과 `category/create` 의 `familyUuid || getSelectedFamilyUuid()` fallback, `invitation/delete` 의 entity 권한 검증 부재도 발견. CLAUDE.md "금지사항" 의 `formData.get('familyUuid')` 금지 규칙이 모호하게 적용됨.
+- **대안 기각**:
+  - 단일 helper (예: `requirePermission`) 로 통합: input shape 가 패턴마다 달라 (single uuid / multi uuid / entity uuid) 인자 분기 복잡. 호출처에서 패턴이 보이지 않아 검토 부담 ↑.
+  - backend trust only (frontend 검증 생략): backend 단일 장애 시 권한 상승 노출. 이중 방어 원칙에서 명시 권장.
+- **트레이드오프**: `assertFamilyAccess` 는 매 호출마다 `getFamilies()` 페치 (단 backend 가 캐시 + 짧은 TTL). single-family 패턴의 session 비교는 캐시된 JWT 만 사용해 0 네트워크.
+- **적용 범위**: `src/lib/server/auth/auth-helpers.ts` (helper) + `src/actions/family/update-family-action.ts` (B) + `src/actions/category/create-category-action.ts` (A, session 비교 추가) + `src/actions/invitation/delete-invitation-action.ts` (C). 다른 Action 은 이미 표준 패턴 준수.
+

--- a/tasks/plan023-server-action-permission-audit/index.json
+++ b/tasks/plan023-server-action-permission-audit/index.json
@@ -1,0 +1,49 @@
+{
+  "name": "plan023-server-action-permission-audit",
+  "description": "Server Action 권한 검증 일괄 감사 + 표준 3-패턴 정착 (ADR-F25). assertFamilyAccess helper 신설 + family/update / category/create / invitation/delete 3 곳의 권한 검증 강화. PR #271 리뷰에서 surfaced 된 패턴 누락 해소.",
+  "status": "pending",
+  "created_at": "2026-05-20",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/adr.md",
+    "CLAUDE.md"
+  ],
+  "depends_on": [],
+  "prerequisites": [
+    "ADR-F25 head 신설 ✅ (docs commit 포함)",
+    "기존 표준 패턴 (expense/income update/delete) 동작 유지"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "assertFamilyAccess helper 신설 + family/update 적용 (Multi-family 패턴 B)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "category/create session 비교 (패턴 A) + invitation/delete entity ownership (패턴 C)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "통합 검증 + 전체 audit grep + 8단계 체크리스트 + status=completed",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "기존 helper (requireAuth / getSelectedFamilyUuid) + service (getFamilies / getInvitationInfo) 모두 재사용. 신규 backend API 불필요. 검증 패턴 3 종 모두 코드베이스에 선행 사례 존재.",
+    "2_tech_stack": "변경 없음. Next.js Server Action + TypeScript + Zod 유지.",
+    "3_user_flow": "동작 변경 없음. 권한 없는 UUID 주입 시 entityNotFound / 권한없음 error 반환 (이전: backend trust 만, 침투 시 권한 상승 가능).",
+    "4_ui": "변경 없음 — Action 시그니처 유지 (familyUuid prop 유지 + 내부 검증만 추가).",
+    "5_api": "Server Action 시그니처 동일. category/create 의 prop 우선 fallback 제거 (session 과 일치 강제).",
+    "6_arch": "assertFamilyAccess(familyUuid) → throws ActionError.entityNotFound on miss. auth-helpers.ts 에 추가. 3 Action 호출처 갱신. plan021 phase-02 의 0번 작업과 동일 영역 — 어느 plan 이 먼저 구현되든 두 번째 plan 의 family/update 작업은 no-op.",
+    "7_adr": "ADR-F25 신설 (docs commit 에 포함) — 3 패턴 결정 근거 + 적용 범위. CLAUDE.md 금지사항 강화 (3 패턴 분류 자체 점검).",
+    "8_docs": "adr.md ADR-F25 + CLAUDE.md 금지사항 패턴 명시. flow.md 변경 없음 (사용자 흐름 동일)."
+  }
+}

--- a/tasks/plan023-server-action-permission-audit/phase-01.md
+++ b/tasks/plan023-server-action-permission-audit/phase-01.md
@@ -18,6 +18,7 @@
 ```ts
 import { ActionError } from "@/lib/errors";
 import { getFamilies } from "@/services/family/family-service";
+import type { Family } from "@/types/family";
 
 /**
  * Multi-family 패턴 권한 검증 (ADR-F25 패턴 B).
@@ -27,7 +28,7 @@ import { getFamilies } from "@/services/family/family-service";
  * settings 처럼 본인 속한 여러 가족 중 하나를 다루는 Action 전용.
  */
 export async function assertFamilyAccess(familyUuid: string): Promise<void> {
-  const families = await getFamilies();
+  const families: Family[] = await getFamilies();
   if (!families.some((f) => f.uuid === familyUuid)) {
     throw ActionError.entityNotFound("가족", familyUuid);
   }

--- a/tasks/plan023-server-action-permission-audit/phase-01.md
+++ b/tasks/plan023-server-action-permission-audit/phase-01.md
@@ -1,0 +1,113 @@
+# Phase 01 — assertFamilyAccess helper 신설 + family/update 적용
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `src/lib/server/auth/auth-helpers.ts` 에 `assertFamilyAccess(familyUuid)` helper 신설. `updateFamilyAction` 에 적용 (Multi-family 패턴 B, ADR-F25). 클라이언트가 본인 속하지 않은 family UUID 주입 시 `entityNotFound` 로 차단.
+
+## Context (자기완결)
+
+- 현재 `src/actions/family/update-family-action.ts` (43 줄): `requireAuth()` 만 수행 → 권한 상승 위험 (PR #271 리뷰 지적)
+- `src/lib/server/auth/auth-helpers.ts` (L1~75 추정): `requireAuth` / `requireAuthOrRedirect` / `getSelectedFamilyUuid` exports
+- `src/services/family/family-service.ts:21-23` 의 `getFamilies()` 가 백엔드 세션 token 기준으로 본인 가족만 반환 (이미 신뢰 경계). list 안에 familyUuid 가 있으면 권한 증거
+- `selectFamily` (L36-43) 의 검증 패턴이 모델 — `families.some(f => f.uuid === familyUuid)` + throw `ActionError.entityNotFound`
+
+## 작업 항목
+
+### 1. `src/lib/server/auth/auth-helpers.ts` 에 helper 추가
+
+```ts
+import { ActionError } from "@/lib/errors";
+import { getFamilies } from "@/services/family/family-service";
+
+/**
+ * Multi-family 패턴 권한 검증 (ADR-F25 패턴 B).
+ * 사용자가 해당 family 의 member 인지 확인. 미소속 시 entityNotFound throw.
+ *
+ * Single-family Action 은 `getSelectedFamilyUuid()` 비교로 충분 — 본 helper 는
+ * settings 처럼 본인 속한 여러 가족 중 하나를 다루는 Action 전용.
+ */
+export async function assertFamilyAccess(familyUuid: string): Promise<void> {
+  const families = await getFamilies();
+  if (!families.some((f) => f.uuid === familyUuid)) {
+    throw ActionError.entityNotFound("가족", familyUuid);
+  }
+}
+```
+
+import 위치는 기존 파일의 import 블록 끝. export 도 기존 패턴 따름.
+
+### 2. `src/actions/family/update-family-action.ts` 갱신
+
+```ts
+import { requireAuth, assertFamilyAccess } from "@/lib/server/auth/auth-helpers";
+// 기존 import 유지
+
+export async function updateFamilyAction(
+  familyUuid: string,
+  data: UpdateFamilyRequest
+): Promise<ActionResult<Family>> {
+  try {
+    await requireAuth();
+
+    if (!familyUuid) {
+      throw ActionError.invalidInput("가족 UUID", familyUuid, "UUID는 필수입니다");
+    }
+
+    await assertFamilyAccess(familyUuid);   // ← 추가
+
+    const family = await updateFamily(familyUuid, data);
+    revalidatePath("/");
+    revalidatePath("/settings");
+    revalidatePath(`/families/${familyUuid}`);
+    return successResult(family);
+  } catch (error) {
+    return handleActionError(error, "가족 정보 수정에 실패했습니다");
+  }
+}
+```
+
+기존 동작 보존 — `requireAuth` 유지, `familyUuid` null check 유지, revalidate 경로 동일. 검증 1줄만 추가.
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan023-server-action-permission-audit
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# helper export 존재
+grep -n 'export async function assertFamilyAccess' \
+  src/lib/server/auth/auth-helpers.ts | wc -l   # == 1
+
+# updateFamilyAction 적용
+grep -n 'assertFamilyAccess' src/actions/family/update-family-action.ts | wc -l   # >= 1
+```
+
+수동 smoke:
+- /settings 에서 본인 가족 예산 수정 → 정상 동작
+- (어렵지만 가능하면) devtools 로 다른 가족 UUID 주입 호출 → entityNotFound error toast
+- 단일 가족 사용자 → 영향 없음
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/lib/server/auth/auth-helpers.ts` | `assertFamilyAccess` 추가 |
+| `src/actions/family/update-family-action.ts` | helper 호출 1줄 추가 |
+
+## Out of Scope
+
+- category/create / invitation/delete 갱신 — phase-02
+- 다른 Action 의 audit — phase-03 (전체 grep 검증)
+- backend 측 권한 검증 (이미 backend 가 책임 + 본 plan 은 frontend 이중 방어)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `getFamilies()` 가 매 update 호출마다 추가 페치 → latency ↑ | 단발 페치 (캐시되지 않음). 단 settings 페이지에서 update 가 빈번 안 함. 필요 시 후속 plan 에서 `unstable_cache` 또는 session 기반 캐시 추가 |
+| circular import — auth-helpers 가 services/family 를 import | family-service 는 lib/server/api 만 import → 순환 없음. tsc 검증 시 발견 가능 |
+| plan021 phase-02 의 0번 작업과 중복 | plan023 이 먼저 머지되면 plan021 phase-02 0번은 자동 no-op (이미 적용됨). 반대도 동일 — 어느 한쪽 머지 후 다른 plan 의 build-with-teams 실행 시 0번/이번 phase 모두 동일 코드 변경이라 skip |

--- a/tasks/plan023-server-action-permission-audit/phase-02.md
+++ b/tasks/plan023-server-action-permission-audit/phase-02.md
@@ -1,0 +1,157 @@
+# Phase 02 — category/create session 비교 + invitation/delete entity ownership
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `createCategoryAction` 에 session 비교 검증 추가 (Single-family 패턴 A, ADR-F25). `deleteInvitationAction` 에 entity ownership 검증 추가 (패턴 C). 두 곳 모두 클라이언트가 본인 외 가족 UUID 주입 시 차단.
+
+## Context (자기완결)
+
+### category/create
+
+현재 `src/actions/category/create-category-action.ts:54`:
+```ts
+const selectedFamilyUuid = familyUuid || (await getSelectedFamilyUuid());
+```
+→ `familyUuid` prop 이 truthy 면 session 무시. 클라이언트 주입 가능.
+
+`updateExpenseAction` (L50-56) 의 session 비교 패턴 적용 필요.
+
+### invitation/delete
+
+현재 `src/actions/invitation/delete-invitation-action.ts:16-26`:
+```ts
+export async function deleteInvitationAction(invitationUuid: string) {
+  await requireAuth();
+  await deleteInvitation(invitationUuid);
+  // ...
+}
+```
+→ invitationUuid 의 family 소속 검증 없음. backend 가 막아도 frontend 이중 방어 부재.
+
+해결: `getActiveInvitations` 또는 invitation entity 조회 → 본인 가족 invitation 인지 확인 후 삭제.
+
+## 작업 항목
+
+### 1. `createCategoryAction` session 비교 (패턴 A)
+
+`src/actions/category/create-category-action.ts` L54 교체:
+
+```ts
+// 변경 전
+const selectedFamilyUuid = familyUuid || (await getSelectedFamilyUuid());
+if (!selectedFamilyUuid) {
+  throw ActionError.familyNotSelected();
+}
+
+// 변경 후
+const sessionFamilyUuid = await getSelectedFamilyUuid();
+if (!sessionFamilyUuid) {
+  throw ActionError.familyNotSelected();
+}
+if (familyUuid && familyUuid !== sessionFamilyUuid) {
+  throw ActionError.invalidInput(
+    "familyUuid",
+    familyUuid,
+    "권한이 없습니다"
+  );
+}
+const selectedFamilyUuid = sessionFamilyUuid;
+```
+
+세션 가족 UUID 를 단일 진실 소스로. prop 은 옵션 (호환성 유지) 이지만 세션과 불일치 시 reject.
+
+호출처 영향: 기존 호출처에서 `familyUuid` 가 항상 세션과 일치하면 동작 변경 없음. 불일치 케이스가 있다면 호출처에서 prop 제거 또는 일치하는 값 전달 (구현 시 grep 으로 호출처 확인 + 필요 시 정리).
+
+### 2. `deleteInvitationAction` entity ownership (패턴 C)
+
+`src/actions/invitation/delete-invitation-action.ts` 갱신:
+
+```ts
+"use server";
+
+import {
+  ActionError,
+  handleActionError,
+  successResult,
+  type ActionResult,
+} from "@/lib/errors";
+import { requireAuth } from "@/lib/server/auth/auth-helpers";
+import {
+  deleteInvitation,
+  getActiveInvitations,
+} from "@/services/invitation/invitation-service";
+import { revalidatePath } from "next/cache";
+
+export async function deleteInvitationAction(
+  invitationUuid: string
+): Promise<ActionResult<void>> {
+  try {
+    await requireAuth();
+
+    // Entity ownership: 본인 가족의 active invitation 목록에 포함되는지 확인
+    const active = await getActiveInvitations();
+    if (!active.some((inv) => inv.uuid === invitationUuid)) {
+      throw ActionError.entityNotFound("초대 링크", invitationUuid);
+    }
+
+    await deleteInvitation(invitationUuid);
+    revalidatePath("/");
+    return successResult(undefined);
+  } catch (error) {
+    return handleActionError(error, "초대 링크 삭제에 실패했습니다");
+  }
+}
+```
+
+`getActiveInvitations` 는 백엔드가 세션 기준 본인 가족의 invitation 만 반환 (이미 신뢰 경계) → list 에 있다는 사실이 권한 증거. 다른 가족 invitation UUID 주입 시 `entityNotFound`.
+
+`getActiveInvitations` 의 반환 타입에 `uuid` 필드가 없으면 `getInvitationsByFamily(familyUuid)` 같은 대안 helper 검토 — 구현 시 service signature 확인.
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan023-server-action-permission-audit
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# category/create session 비교 패턴
+grep -nE 'sessionFamilyUuid|familyUuid !== ' \
+  src/actions/category/create-category-action.ts | wc -l   # >= 2
+
+# category/create 의 prop fallback 제거
+! grep -n 'familyUuid || (await getSelectedFamilyUuid' \
+  src/actions/category/create-category-action.ts
+
+# invitation/delete entity 검증
+grep -nE 'getActiveInvitations|entityNotFound.*invitation|some.*invitationUuid' \
+  src/actions/invitation/delete-invitation-action.ts | wc -l   # >= 1
+```
+
+수동 smoke:
+- 카테고리 생성 (현재 가족) → 정상
+- 카테고리 생성 (devtools 로 다른 가족 UUID prop 주입) → "권한이 없습니다" error toast
+- 초대 링크 삭제 (본인 가족) → 정상
+- 초대 링크 삭제 (다른 가족 invitation UUID 주입) → "초대 링크를 찾을 수 없습니다" error toast
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/actions/category/create-category-action.ts` | session 비교 추가 |
+| `src/actions/invitation/delete-invitation-action.ts` | entity ownership 검증 추가 |
+
+## Out of Scope
+
+- 다른 Action audit (이미 표준 패턴 준수) — phase-03 grep 으로 확인만
+- backend 측 권한 검증 강화 (별도 backend issue)
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `getActiveInvitations` 반환 타입에 `uuid` 필드 없음 | 구현 시 type 확인 후 필요 시 InvitationInfoData 구조 활용. 대안: `getInvitationInfo(token)` (token 기반) 은 부적합 (uuid 입력) |
+| category/create 호출처가 다른 가족 UUID 를 의도적으로 전달하는 케이스 (admin 시나리오) | 현재 그런 호출처 없음 (`grep -rn 'createCategoryAction' src` 확인). 향후 admin 기능 추가 시 별도 권한 도입 |
+| `getActiveInvitations()` 추가 페치로 invitation 삭제 latency ↑ | invitation 삭제는 빈번 작업 아님 (가끔). cost 무시 가능 |

--- a/tasks/plan023-server-action-permission-audit/phase-03.md
+++ b/tasks/plan023-server-action-permission-audit/phase-03.md
@@ -1,0 +1,90 @@
+# Phase 03 — 통합 검증 + 전체 audit grep + status="completed"
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase-01 + phase-02 통합 검증. 모든 가족 식별자 다루는 Action 이 ADR-F25 3 패턴 중 하나를 명시하는지 일괄 grep 으로 확인. `index.json` status 마킹 + commit.
+
+## 작업 항목
+
+### 1. 통합 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan023-server-action-permission-audit
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test:ci
+```
+
+### 2. 전체 Action audit grep
+
+각 가족 식별자 다루는 Action 이 3 패턴 중 하나를 사용하는지 확인:
+
+```bash
+# Single-family 패턴 (A): session 비교 또는 getSelectedFamilyUuid 단독
+echo "=== Pattern A (Single-family) ==="
+grep -lE 'sessionFamilyUuid|getSelectedFamilyUuid' src/actions/{expense,income,category}/*.ts | sort
+
+# Multi-family 패턴 (B): assertFamilyAccess
+echo "=== Pattern B (Multi-family) ==="
+grep -lE 'assertFamilyAccess' src/actions/**/*.ts | sort
+
+# Entity ownership 패턴 (C): entity 조회 후 some 검증
+echo "=== Pattern C (Entity ownership) ==="
+grep -lE 'getActiveInvitations|some\(.*\)' src/actions/invitation/*.ts | sort
+
+# 누락 후보: requireAuth 만 있고 familyUuid 도 받는 Action
+echo "=== 누락 후보 (수동 점검 필요) ==="
+for f in src/actions/**/*.ts; do
+  if grep -q 'familyUuid' "$f" && \
+     ! grep -qE 'getSelectedFamilyUuid|assertFamilyAccess|some\(' "$f"; then
+    echo "  - $f"
+  fi
+done
+```
+
+누락 후보 결과가 있으면 사용자에게 보고 (이번 plan 범위 밖이면 후속 plan 후보로 기록).
+
+### 3. 수동 smoke (구현자 책임)
+
+- `/settings` 가족 예산 수정 → 정상
+- 카테고리 생성 → 정상
+- 초대 링크 생성 → 삭제 → 정상
+- 기존 expense/income create/update/delete 회귀 없음
+
+### 4. 8단계 체크리스트 자체 점검
+
+| 단계 | 확인 |
+|---|---|
+| 1 구현가능성 | 기존 helper + service 재사용 ✅ |
+| 2 기술스택 | 변경 없음 ✅ |
+| 3 사용자흐름 | 동작 변경 없음, 보안만 강화 ✅ |
+| 4 UI | 변경 없음 ✅ |
+| 5 API | Action 시그니처 유지, category/create 의 prop fallback 만 제거 ✅ |
+| 6 아키텍처 | assertFamilyAccess helper 신설 + 3 Action 갱신 ✅ |
+| 7 ADR | ADR-F25 신설 (docs commit 포함) + CLAUDE.md 강화 ✅ |
+| 8 docs | adr.md + CLAUDE.md ✅ (flow.md 무변경) |
+
+### 5. `index.json` status 마킹 + commit
+
+```bash
+# index.json 의 "status": "pending" → "completed" (Edit tool)
+
+git add tasks/plan023-server-action-permission-audit/index.json
+git commit -m "chore(plan023): mark task completed"
+git push
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan023-server-action-permission-audit/index.json` | status=completed |
+
+## Out of Scope
+
+- backend 측 권한 검증 (별도 backend issue 후보)
+- 다른 plan task 의 상태 변경
+- 새 ADR 추가


### PR DESCRIPTION
## Summary

PR #271 (plan021) 리뷰에서 surfaced 된 \`updateFamilyAction\` 권한 검증 누락을 계기로, 가족 식별자 다루는 모든 Server Action 을 감사하고 표준 3-패턴을 정착시키는 plan.

### 감사 결과 (3 건 누락)

| Action | 누락 | 적용 패턴 |
|---|---|---|
| \`family/update\` | requireAuth 만 — 권한 검증 없음 | B. Multi-family (assertFamilyAccess) |
| \`category/create\` | familyUuid prop fallback 으로 session 무시 | A. Single-family (session 비교) |
| \`invitation/delete\` | invitationUuid entity 권한 검증 없음 | C. Entity ownership |

### 핵심 결정 (ADR-F25)

- **A. Single-family**: \`getSelectedFamilyUuid()\` + 입력 familyUuid 가 있으면 session 비교 (expense/income update/delete 패턴)
- **B. Multi-family**: \`assertFamilyAccess(familyUuid)\` helper 신설 — settings 처럼 본인 속한 여러 가족 다루는 Action
- **C. Entity ownership**: entity 조회 후 family 소속 확인

### docs 변경

- \`docs/adr.md\` — ADR-F25 신설
- \`CLAUDE.md\` — 금지사항 섹션 3 패턴 분류 명시 강화

### task 파일

- phase-01: assertFamilyAccess helper + family/update 적용
- phase-02: category/create session 비교 + invitation/delete entity 검증
- phase-03: 통합 검증 + 전체 audit grep + completed

## Test plan

구현 PR 검증 항목:

- [ ] \`pnpm lint\` / \`pnpm tsc --noEmit\` / \`pnpm build\` / \`pnpm test:ci\` 통과
- [ ] \`assertFamilyAccess\` helper 가 auth-helpers.ts 에 export
- [ ] \`family/update\` / \`category/create\` / \`invitation/delete\` 3 Action 에 패턴 적용 확인
- [ ] 다른 가족 UUID 주입 시 entityNotFound / 권한없음 error 반환 (devtools smoke)
- [ ] 기존 expense/income create/update/delete 회귀 없음
- [ ] 전체 audit grep — 누락 후보 0 또는 사용자 보고