### PR TITLE
feat(security): Server Action 권한 검증 3-패턴 표준화 (plan023)

### DIFF
--- a/src/__tests__/actions/family/update-family-action.test.ts
+++ b/src/__tests__/actions/family/update-family-action.test.ts
@@ -5,6 +5,7 @@
 // Mock 설정 - import 전에 선언
 jest.mock("@/lib/server/auth/auth-helpers", () => ({
   requireAuth: jest.fn().mockResolvedValue({ user: { id: "test-user" } }),
+  assertFamilyAccess: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@/lib/server/api/client", () => ({

--- a/src/actions/category/create-category-action.ts
+++ b/src/actions/category/create-category-action.ts
@@ -51,10 +51,18 @@ export async function createCategoryAction(
     }
     const validData = validationResult.data;
 
-    const selectedFamilyUuid = familyUuid || (await getSelectedFamilyUuid());
-    if (!selectedFamilyUuid) {
+    const sessionFamilyUuid = await getSelectedFamilyUuid();
+    if (!sessionFamilyUuid) {
       throw ActionError.familyNotSelected();
     }
+    if (familyUuid && familyUuid !== sessionFamilyUuid) {
+      throw ActionError.invalidInput(
+        "familyUuid",
+        familyUuid,
+        "권한이 없습니다"
+      );
+    }
+    const selectedFamilyUuid = sessionFamilyUuid;
 
     const category = await createCategory(selectedFamilyUuid, validData);
 

--- a/src/actions/category/create-category-action.ts
+++ b/src/actions/category/create-category-action.ts
@@ -51,6 +51,7 @@ export async function createCategoryAction(
     }
     const validData = validationResult.data;
 
+    // ADR-F25 패턴 A: Single-family — 입력 familyUuid 가 세션과 불일치 시 거부
     const sessionFamilyUuid = await getSelectedFamilyUuid();
     if (!sessionFamilyUuid) {
       throw ActionError.familyNotSelected();

--- a/src/actions/family/update-family-action.ts
+++ b/src/actions/family/update-family-action.ts
@@ -10,8 +10,8 @@ import {
   successResult,
   type ActionResult,
 } from "@/lib/errors";
-import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { getFamilies, updateFamily } from "@/services/family/family-service";
+import { requireAuth, assertFamilyAccess } from "@/lib/server/auth/auth-helpers";
+import { updateFamily } from "@/services/family/family-service";
 import type { Family, UpdateFamilyRequest } from "@/types/family";
 import { revalidatePath } from "next/cache";
 
@@ -30,11 +30,7 @@ export async function updateFamilyAction(
       );
     }
 
-    // 권한 검증: 사용자가 해당 family 멤버인지 확인 (백엔드가 세션 토큰 기준으로 본인 가족만 반환)
-    const families = await getFamilies();
-    if (!families.some((f) => f.uuid === familyUuid)) {
-      throw ActionError.entityNotFound("가족", familyUuid);
-    }
+    await assertFamilyAccess(familyUuid); // ADR-F25 패턴 B: Multi-family 권한 검증
 
     const family = await updateFamily(familyUuid, data);
 

--- a/src/actions/invitation/delete-invitation-action.ts
+++ b/src/actions/invitation/delete-invitation-action.ts
@@ -5,12 +5,19 @@
 "use server";
 
 import {
+  ActionError,
   handleActionError,
   successResult,
   type ActionResult,
 } from "@/lib/errors";
-import { requireAuth } from "@/lib/server/auth/auth-helpers";
-import { deleteInvitation } from "@/services/invitation/invitation-service";
+import {
+  getSelectedFamilyUuid,
+  requireAuth,
+} from "@/lib/server/auth/auth-helpers";
+import {
+  deleteInvitation,
+  getActiveInvitations,
+} from "@/services/invitation/invitation-service";
 import { revalidatePath } from "next/cache";
 
 export async function deleteInvitationAction(
@@ -18,6 +25,18 @@ export async function deleteInvitationAction(
 ): Promise<ActionResult<void>> {
   try {
     await requireAuth();
+
+    const familyUuid = await getSelectedFamilyUuid();
+    if (!familyUuid) {
+      throw ActionError.familyNotSelected();
+    }
+
+    // Entity ownership: 본인 가족의 active invitation 목록에 포함되는지 확인 (ADR-F25 패턴 C)
+    const active = await getActiveInvitations(familyUuid);
+    if (!active.some((inv) => inv.uuid === invitationUuid)) {
+      throw ActionError.entityNotFound("초대 링크", invitationUuid);
+    }
+
     await deleteInvitation(invitationUuid);
     revalidatePath("/");
     return successResult(undefined);

--- a/src/lib/server/auth/auth-helpers.ts
+++ b/src/lib/server/auth/auth-helpers.ts
@@ -72,6 +72,11 @@ export async function getSelectedFamilyUuid(): Promise<string | null> {
  *
  * Single-family Action 은 `getSelectedFamilyUuid()` 비교로 충분 — 본 helper 는
  * settings 처럼 본인 속한 여러 가족 중 하나를 다루는 Action 전용.
+ *
+ * 주의: `getFamilies()` 는 매 호출마다 백엔드 페치 (request 단위 캐시 미적용).
+ * 동일 request 안에서 다른 곳이 getFamilies 를 또 부르면 중복 왕복 발생 — 빈도
+ * 낮은 Action 권한 검증 용도라 현재는 React cache() 미사용. 호출 빈도가
+ * 높아지면 family-service 측에 cache() 도입 검토.
  */
 export async function assertFamilyAccess(familyUuid: string): Promise<void> {
   const families = await getFamilies();

--- a/src/lib/server/auth/auth-helpers.ts
+++ b/src/lib/server/auth/auth-helpers.ts
@@ -5,6 +5,7 @@
 
 import { ActionError } from "@/lib/errors";
 import { getCachedSession } from "@/lib/server/cache";
+import { getFamilies } from "@/services/family/family-service";
 import type { Session } from "next-auth";
 import { redirect } from "next/navigation";
 
@@ -63,4 +64,18 @@ export async function requireAuthOrRedirect(
 export async function getSelectedFamilyUuid(): Promise<string | null> {
   const session = await getCachedSession();
   return session?.user?.profile?.defaultFamilyUuid ?? null;
+}
+
+/**
+ * Multi-family 패턴 권한 검증 (ADR-F25 패턴 B).
+ * 사용자가 해당 family 의 member 인지 확인. 미소속 시 entityNotFound throw.
+ *
+ * Single-family Action 은 `getSelectedFamilyUuid()` 비교로 충분 — 본 helper 는
+ * settings 처럼 본인 속한 여러 가족 중 하나를 다루는 Action 전용.
+ */
+export async function assertFamilyAccess(familyUuid: string): Promise<void> {
+  const families = await getFamilies();
+  if (!families.some((f) => f.uuid === familyUuid)) {
+    throw ActionError.entityNotFound("가족", familyUuid);
+  }
 }

--- a/tasks/plan023-server-action-permission-audit/index.json
+++ b/tasks/plan023-server-action-permission-audit/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan023-server-action-permission-audit",
   "description": "Server Action 권한 검증 일괄 감사 + 표준 3-패턴 정착 (ADR-F25). assertFamilyAccess helper 신설 + family/update / category/create / invitation/delete 3 곳의 권한 검증 강화. PR #271 리뷰에서 surfaced 된 패턴 누락 해소.",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-20",
   "total_phases": 3,
   "related_docs": [
@@ -19,21 +19,21 @@
       "file": "phase-01.md",
       "title": "assertFamilyAccess helper 신설 + family/update 적용 (Multi-family 패턴 B)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "category/create session 비교 (패턴 A) + invitation/delete entity ownership (패턴 C)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "통합 검증 + 전체 audit grep + 8단계 체크리스트 + status=completed",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "planning_checklist": {

--- a/tasks/plan023-server-action-permission-audit/phase-01.md
+++ b/tasks/plan023-server-action-permission-audit/phase-01.md
@@ -6,8 +6,9 @@
 
 ## Context (자기완결)
 
-- 현재 `src/actions/family/update-family-action.ts` (43 줄): `requireAuth()` 만 수행 → 권한 상승 위험 (PR #271 리뷰 지적)
-- `src/lib/server/auth/auth-helpers.ts` (L1~75 추정): `requireAuth` / `requireAuthOrRedirect` / `getSelectedFamilyUuid` exports
+- 현재 `src/actions/family/update-family-action.ts` (49 줄): plan021 phase-02 의 후속 작업으로 이미 inline `families.some((f) => f.uuid === familyUuid)` 검증이 적용된 상태 (L34-38).
+- 본 phase 의 실제 작업: **inline 검증을 `assertFamilyAccess(familyUuid)` helper 로 추출** — 다른 Multi-family Action 에서도 재사용 가능하게 표준화 (ADR-F25 패턴 B).
+- `src/lib/server/auth/auth-helpers.ts`: `requireAuth` / `requireAuthOrRedirect` / `getSelectedFamilyUuid` exports
 - `src/services/family/family-service.ts:21-23` 의 `getFamilies()` 가 백엔드 세션 token 기준으로 본인 가족만 반환 (이미 신뢰 경계). list 안에 familyUuid 가 있으면 권한 증거
 - `selectFamily` (L36-43) 의 검증 패턴이 모델 — `families.some(f => f.uuid === familyUuid)` + throw `ActionError.entityNotFound`
 
@@ -37,37 +38,41 @@ export async function assertFamilyAccess(familyUuid: string): Promise<void> {
 
 import 위치는 기존 파일의 import 블록 끝. export 도 기존 패턴 따름.
 
-### 2. `src/actions/family/update-family-action.ts` 갱신
+### 2. `src/actions/family/update-family-action.ts` 갱신 — inline 검증을 helper 호출로 교체
 
+변경 전 (현재 L13 + L34-38):
 ```ts
-import { requireAuth, assertFamilyAccess } from "@/lib/server/auth/auth-helpers";
-// 기존 import 유지
+import { requireAuth } from "@/lib/server/auth/auth-helpers";
+import { getFamilies, updateFamily } from "@/services/family/family-service";
+// ...
+await requireAuth();
 
-export async function updateFamilyAction(
-  familyUuid: string,
-  data: UpdateFamilyRequest
-): Promise<ActionResult<Family>> {
-  try {
-    await requireAuth();
+if (!familyUuid) {
+  throw ActionError.invalidInput("가족 UUID", familyUuid, "UUID는 필수입니다");
+}
 
-    if (!familyUuid) {
-      throw ActionError.invalidInput("가족 UUID", familyUuid, "UUID는 필수입니다");
-    }
-
-    await assertFamilyAccess(familyUuid);   // ← 추가
-
-    const family = await updateFamily(familyUuid, data);
-    revalidatePath("/");
-    revalidatePath("/settings");
-    revalidatePath(`/families/${familyUuid}`);
-    return successResult(family);
-  } catch (error) {
-    return handleActionError(error, "가족 정보 수정에 실패했습니다");
-  }
+// 권한 검증: 사용자가 해당 family 멤버인지 확인 (백엔드가 세션 토큰 기준으로 본인 가족만 반환)
+const families = await getFamilies();
+if (!families.some((f) => f.uuid === familyUuid)) {
+  throw ActionError.entityNotFound("가족", familyUuid);
 }
 ```
 
-기존 동작 보존 — `requireAuth` 유지, `familyUuid` null check 유지, revalidate 경로 동일. 검증 1줄만 추가.
+변경 후:
+```ts
+import { requireAuth, assertFamilyAccess } from "@/lib/server/auth/auth-helpers";
+import { updateFamily } from "@/services/family/family-service";   // getFamilies import 제거
+// ...
+await requireAuth();
+
+if (!familyUuid) {
+  throw ActionError.invalidInput("가족 UUID", familyUuid, "UUID는 필수입니다");
+}
+
+await assertFamilyAccess(familyUuid);   // ← inline 검증을 helper 호출로 교체
+```
+
+기존 동작 보존 — `requireAuth` 유지, `familyUuid` null check 유지, revalidate 경로 동일. `getFamilies` 직접 import 제거 (helper 내부로 이동).
 
 ### 3. 자동 verification
 
@@ -85,6 +90,9 @@ grep -n 'export async function assertFamilyAccess' \
 
 # updateFamilyAction 적용
 grep -n 'assertFamilyAccess' src/actions/family/update-family-action.ts | wc -l   # >= 1
+
+# update-family-action 의 inline 검증 (getFamilies 직접 호출) 제거 확인
+! grep -n 'getFamilies' src/actions/family/update-family-action.ts
 ```
 
 수동 smoke:

--- a/tasks/plan023-server-action-permission-audit/phase-02.md
+++ b/tasks/plan023-server-action-permission-audit/phase-02.md
@@ -60,7 +60,7 @@ const selectedFamilyUuid = sessionFamilyUuid;
 
 세션 가족 UUID 를 단일 진실 소스로. prop 은 옵션 (호환성 유지) 이지만 세션과 불일치 시 reject.
 
-호출처 영향: 기존 호출처에서 `familyUuid` 가 항상 세션과 일치하면 동작 변경 없음. 불일치 케이스가 있다면 호출처에서 prop 제거 또는 일치하는 값 전달 (구현 시 grep 으로 호출처 확인 + 필요 시 정리).
+호출처 영향: `src/app/(authenticated)/categories/page.tsx` 가 `getSelectedFamilyAction()` 의 server-side 결과를 `CategoryPageClient → AddCategoryDialog → createCategoryAction` 으로 전달 (정상 사용 시 항상 session 과 일치). devtools 로 다른 가족 UUID 를 prop 주입하는 케이스만 차단됨. 호출처 코드 변경 불필요 — `familyUuid` prop 유지.
 
 ### 2. `deleteInvitationAction` entity ownership (패턴 C)
 
@@ -75,7 +75,10 @@ import {
   successResult,
   type ActionResult,
 } from "@/lib/errors";
-import { requireAuth } from "@/lib/server/auth/auth-helpers";
+import {
+  getSelectedFamilyUuid,
+  requireAuth,
+} from "@/lib/server/auth/auth-helpers";
 import {
   deleteInvitation,
   getActiveInvitations,
@@ -88,8 +91,13 @@ export async function deleteInvitationAction(
   try {
     await requireAuth();
 
+    const familyUuid = await getSelectedFamilyUuid();
+    if (!familyUuid) {
+      throw ActionError.familyNotSelected();
+    }
+
     // Entity ownership: 본인 가족의 active invitation 목록에 포함되는지 확인
-    const active = await getActiveInvitations();
+    const active = await getActiveInvitations(familyUuid);
     if (!active.some((inv) => inv.uuid === invitationUuid)) {
       throw ActionError.entityNotFound("초대 링크", invitationUuid);
     }
@@ -103,9 +111,9 @@ export async function deleteInvitationAction(
 }
 ```
 
-`getActiveInvitations` 는 백엔드가 세션 기준 본인 가족의 invitation 만 반환 (이미 신뢰 경계) → list 에 있다는 사실이 권한 증거. 다른 가족 invitation UUID 주입 시 `entityNotFound`.
+`getActiveInvitations(familyUuid: string)` 는 백엔드가 세션 + 가족 기준 본인 가족의 invitation 만 반환 (이미 신뢰 경계) → list 에 있다는 사실이 권한 증거. 다른 가족 invitation UUID 주입 시 `entityNotFound`. 시그니처 확인 (`src/services/invitation/invitation-service.ts:47`) — familyUuid 필수 인자.
 
-`getActiveInvitations` 의 반환 타입에 `uuid` 필드가 없으면 `getInvitationsByFamily(familyUuid)` 같은 대안 helper 검토 — 구현 시 service signature 확인.
+`InvitationInfo` 타입에 `uuid` 필드 존재 (`src/types/invitation*.ts` 확인 완료).
 
 ### 3. 자동 verification
 
@@ -152,6 +160,6 @@ grep -nE 'getActiveInvitations|entityNotFound.*invitation|some.*invitationUuid' 
 
 | 리스크 | 완화 |
 |---|---|
-| `getActiveInvitations` 반환 타입에 `uuid` 필드 없음 | 구현 시 type 확인 후 필요 시 InvitationInfoData 구조 활용. 대안: `getInvitationInfo(token)` (token 기반) 은 부적합 (uuid 입력) |
-| category/create 호출처가 다른 가족 UUID 를 의도적으로 전달하는 케이스 (admin 시나리오) | 현재 그런 호출처 없음 (`grep -rn 'createCategoryAction' src` 확인). 향후 admin 기능 추가 시 별도 권한 도입 |
+| `getActiveInvitations` 시그니처 (`familyUuid: string` 필수) | 확인 완료 — service:47. action 내부에서 `getSelectedFamilyUuid()` 호출 후 인자 전달. `InvitationInfo.uuid` 필드 존재 확인 완료 |
+| category/create 호출처가 다른 가족 UUID 를 의도적으로 전달하는 케이스 (admin 시나리오) | 호출처 (page.tsx → CategoryPageClient → AddCategoryDialog) 가 모두 server-side `getSelectedFamilyAction()` 결과만 전달 — 정상 사용 시 일치. 향후 admin 기능 추가 시 별도 권한 도입 |
 | `getActiveInvitations()` 추가 페치로 invitation 삭제 latency ↑ | invitation 삭제는 빈번 작업 아님 (가끔). cost 무시 가능 |

--- a/tasks/plan023-server-action-permission-audit/phase-03.md
+++ b/tasks/plan023-server-action-permission-audit/phase-03.md
@@ -33,7 +33,7 @@ grep -lE 'assertFamilyAccess' src/actions/**/*.ts | sort
 
 # Entity ownership 패턴 (C): entity 조회 후 some 검증
 echo "=== Pattern C (Entity ownership) ==="
-grep -lE 'getActiveInvitations|some\(.*\)' src/actions/invitation/*.ts | sort
+grep -lE 'getActiveInvitations|\.some\(\(.+\) => .+\.uuid ===' src/actions/invitation/*.ts | sort
 
 # 누락 후보: requireAuth 만 있고 familyUuid 도 받는 Action
 echo "=== 누락 후보 (수동 점검 필요) ==="


### PR DESCRIPTION
## Summary

ADR-F25 의 3 패턴 (Single-family / Multi-family / Entity ownership) 을 가족 식별자 다루는 Server Action 에 일괄 적용.
PR #271 리뷰에서 surfaced 된 권한 검증 누락 3 건을 해소하고, 향후 신규 Action 작성 시 3 패턴 자체 점검의 표준이 되도록 정착.

### 변경

| Action | 패턴 | 변경 |
|---|---|---|
| `update-family-action` | **B. Multi-family** | inline `getFamilies().some(...)` 검증 → `assertFamilyAccess(familyUuid)` helper 호출로 교체 |
| `create-category-action` | **A. Single-family** | `familyUuid || getSelectedFamilyUuid()` fallback 제거 → session 단일 소스 + 불일치 reject |
| `delete-invitation-action` | **C. Entity ownership** | `getActiveInvitations(familyUuid)` 목록 포함 여부로 invitationUuid 권한 검증 |

신규 helper: `src/lib/server/auth/auth-helpers.ts` — `assertFamilyAccess(familyUuid)` (Multi-family 전용)

### 보안 효과

클라이언트가 본인 속하지 않은 가족 UUID 를 prop / formData 로 주입하면 `entityNotFound` 또는 "권한이 없습니다" error 로 차단. 정상 사용 (server-side `getSelectedFamilyAction()` 결과 전달) 시 동작 변경 없음.

### Pipeline (build-with-teams)

- critic v2 APPROVE (v1 REVISE 3 건 — phase-02 컴파일 실패 + phase-01 misdescription + 호출처 영향 — 모두 해소)
- executor: phase-01/02/03 순차 실행 (test mock 1 건 보강 — `assertFamilyAccess` 도입 대응)
- code-reviewer: APPROVE (LOW 1 건 — 중복 타입 주석 — team-lead 직접 정리)
- docs-verifier: PASS (ADR-F04/F06/F25 + 문서 부패 모두 PASS)

### 후속 plan 후보 (audit grep 으로 발견)

현재 `requireAuth` 만 있고 frontend 이중 권한 검증이 없는 Action 3 건:

- `src/actions/family/get-family-by-id-action.ts`
- `src/actions/family/select-family-action.ts`
- `src/actions/user/set-default-family-action.ts`

backend 가 세션 token 기준 단방어 중. 별도 plan 분리 권장.

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm build` — ✓ 15/15 pages
- [x] `pnpm test:ci` — 33 suites / 242 tests pass
- [x] audit grep — 패턴 A 12 / B 1 / C 2 분류 확인
- [ ] devtools 로 다른 가족 UUID 주입 시 차단되는지 수동 smoke (PR 리뷰어 확인)