### PR TITLE
docs(plan022): gradient-fg 시맨틱 토큰 완전 정착 task

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -413,8 +413,13 @@
   - `text-white` 유지: ADR-F13 의 "globals.css `@theme` 외부에서 hex/rgb/hsl/named 색 금지" 원칙 위반. 디자인 토큰 단일 소스 깨짐.
   - `text-bg` (surface foreground): light/dark 가 반전되는 토큰이라 강조 배경 위 가독성 일관성 깨짐 (dark mode 에서 어두운 색 → expense 빨강 위 contrast 약화).
   - 인라인 `style={{ color: "white" }}`: ADR-F13 위반 + CLAUDE.md "인라인 style 최소화" 위반.
-- **트레이드오프**: 토큰 수 증가 (현재 brand-fg / expense-fg 신설, income-fg / warning-fg 는 필요 시 후속 추가). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
-- **적용 범위**: `src/app/globals.css` (`--color-brand-fg` / `--color-expense-fg` 정의) + `src/components/notifications/NotificationBell.tsx` (`text-expense-fg`) + `src/components/layout/Header.tsx` (`text-brand-fg` — 로고 아이콘 + AvatarFallback) + `src/app/providers.tsx` (`text-brand-fg` — sonner actionButton). 향후 강조 배경 위 텍스트가 필요한 모든 위치 (Badge / Toast destructive variant / 그래프 강조 라벨 등) 에 동일 원칙 적용.
+- **트레이드오프**: 토큰 수 증가 (brand-fg / expense-fg / income-fg / warning-fg 4 종). 단 ADR-F13 의 정합성 + dark mode 가독성 일관성 이득이 큼.
+- **적용 범위 (plan022 완전 정착)**: `src/app/globals.css` 4 토큰 정의 + 51 호출처 일괄 마이그레이션. **매핑 룰**:
+  - `gradient-budget` / `gradient-family` / `gradient-primary` / `gradient-category` / `bg-brand-*` 위 → `text-brand-fg`
+  - `gradient-expense` / `bg-expense` / `bg-destructive` 위 → `text-expense-fg`
+  - `gradient-income` / `bg-income` 위 → `text-income-fg`
+  - `bg-warning` 위 → `text-warning-fg`
+  - gradient/배경이 surface (bg-bg-elev 등) 인 경우는 본 ADR 비대상 — 일반 `text-fg` 사용
 
 ---
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -407,7 +407,7 @@
 <a id="adr-f23"></a>
 
 ## ADR-F23: semantic foreground 토큰 (`--color-{semantic}-fg`) 으로 강조 배경 위 텍스트 색 명시
-- **결정**: `bg-expense` / `bg-income` / `bg-warning` 같은 채도 높은 시맨틱 배경 위에 텍스트를 얹을 때는 `text-white` / `text-black` 하드코딩 대신 **시맨틱 foreground 토큰** (`--color-expense-fg` 등) 을 사용한다. light/dark 양쪽에서 동일하게 강조 배경과 대비되는 near-white 값 (`oklch(0.985 0.003 230)`) 으로 정의 — surface `--color-fg` (light=어두움, dark=밝음) 와 분리.
+- **결정**: `bg-expense` / `bg-income` / `bg-warning` 같은 채도 높은 시맨틱 배경 위에 텍스트를 얹을 때는 `text-white` / `text-black` 하드코딩 대신 **시맨틱 foreground 토큰** (`--color-expense-fg` 등) 을 사용한다. light/dark 양쪽에서 동일하게 강조 배경과 대비되는 near-white 값 `oklch(0.985 0.003 <배경 hue>)` 으로 정의 — surface `--color-fg` (light=어두움, dark=밝음) 와 분리. **hue 통일 원칙**: foreground 토큰의 hue 는 항상 대응 배경 토큰과 일치 (시맨틱 일관성). plan017 의 임시 `expense-fg hue=230` 은 plan022 에서 hue=25 로 통일.
 - **맥락**: plan017 NotificationBell 의 `bg-expense text-white` Badge 가 ADR-F13 (OKLCH 토큰 강제, hex/rgb/hsl/named color 금지) 의 정신과 충돌. 단순 교체로 `text-bg` 같은 surface foreground 를 쓰면 dark mode 에서 `--color-bg` 가 어두운 색이 되어 빨간 expense 배경 위에서 가독성이 더 나빠짐. 강조 배경은 light/dark 무관하게 채도 유지가 의도이므로 foreground 도 모드 독립적 near-white 가 자연스럽다.
 - **대안 기각**:
   - `text-white` 유지: ADR-F13 의 "globals.css `@theme` 외부에서 hex/rgb/hsl/named 색 금지" 원칙 위반. 디자인 토큰 단일 소스 깨짐.

--- a/tasks/plan022-gradient-fg-tokens/index.json
+++ b/tasks/plan022-gradient-fg-tokens/index.json
@@ -1,0 +1,50 @@
+{
+  "name": "plan022-gradient-fg-tokens",
+  "description": "ADR-F23 완전 정착. income-fg / warning-fg 토큰 신설 + 51 호출처의 text-white 일괄 마이그레이션 (gradient/배경별 매핑 룰). PR #271 reply 에서 약속한 후속 plan.",
+  "status": "pending",
+  "created_at": "2026-05-20",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/adr.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration"
+  ],
+  "prerequisites": [
+    "ADR-F23 시맨틱 fg 토큰 원칙 정의 ✅",
+    "--color-brand-fg / --color-expense-fg 정의 ✅"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "globals.css 에 --color-income-fg / --color-warning-fg 토큰 추가",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "51 호출처의 text-white 일괄 마이그레이션 (매핑 룰 적용)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "text-white grep 0 검증 + 통합 검증 + status=completed",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "토큰 2 종 신설 + className 일괄 교체. 매핑 룰 명확 — 자동 grep-replace 가능. 회귀 위험은 gradient/배경 미식별 케이스 (text-white 가 OKLCH 토큰과 무관한 surface 위) 식별 필요.",
+    "2_tech_stack": "변경 없음. Tailwind v4 + globals.css @theme.",
+    "3_user_flow": "동작 변경 없음. 시각만 light/dark 일관성 ↑.",
+    "4_ui": "gradient 위 텍스트가 mode 독립적 near-white 유지. dark mode 에서도 강조 배경 contrast 동일.",
+    "5_api": "변경 없음.",
+    "6_arch": "globals.css 2 토큰 추가 + 20+ tsx 파일의 text-white → text-{brand,expense,income,warning}-fg 교체.",
+    "7_adr": "ADR-F23 적용 범위 갱신 (4 토큰 + 매핑 룰 명시) — 신규 ADR 아님.",
+    "8_docs": "ADR-F23 적용 범위 + 매핑 룰. flow.md 무변경."
+  }
+}

--- a/tasks/plan022-gradient-fg-tokens/phase-01.md
+++ b/tasks/plan022-gradient-fg-tokens/phase-01.md
@@ -1,0 +1,73 @@
+# Phase 01 — globals.css 에 income-fg / warning-fg 토큰 추가
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `--color-income-fg` 와 `--color-warning-fg` 토큰을 `src/app/globals.css` 에 추가. ADR-F23 4 토큰 (brand/expense/income/warning) 완전 정착의 기반.
+
+## Context (자기완결)
+
+- 현재 `src/app/globals.css` L19-24 의 semantic 토큰 영역:
+  ```css
+  --color-income:  oklch(0.610 0.150 152);
+  --color-expense: oklch(0.620 0.180 25);
+  --color-warning: oklch(0.760 0.150 78);
+  --color-expense-fg: oklch(0.985 0.003 230);
+  --color-brand-fg: oklch(0.985 0.003 188);
+  ```
+- 누락: `--color-income-fg` / `--color-warning-fg`
+- ADR-F23 원칙: near-white (`oklch(0.985 ...)`) 값 + hue 는 배경 색과 일치 (시맨틱 일관)
+
+## 작업 항목
+
+### 1. globals.css 토큰 2 종 추가
+
+L23-24 (expense-fg / brand-fg) 옆에 income-fg / warning-fg 추가:
+
+```css
+/* ── semantic ───────────────────────────────── */
+--color-income:  oklch(0.610 0.150 152);
+--color-expense: oklch(0.620 0.180 25);
+--color-warning: oklch(0.760 0.150 78);
+--color-expense-fg: oklch(0.985 0.003 25);   /* expense 위 near-white. hue=25 */
+--color-income-fg:  oklch(0.985 0.003 152);  /* income 위 near-white. hue=152 (income) */
+--color-warning-fg: oklch(0.985 0.003 78);   /* warning 위 near-white. hue=78 (warning) */
+--color-brand-fg:   oklch(0.985 0.003 188);  /* brand-500 위 near-white. hue=188 (brand) */
+```
+
+기존 `--color-expense-fg: oklch(0.985 0.003 230)` 의 hue=230 (cool gray) 도 hue=25 (expense) 로 통일 — 시맨틱 일관성. 단 값 차이가 미세 (chroma 0.003) 이므로 시각 영향 거의 없음 + ADR-F23 의 "hue 는 배경 색과 일치" 원칙 명시화.
+
+### 2. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan022-gradient-fg-tokens
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# 4 토큰 정의 확인
+grep -nE '--color-(brand|expense|income|warning)-fg:' src/app/globals.css | wc -l   # == 4
+```
+
+수동 smoke:
+- 빌드 후 색 토큰 누락 에러 없음
+- 기존 `text-expense-fg` (NotificationBell Badge) 회귀 없음 — chroma 0.003 차이는 시각 무영향
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/globals.css` | 2 토큰 추가 + expense-fg hue 조정 (230 → 25) |
+
+## Out of Scope
+
+- 51 호출처 마이그레이션 — phase-02
+- 다른 토큰 (cat-*-fg, surface) — 본 plan 범위 아님
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `oklch(0.985 0.003 25)` 의 hue=25 가 기존 `oklch(0.985 0.003 230)` 와 미세한 시각 차이 | chroma=0.003 매우 낮음 → 인지 불가. 빌드 후 NotificationBell smoke 로 확인 |
+| Tailwind v4 가 `text-income-fg` / `text-warning-fg` arbitrary class 인식 못 함 | `@theme` 블록 안 `--color-*` 정의는 Tailwind v4 가 자동 utility 생성. 미작동 시 `text-[var(--color-income-fg)]` 폴백 |

--- a/tasks/plan022-gradient-fg-tokens/phase-01.md
+++ b/tasks/plan022-gradient-fg-tokens/phase-01.md
@@ -69,5 +69,5 @@ grep -nE '--color-(brand|expense|income|warning)-fg:' src/app/globals.css | wc -
 
 | 리스크 | 완화 |
 |---|---|
-| `oklch(0.985 0.003 25)` 의 hue=25 가 기존 `oklch(0.985 0.003 230)` 와 미세한 시각 차이 | chroma=0.003 매우 낮음 → 인지 불가. 빌드 후 NotificationBell smoke 로 확인 |
+| `oklch(0.985 0.003 25)` 의 hue=25 가 기존 `oklch(0.985 0.003 230)` 와 미세한 시각 차이 | chroma=0.003 매우 낮음 → 인지 불가. **회귀 추적**: ADR-F23 의 "hue 통일 원칙" 갱신과 함께 기록 (plan017 hue=230 → plan022 hue=25 통일). 빌드 후 (a) NotificationBell expense Badge, (b) 다른 `text-expense-fg` 호출처 (있다면 grep 으로 식별) 의 visual smoke 로 확인 |
 | Tailwind v4 가 `text-income-fg` / `text-warning-fg` arbitrary class 인식 못 함 | `@theme` 블록 안 `--color-*` 정의는 Tailwind v4 가 자동 utility 생성. 미작동 시 `text-[var(--color-income-fg)]` 폴백 |

--- a/tasks/plan022-gradient-fg-tokens/phase-02.md
+++ b/tasks/plan022-gradient-fg-tokens/phase-02.md
@@ -1,0 +1,135 @@
+# Phase 02 — 51 호출처 text-white 일괄 마이그레이션
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: 51 개 `text-white` 호출처를 ADR-F23 매핑 룰에 따라 `text-{brand,expense,income,warning}-fg` 로 일괄 교체. surface 위 (bg-bg-elev 등) 의 text-white 는 본 ADR 비대상 — 회귀 방지를 위해 사용처별 컨텍스트 확인 후 교체.
+
+## Context (자기완결)
+
+### 매핑 룰 (ADR-F23)
+
+| 배경 패턴 | fg 토큰 |
+|---|---|
+| `gradient-budget` / `gradient-family` / `gradient-primary` / `gradient-category` / `bg-brand-*` / Avatar fallback brand | `text-brand-fg` |
+| `gradient-expense` / `bg-expense` / `bg-destructive` | `text-expense-fg` |
+| `gradient-income` / `bg-income` | `text-income-fg` |
+| `bg-warning` | `text-warning-fg` |
+| surface (`bg-bg-elev` / `bg-popover` 등) — 본 ADR 비대상 | 유지 또는 `text-fg` |
+
+### 51 호출처 분포 (sample)
+
+```
+src/components/ui/badge.tsx
+src/components/ui/button.tsx
+src/components/landing/LandingPage.tsx
+src/components/empty/EmptyState.tsx
+src/components/auth/SignInForm.tsx
+src/components/layout/BottomNavigation.tsx
+src/components/layout/Header.tsx
+src/components/expenses/forms/ExpenseFilters.tsx
+src/components/auth/AuthCenterCard.tsx
+src/components/dashboard/QuickActions.tsx
+src/components/dashboard/BudgetHeroCard.tsx
+src/components/transactions/dialogs/EditTransactionDialog.tsx
+src/components/error/ErrorBoundaryCard.tsx
+src/components/recurring-expense/RecurringExpenseList.tsx
+src/components/families/FamilySelector.tsx
+src/components/common/LoadingSpinner.tsx
+src/app/auth/signout/page.tsx
+src/app/(authenticated)/settings/_components/SettingsPageClient.tsx
+src/app/auth/error/page.tsx
+src/app/auth/signin/page.tsx
+```
+
+## 작업 항목
+
+### 1. 각 파일별 컨텍스트 확인 + 교체
+
+각 파일에서 `text-white` 가 어떤 배경 위에 있는지 ancestor className 확인 후 매핑 룰 적용. **일괄 sed 금지** — 컨텍스트 무관 교체 시 surface 위 text-white 도 변경되어 dark mode 회귀 위험.
+
+권장 도구: `mcp__plugin_oh-my-claudecode_t__ast_grep_replace` 또는 `mcp__plugin_oh-my-claudecode_t__ast_grep_search` 로 className 컨텍스트 추출.
+
+수동 grep 으로 빠른 확인:
+
+```bash
+# 각 파일별 text-white 와 인접 className 확인
+for f in $(grep -rln 'text-white' src --include='*.tsx'); do
+  echo "═══ $f ═══"
+  grep -nE 'text-white' "$f"
+done
+```
+
+### 2. 카테고리별 매핑 사례
+
+**brand-fg 적용** (gradient-budget / family / primary 위):
+- `BudgetHeroCard.tsx` L23: `gradient-primary ... text-white` → `text-brand-fg`
+- `SettingsPageClient.tsx` (gradient-primary Button) → `text-brand-fg`
+- `Header.tsx` 로고 아이콘 wrapper (이미 brand-fg 적용 — ADR-F23 적용 범위에 명시) → 회귀 점검만
+- `landing/LandingPage.tsx` Hero CTA → 배경 따라 결정
+- `auth/AuthCenterCard.tsx` aside → 배경 따라 결정
+
+**expense-fg 적용** (gradient-expense / bg-expense / destructive):
+- `ui/button.tsx` L13 `destructive: "bg-destructive text-white"` → `text-expense-fg`
+- `QuickActions.tsx` 의 expense gradient 버튼 → `text-expense-fg`
+- `ExpenseFilters.tsx` / `EditTransactionDialog.tsx` 의 expense 강조 → 케이스별
+
+**income-fg 적용**:
+- `QuickActions.tsx` 의 income gradient 버튼 → `text-income-fg`
+- `RecurringExpenseList.tsx` income 강조 부분
+
+**비대상 (text-white 유지 또는 text-fg)**:
+- `ui/badge.tsx` 의 default variant — surface 컨텍스트라 비대상 (단 className 분석 후 결정)
+- `LoadingSpinner.tsx` — bg 가 transparent / surface 면 비대상
+
+### 3. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan022-gradient-fg-tokens
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# text-white grep — ADR-F23 적용 범위 안 (gradient/bg-expense/bg-income/bg-warning 인접) 0
+# 단 surface 위 (bg-bg-elev 등) text-white 는 유지 가능
+grep -rn 'text-white' src/components src/app --include='*.tsx' | \
+  grep -v 'bg-bg-\|bg-popover\|bg-card\|bg-transparent' | wc -l   # << 5 (남으면 추가 검토)
+
+# fg 토큰 사용 횟수
+grep -rn 'text-brand-fg\|text-expense-fg\|text-income-fg\|text-warning-fg' \
+  src/components src/app --include='*.tsx' | wc -l   # >= 40
+```
+
+수동 smoke:
+- BudgetHeroCard (Dashboard) — Teal gradient + 흰 텍스트 자연 (light/dark 동일)
+- Auth signin/signout 페이지 — Hero 배경 위 텍스트 자연
+- Sign-out destructive 버튼 — expense red 위 흰 텍스트
+- Header 로고 + AvatarFallback — brand-500 위 흰 텍스트
+- BottomNavigation FAB — gradient 위 흰 텍스트
+- Dark mode 전환 — 모든 강조 텍스트 contrast 유지
+
+## Critical Files
+
+| 영역 | 파일 수 | 예상 매핑 |
+|---|---|---|
+| dashboard | 2 (BudgetHeroCard, QuickActions) | brand-fg + expense-fg + income-fg |
+| layout | 2 (Header, BottomNavigation) | brand-fg |
+| auth | 4 (SignInForm, AuthCenterCard, signin/signout/error pages) | brand-fg |
+| ui primitives | 2 (button.tsx, badge.tsx) | expense-fg (destructive), 케이스별 |
+| 기타 | 10+ | 케이스별 |
+
+## Out of Scope
+
+- 토큰 정의 (phase-01)
+- surface 위 text-white (text-fg 대체는 별도 plan 검토)
+- emoji / SVG 색상 변경
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| 컨텍스트 미식별로 surface 위 text-white 잘못 교체 | 각 파일 ancestor className 검토 후 교체. sed 일괄 금지. 의심 시 사용자 확인 |
+| Tailwind v4 가 새 token utility 미인식 | phase-01 build 검증 통과 시 안전. 미인식 시 `text-[var(--color-*-fg)]` 폴백 |
+| 51 파일 = 5 작업 한도 초과 | 카테고리별 묶음 (dashboard / layout / auth / ui / 기타) 5 묶음으로 처리. 항목 단위가 아닌 카테고리 단위 카운트 |
+| Button destructive variant 회귀 (AlertDialog) | 모든 AlertDialogAction 호출처 (plan020 의 4 곳) 가 destructive variant 사용 — 마이그레이션 후 회귀 smoke 필수 |

--- a/tasks/plan022-gradient-fg-tokens/phase-03.md
+++ b/tasks/plan022-gradient-fg-tokens/phase-03.md
@@ -1,0 +1,75 @@
+# Phase 03 — text-white grep 0 검증 + status="completed"
+
+**Model**: haiku
+**Status**: pending
+**Goal**: phase-01 + phase-02 통합 검증. 강조 배경 위 text-white 잔재 0 확인. `index.json` status 마킹.
+
+## 작업 항목
+
+### 1. 통합 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan022-gradient-fg-tokens
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test:ci
+
+# 4 fg 토큰 정의 확인
+grep -nE '--color-(brand|expense|income|warning)-fg:' src/app/globals.css | wc -l   # == 4
+
+# ADR-F23 적용 범위 안 text-white 0
+# (gradient / bg-expense / bg-income / bg-warning / bg-destructive 인접 text-white)
+echo "=== ADR-F23 위반 잔재 (수동 검토) ==="
+for f in $(grep -rln 'text-white' src --include='*.tsx'); do
+  if grep -E 'gradient-(budget|family|primary|category|expense|income)|bg-expense|bg-income|bg-warning|bg-destructive|bg-brand-' "$f" > /dev/null; then
+    echo "  검토: $f"
+    grep -nE 'text-white' "$f" | head -3
+  fi
+done
+```
+
+남은 잔재가 있으면 사용자에게 보고. surface 위 text-white (bg-bg-elev 등) 는 비대상으로 유지 가능.
+
+### 2. 수동 smoke (구현자 책임)
+
+- Dashboard: BudgetHeroCard / QuickActions 모든 카드
+- Auth: signin / signout / error 페이지 + AuthCenterCard
+- Header: 로고 + Avatar + dropdown
+- BottomNavigation: FAB + 활성 탭
+- 삭제 confirm: AlertDialog destructive variant 4 곳
+- 모든 화면 dark mode 전환 → contrast 일관
+
+### 3. 8단계 체크리스트
+
+| 단계 | 확인 |
+|---|---|
+| 1 구현가능성 | 토큰 2 종 추가 + className 일괄 교체 ✅ |
+| 2 기술스택 | 변경 없음 ✅ |
+| 3 사용자흐름 | 동작 변경 없음 ✅ |
+| 4 UI | gradient 위 텍스트 light/dark 일관 ✅ |
+| 5 API | 변경 없음 ✅ |
+| 6 아키텍처 | globals.css + 20+ tsx 파일 ✅ |
+| 7 ADR | ADR-F23 적용 범위 갱신 (4 토큰 + 매핑 룰) ✅ |
+| 8 docs | ADR-F23 ✅ |
+
+### 4. `index.json` status 마킹 + commit
+
+```bash
+git add tasks/plan022-gradient-fg-tokens/index.json
+git commit -m "chore(plan022): mark task completed"
+git push
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `tasks/plan022-gradient-fg-tokens/index.json` | status=completed |
+
+## Out of Scope
+
+- surface 위 text-white 대응 (별도 검토)
+- lint rule 도입 (text-white 차단)


### PR DESCRIPTION
## Summary

PR #271 (plan021) reply 에서 약속한 후속 plan. ADR-F23 의 시맨틱 foreground 토큰을 4 종 (brand/expense/income/warning) 완전 정착시키고 51 호출처 \`text-white\` 를 일괄 마이그레이션.

### 핵심 결정

- globals.css 2 토큰 신설: \`--color-income-fg\` / \`--color-warning-fg\` (brand-fg / expense-fg 는 이미 존재)
- ADR-F23 적용 범위 갱신: 4 토큰 + 매핑 룰 명시
- **매핑 룰**:
  - gradient-budget/family/primary/category + bg-brand-* → \`text-brand-fg\`
  - gradient-expense + bg-expense + bg-destructive → \`text-expense-fg\`
  - gradient-income + bg-income → \`text-income-fg\`
  - bg-warning → \`text-warning-fg\`
  - surface (bg-bg-elev 등) 위 text-white 는 비대상

### docs 변경

- \`docs/adr.md\` — ADR-F23 적용 범위 + 매핑 룰

### task 파일

- phase-01: globals.css 2 토큰 추가 + expense-fg hue 통일
- phase-02: 51 호출처 카테고리별 마이그레이션 (dashboard/layout/auth/ui/기타)
- phase-03: text-white grep 검증 + completed

## Test plan

구현 PR 검증 항목:

- [ ] \`pnpm lint\` / \`pnpm tsc --noEmit\` / \`pnpm build\` / \`pnpm test:ci\` 통과
- [ ] globals.css 에 4 fg 토큰 모두 정의
- [ ] ADR-F23 적용 범위 안 (gradient/bg-expense/income/warning/destructive 인접) text-white 잔재 0
- [ ] BudgetHeroCard / Auth / Header / BottomNavigation 모두 자연스러운 표시
- [ ] AlertDialog destructive variant 4 곳 (plan020) 회귀 없음
- [ ] Dark mode 전환 시 강조 텍스트 contrast 일관