### PR TITLE
docs(plan024): /categories 페이지 Teal 리디자인 task

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -456,6 +456,38 @@ AlertDialog:
 
 ---
 
+## 14-5. /categories 페이지 구조 (plan024)
+
+Teal 리디자인 + 인라인 style 제거 + Empty state 일관화.
+
+```
+[/categories (server)]
+    ├─ getSelectedFamilyAction() → familyUuid
+    └─ getFamilyCategoriesAction(familyUuid) → CategoryResponse[]
+        │
+        └─ CategoryPageClient (use client)
+                │
+                ├─ CategoriesHero (gradient-category Teal)
+                │   ├─ 가족명 + 총 카테고리 수
+                │   └─ 카테고리 추가 CTA
+                │
+                ├─ CategoryList (grid 2/3/4)
+                │   └─ CategoryItem
+                │       ├─ 아이콘 영역 정사각형 (w-10 h-10 / w-12 h-12)
+                │       ├─ 동적 색은 CSS variable (--cat-color)
+                │       └─ Edit / Delete (destructive variant, plan020)
+                │
+                └─ Empty → EmptyState 공용 (plan012)
+```
+
+핵심 변경:
+- CategoriesHero 신설 — settings/budget Hero 패턴 일관
+- `style={{ backgroundColor, color }}` 인라인 → `style={{ '--cat-color': color } as CSSProperties}` + Tailwind arbitrary class
+- 색 코드 oklch 문자열 노출 제거 (dot 미리보기만)
+- 사용 통계 (이번 달 지출 금액) — 별도 plan 후보
+
+---
+
 ## 15. /settings 페이지 구조 (plan021)
 
 ```

--- a/tasks/plan024-categories-redesign/index.json
+++ b/tasks/plan024-categories-redesign/index.json
@@ -1,0 +1,53 @@
+{
+  "name": "plan024-categories-redesign",
+  "description": "/categories 페이지 Teal 리디자인. CategoriesHero 신설 + CategoryItem 인라인 style → CSS variable + 색 코드 oklch 문자열 노출 제거 + 아이콘 정사각형 통일 + Empty state EmptyState 공용 재사용 (plan012).",
+  "status": "pending",
+  "created_at": "2026-05-20",
+  "total_phases": 3,
+  "related_docs": [
+    "docs/flow.md"
+  ],
+  "depends_on": [
+    "plan001-design-system-teal-migration",
+    "plan012-empty-error-loading-states",
+    "plan020-toast-alertdialog-polish"
+  ],
+  "prerequisites": [
+    "plan001 머지 ✅",
+    "plan012 EmptyState 컴포넌트 ✅ (src/components/empty/EmptyState.tsx)",
+    "plan020 (AlertDialog destructive variant 4 호출처) — 머지 후"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "CategoriesHero 신설 + page.tsx 갱신 (Teal Hero)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "CategoryItem CSS variable 패턴 + 색 코드 텍스트 제거 + 아이콘 정사각형",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "Empty state EmptyState 공용 재사용 + Dialog 토큰 점검 + 검증 + completed",
+      "model": "sonnet",
+      "status": "pending"
+    }
+  ],
+  "planning_checklist": {
+    "1_feasibility": "기존 데이터 (CategoryResponse[]) 그대로 사용. EmptyState 공용 컴포넌트 + CategoriesHero 신설. CSS variable 패턴은 Tailwind v4 arbitrary class 가 지원.",
+    "2_tech_stack": "변경 없음. shadcn Card + CSS variable + Server Action 유지.",
+    "3_user_flow": "CRUD 동작 변경 없음. 시각만 일관성 ↑.",
+    "4_ui": "CategoriesHero: 가족명 + 총 카테고리 수 (gradient-category 톤). CategoryItem: 정사각형 아이콘 + dot 미리보기만. Empty: EmptyState 공용. AddDialog/EditDialog: 토큰 점검.",
+    "5_api": "변경 없음.",
+    "6_arch": "CategoriesHero.tsx 신설 + CategoryItem CSS variable 적용 + EmptyState 재사용. page.tsx 헤더 영역 교체.",
+    "7_adr": "skip — 모두 기존 패턴 재사용 (Hero=Settings, CSS variable=ADR-F13 정신, EmptyState=plan012).",
+    "8_docs": "flow.md §14-5 신규 (/categories 구조 + 핵심 변경 4 가지)."
+  }
+}

--- a/tasks/plan024-categories-redesign/phase-01.md
+++ b/tasks/plan024-categories-redesign/phase-01.md
@@ -1,0 +1,171 @@
+# Phase 01 — CategoriesHero 신설 + page.tsx 갱신
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `CategoriesHero` 컴포넌트를 신설해 `/categories` 상단에 Teal gradient hero 카드 (가족명 + 총 카테고리 수) 표시. settings/budget Hero 패턴 일관.
+
+## Context (자기완결)
+
+- 현재 `src/app/(authenticated)/categories/page.tsx` (42 줄):
+  - L27-33: 단순 `<div><h1>카테고리 관리</h1><p>...</p></div>` 헤더
+  - L28: `container mx-auto py-6 px-4 max-w-4xl` wrapper
+- 현재 `CategoryPageClient.tsx` (96 줄):
+  - L59-71: "총 N개의 카테고리" 카운터 + 카테고리 추가 버튼 (CategoryPageClient 의 첫 row)
+- 참고 컴포넌트: `src/components/settings/SettingsHero.tsx` (plan021) 또는 `src/components/dashboard/BudgetHeroCard.tsx`
+
+## 작업 항목
+
+### 1. `src/components/categories/CategoriesHero.tsx` 신설
+
+```tsx
+import { Card } from "@/components/ui/card";
+import { FolderTree } from "lucide-react";
+
+interface CategoriesHeroProps {
+  familyName: string | null;
+  categoryCount: number;
+}
+
+export function CategoriesHero({ familyName, categoryCount }: CategoriesHeroProps) {
+  return (
+    <Card className="overflow-hidden border-0 gradient-category text-brand-fg">
+      <div className="p-5 md:p-6">
+        <p className="text-xs md:text-sm text-brand-fg/80 mb-1">카테고리 관리</p>
+        <h1 className="text-xl md:text-2xl font-bold mb-3">
+          {familyName ?? "가족"}
+          <span className="block text-sm md:text-base font-normal text-brand-fg/80 mt-0.5">
+            지출 카테고리를 추가, 수정, 삭제할 수 있습니다
+          </span>
+        </h1>
+        <div className="flex items-center gap-2 text-sm md:text-base">
+          <FolderTree className="w-4 h-4 text-brand-fg/80" />
+          <span className="font-num font-medium tabular-nums">{categoryCount}</span>
+          <span className="text-xs text-brand-fg/70">개 등록됨</span>
+        </div>
+      </div>
+    </Card>
+  );
+}
+```
+
+`gradient-category` 시맨틱 클래스 사용 (plan001). `text-brand-fg` (plan022) — Teal h=188 위 near-white.
+
+### 2. `page.tsx` 갱신 — 가족 정보 페치 + Hero 렌더
+
+```tsx
+// 변경 전 (L13-17)
+const familyResult = await getSelectedFamilyAction();
+if (!familyResult.success || !familyResult.data) {
+  redirect("/families/create");
+}
+const familyUuid = familyResult.data;
+
+// 변경 후 — 가족 객체 페치 (이름 표시용)
+const selectedFamily = await getSelectedFamilyAction();
+if (!selectedFamily.success || !selectedFamily.data) {
+  redirect("/families/create");
+}
+const familyUuid = selectedFamily.data;
+
+// getFamilyByIdAction (또는 getFamiliesAction + find) 로 가족 정보 페치
+import { getFamilyByIdAction } from "@/actions/family/get-family-by-id-action";
+
+const familyInfo = await getFamilyByIdAction(familyUuid);
+const familyName = familyInfo.success ? familyInfo.data.name : null;
+```
+
+`getFamilyByIdAction` 시그니처 확인 후 import. 없으면 `getFamiliesAction()` 결과에서 `find(f => f.uuid === familyUuid)` 로 대체.
+
+```tsx
+// L27-33 헤더 영역 교체
+<div className="container mx-auto py-6 px-4 max-w-4xl space-y-6">
+  <CategoriesHero
+    familyName={familyName}
+    categoryCount={categories.length}
+  />
+  <CategoryPageClient
+    initialCategories={categories}
+    familyUuid={familyUuid}
+    hasInitialError={hasError}
+  />
+</div>
+```
+
+이전 `mb-6` 헤더 div + CategoryPageClient 의 `mb-6` 카운터 row 통합 — Hero 가 카운터 역할 흡수.
+
+### 3. `CategoryPageClient.tsx` 갱신 — 카운터 row 제거
+
+L59-71 의 "총 N개의 카테고리" + "카테고리 추가" Button row 에서 카운터 텍스트 제거. 추가 버튼은 grid 위 우측 정렬로 유지:
+
+```tsx
+// 변경 전
+<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
+  <p className="text-sm text-fg-muted">
+    총 <span className="font-semibold text-fg">{categories.length}</span>개의 카테고리
+  </p>
+  <Button onClick={() => setAddDialogOpen(true)}>
+    <Plus className="w-4 h-4 mr-2" />
+    카테고리 추가
+  </Button>
+</div>
+
+// 변경 후 — 카운터는 Hero 에 있으니 추가 버튼만
+<div className="flex justify-end mb-4">
+  <Button onClick={() => setAddDialogOpen(true)}>
+    <Plus className="w-4 h-4 mr-2" />
+    카테고리 추가
+  </Button>
+</div>
+```
+
+### 4. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan024-categories-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# CategoriesHero 파일 존재
+test -f src/components/categories/CategoriesHero.tsx
+
+# CategoriesHero 호출
+grep -n 'CategoriesHero' src/app/\(authenticated\)/categories/page.tsx | wc -l   # >= 2
+
+# 카운터 텍스트 제거 (CategoryPageClient 에 "총 ... 카테고리" 패턴 없음)
+! grep -n '총.*개의 카테고리' src/app/\(authenticated\)/categories/_components/CategoryPageClient.tsx
+
+# 신 토큰 사용 (Hero)
+grep -nE 'gradient-category|text-brand-fg' src/components/categories/CategoriesHero.tsx | wc -l   # >= 2
+```
+
+수동 smoke:
+- /categories 접속 → 상단 Teal gradient Hero (가족명 + 카테고리 수)
+- 카테고리 0개 사용자 → "0개 등록됨" + Empty state (phase-03 에서 다룸)
+- 다크 모드 → gradient-category 자연
+- 모바일 (< 768px) → Hero padding 줄어들지만 정보 유지
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/components/categories/CategoriesHero.tsx` | 신규 |
+| `src/app/(authenticated)/categories/page.tsx` | 가족 정보 페치 + Hero 렌더 |
+| `src/app/(authenticated)/categories/_components/CategoryPageClient.tsx` | 카운터 텍스트 제거 |
+
+## Out of Scope
+
+- CategoryItem 인라인 style 정리 — phase-02
+- Empty state EmptyState 재사용 — phase-03
+- Dialog 토큰 점검 — phase-03
+- 사용 통계 (이번 달 지출 금액 등) — 별도 plan
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `getFamilyByIdAction` 시그니처 부재 또는 `ActionResult<Family>` 와 mismatch | 구현 시 import + 타입 확인. 없으면 `getFamiliesAction().data.find(...)` 패턴으로 대체 (이미 SettingsHero 가 동일 패턴) |
+| `gradient-category` 클래스가 globals.css 에 없음 | L230 에 존재 확인 됨 (`.gradient-category {...}`) ✅ |
+| `text-brand-fg` 토큰이 globals.css 에 없음 | plan022 phase-01 완료 후 정착. 본 plan 머지 시점에 plan022 가 미머지면 `text-white` fallback |

--- a/tasks/plan024-categories-redesign/phase-01.md
+++ b/tasks/plan024-categories-redesign/phase-01.md
@@ -67,14 +67,20 @@ if (!selectedFamily.success || !selectedFamily.data) {
 }
 const familyUuid = selectedFamily.data;
 
-// getFamilyByIdAction (또는 getFamiliesAction + find) 로 가족 정보 페치
-import { getFamilyByIdAction } from "@/actions/family/get-family-by-id-action";
+// ADR-F25 권한 검증 — 본인 소속 가족 목록에서 find 로 제한
+// getFamilyByIdAction(familyUuid) 직접 호출은 본 action 이 자체적으로
+// 사용자 소속 여부를 검증하지 않으므로 다른 가족 UUID 주입 시 정보 노출 위험.
+// getFamiliesAction() 결과는 본인 소속 가족만 반환하므로 find 로 안전하게 제한.
+import { getFamiliesAction } from "@/actions/family/get-families-action";
 
-const familyInfo = await getFamilyByIdAction(familyUuid);
-const familyName = familyInfo.success ? familyInfo.data.name : null;
+const familiesResult = await getFamiliesAction();
+const familyInfo = familiesResult.success
+  ? familiesResult.data.find((f) => f.uuid === familyUuid)
+  : null;
+const familyName = familyInfo?.name ?? null;
 ```
 
-`getFamilyByIdAction` 시그니처 확인 후 import. 없으면 `getFamiliesAction()` 결과에서 `find(f => f.uuid === familyUuid)` 로 대체.
+대안: `getFamilyByIdAction` 에 ADR-F25 패턴 (A) 권한 검증 (`getSelectedFamilyUuid()` 비교) 을 추가하는 경로도 가능하나, action 의 책임이 커지므로 page 측에서 `getFamiliesAction().find()` 로 제한하는 쪽이 단순. SettingsHero 가 동일 패턴.
 
 ```tsx
 // L27-33 헤더 영역 교체
@@ -166,6 +172,7 @@ grep -nE 'gradient-category|text-brand-fg' src/components/categories/CategoriesH
 
 | 리스크 | 완화 |
 |---|---|
-| `getFamilyByIdAction` 시그니처 부재 또는 `ActionResult<Family>` 와 mismatch | 구현 시 import + 타입 확인. 없으면 `getFamiliesAction().data.find(...)` 패턴으로 대체 (이미 SettingsHero 가 동일 패턴) |
+| `getFamilyByIdAction` 권한 검증 미명시 시 다른 가족 UUID 주입 가능 (ADR-F25 위반) — 인증된 사용자가 자신이 속하지 않은 가족 정보 열람 위험 | `getFamiliesAction()` (본인 소속만 반환) 결과에서 `find(f => f.uuid === familyUuid)` 로 제한. 본 phase 의 page 코드 스니펫이 이미 이 패턴 반영 |
+| `getFamiliesAction` 결과 타입과 `Family` 타입 mismatch | 구현 시 `getFamiliesAction()` 반환 타입 확인 (`ActionResult<Family[]>`). SettingsHero 가 동일 패턴이므로 참조 가능 |
 | `gradient-category` 클래스가 globals.css 에 없음 | L230 에 존재 확인 됨 (`.gradient-category {...}`) ✅ |
 | `text-brand-fg` 토큰이 globals.css 에 없음 | plan022 phase-01 완료 후 정착. 본 plan 머지 시점에 plan022 가 미머지면 `text-white` fallback |

--- a/tasks/plan024-categories-redesign/phase-02.md
+++ b/tasks/plan024-categories-redesign/phase-02.md
@@ -1,0 +1,167 @@
+# Phase 02 — CategoryItem CSS variable 패턴 + 색 코드 텍스트 제거 + 아이콘 정사각형
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `CategoryItem.tsx` 의 동적 카테고리 색을 인라인 `style={{ backgroundColor, color }}` 에서 CSS variable + Tailwind arbitrary class 패턴으로 마이그레이션. 색 코드 oklch 문자열 노출 제거. 아이콘 영역 정사각형 통일.
+
+## Context (자기완결)
+
+- 현재 `src/app/(authenticated)/categories/_components/CategoryItem.tsx` (98 줄):
+  - L15-23: `withAlpha` helper (oklch alpha 변형 + hex fallback)
+  - L36-43: 아이콘 영역 — `w-10 h-8 md:w-12 md:h-12` (mobile 정사각형 아님!) + 인라인 style
+  - L70-73: mobile 색 dot — 인라인 style
+  - L86-92: desktop 색 dot + `{category.color}` oklch 문자열 노출
+- ADR-F13: hex/rgb/hsl 직접 작성 금지 — 단 사용자 정의 동적 색은 예외 (DB 저장 값). CSS variable 로 캡슐화
+
+## 작업 항목
+
+### 1. CSS variable 패턴 적용 + withAlpha helper 제거
+
+```tsx
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { CategoryResponse } from "@/types/category";
+import { Edit2, EyeOff, Trash2 } from "lucide-react";
+import type { CSSProperties } from "react";
+
+interface CategoryItemProps {
+  category: CategoryResponse;
+  onEdit: (category: CategoryResponse) => void;
+  onDelete: (category: CategoryResponse) => void;
+}
+
+export function CategoryItem({ category, onEdit, onDelete }: CategoryItemProps) {
+  // 동적 사용자 색 — CSS variable 로 캡슐화 (ADR-F13 정신)
+  const colorStyle = {
+    "--cat-color": category.color ?? "var(--color-brand-500)",
+  } as CSSProperties;
+
+  return (
+    <Card className="hover:shadow-md transition-shadow" style={colorStyle}>
+      <CardContent className="px-2 md:p-4">
+        <div className="flex flex-col justify-between h-full gap-2 md:gap-3">
+          <div className="flex items-start justify-between">
+            {/* 아이콘 영역 — 정사각형 통일, color-mix 로 alpha 적용 */}
+            <div
+              className="w-10 h-10 md:w-12 md:h-12 rounded-lg flex items-center justify-center text-xl md:text-2xl shrink-0
+                         bg-[color-mix(in_srgb,var(--cat-color)_16%,transparent)]
+                         text-[var(--cat-color)]"
+            >
+              {category.icon}
+            </div>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 md:h-8 md:w-8"
+                onClick={() => onEdit(category)}
+              >
+                <Edit2 className="w-3 h-3 md:w-4 md:h-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 md:h-8 md:w-8"
+                onClick={() => onDelete(category)}
+              >
+                <Trash2 className="w-3 h-3 md:w-4 md:h-4 text-expense" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className="font-semibold text-sm md:text-base text-fg truncate">
+                {category.name}
+              </h3>
+
+              {/* mobile 색 dot */}
+              <div className="w-2.5 h-2.5 rounded-full shrink-0 md:hidden bg-[var(--cat-color)]" />
+
+              {category.excludeFromBudget && (
+                <Badge
+                  variant="secondary"
+                  className="text-[10px] px-1.5 py-0 h-5 gap-1 text-fg-muted w-fit whitespace-nowrap shrink-0"
+                >
+                  <EyeOff className="w-3 h-3" />
+                  <span className="hidden md:inline">예산 제외</span>
+                </Badge>
+              )}
+            </div>
+
+            {/* desktop 색 dot — 색 코드 텍스트 제거 (UX 노이즈) */}
+            <div className="hidden md:flex items-center gap-2 mt-1">
+              <div className="w-3 h-3 md:w-4 md:h-4 rounded-full bg-[var(--cat-color)]" />
+              <span className="text-xs text-fg-subtle">색</span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+### 변경 요약
+
+1. **`withAlpha` helper 제거** — `color-mix(in srgb, var(--cat-color) 16%, transparent)` 가 모든 색 포맷 (oklch/hex/rgb) 자동 처리
+2. **인라인 style 제거** — Card 의 `style={colorStyle}` 만 유지 (CSS variable 설정). 자식 요소들은 Tailwind arbitrary class
+3. **아이콘 영역 정사각형** — `w-10 h-8 md:w-12 md:h-12` → `w-10 h-10 md:w-12 md:h-12`
+4. **색 코드 텍스트 제거** — `{category.color}` (oklch 문자열) → "색" 라벨 (또는 dot 만 두고 라벨 자체 제거)
+5. **fallback 색** — `category.color` 가 null 일 때 `var(--color-brand-500)` 으로 안전한 기본
+
+### 2. 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan024-categories-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+
+# 인라인 style 사용 1회만 (CSS variable 설정만)
+grep -cE 'style=\{' src/app/\(authenticated\)/categories/_components/CategoryItem.tsx   # == 1
+
+# withAlpha helper 제거
+! grep -n 'withAlpha\|function withAlpha' \
+  src/app/\(authenticated\)/categories/_components/CategoryItem.tsx
+
+# CSS variable 사용
+grep -nE 'cat-color|color-mix' src/app/\(authenticated\)/categories/_components/CategoryItem.tsx | wc -l   # >= 3
+
+# oklch 문자열 노출 제거 ({category.color} 텍스트 표시 안 함)
+! grep -nE '\{category\.color\}' src/app/\(authenticated\)/categories/_components/CategoryItem.tsx
+
+# 아이콘 정사각형
+grep -n 'w-10 h-10' src/app/\(authenticated\)/categories/_components/CategoryItem.tsx | wc -l   # >= 1
+```
+
+수동 smoke:
+- 카테고리 카드 아이콘 영역 정사각형 (mobile/desktop 모두)
+- 동적 사용자 색이 정확히 표시 (16% 알파 배경 + 100% 색 아이콘 + dot)
+- 색 코드 oklch 문자열 미표시
+- 다크 모드 → `color-mix` 가 transparent 와 자연 합성
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/categories/_components/CategoryItem.tsx` | CSS variable + arbitrary class + 정사각형 + 색 코드 제거 |
+
+## Out of Scope
+
+- AddDialog / EditDialog 의 색상 picker UX — phase-03 에서 토큰 점검만
+- 카테고리 색 새 default 토큰 — 현재 그대로
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| Tailwind v4 가 `bg-[color-mix(...)]` arbitrary class 미인식 | Tailwind v4 가 임의 CSS expression 지원 — 미인식 시 `style={{ background: 'color-mix(...)' }}` 일부 분리 |
+| `color-mix(in srgb, ...)` 가 oklch 색과 호환 안 됨 | `srgb` 색공간이라 모든 색 포맷 자동 변환. ChromeBlue 등에서 검증 |
+| Card 의 `style={colorStyle}` 이 Card 컴포넌트 className 과 충돌 | shadcn Card 가 `className` + `style` 모두 forwardRef 통과 — 충돌 없음 |
+| `var(--cat-color)` 가 정의 안 되면 fallback 없음 | `category.color ?? "var(--color-brand-500)"` 명시 |

--- a/tasks/plan024-categories-redesign/phase-03.md
+++ b/tasks/plan024-categories-redesign/phase-03.md
@@ -1,0 +1,155 @@
+# Phase 03 — Empty state EmptyState 재사용 + Dialog 토큰 점검 + 검증 + completed
+
+**Model**: sonnet
+**Status**: pending
+**Goal**: `CategoryList.tsx` 의 Empty state 를 `plan012` 의 공용 `EmptyState` 컴포넌트로 교체. `AddCategoryDialog.tsx` / `EditCategoryDialog.tsx` 의 토큰 점검 (legacy 잔재). 통합 검증 + completed.
+
+## Context (자기완결)
+
+### Empty state 현재
+
+`src/app/(authenticated)/categories/_components/CategoryList.tsx` L55-66:
+```tsx
+if (categories.length === 0) {
+  return (
+    <Card>
+      <CardContent className="py-12">
+        <div className="text-center text-fg-muted">
+          <p className="text-lg mb-2">등록된 카테고리가 없습니다</p>
+          <p className="text-sm">카테고리를 추가해주세요</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+→ `src/components/empty/EmptyState.tsx` (plan012) 공용 컴포넌트로 교체.
+
+### Dialog 토큰 점검 대상
+
+`AddCategoryDialog.tsx` (192 줄) / `EditCategoryDialog.tsx` (195 줄):
+- legacy 토큰 (`bg-white/border-gray-/text-muted-foreground/text-gray-`) 잔재 확인
+- 색상 picker UX 변경 안 함 (기능 회귀 방지)
+
+## 작업 항목
+
+### 1. CategoryList Empty state 교체
+
+```tsx
+import { EmptyState } from "@/components/empty/EmptyState";
+import { FolderPlus } from "lucide-react";
+
+if (categories.length === 0) {
+  return (
+    <EmptyState
+      icon={FolderPlus}
+      title="등록된 카테고리가 없습니다"
+      description="카테고리를 추가해 가족의 지출을 관리해보세요"
+    />
+  );
+}
+```
+
+`EmptyState` 컴포넌트의 실제 prop 시그니처는 plan012 의 `src/components/empty/EmptyState.tsx` 확인 후 정확히 맞춘다. 예상 prop: `icon` (lucide), `title`, `description`, 선택적 `cta` (Button props).
+
+선택 사항: `cta` prop 이 있으면 "카테고리 추가" CTA 를 Empty state 안에 inline 으로 두는 것이 UX 우수. 단 페이지 우상단 "카테고리 추가" 버튼이 이미 있으므로 중복 시 제거 결정.
+
+### 2. AddCategoryDialog / EditCategoryDialog 토큰 점검
+
+```bash
+# legacy 토큰 잔재 확인
+grep -nE 'bg-white|border-gray-|text-muted-foreground|text-gray-|gradient-primary' \
+  src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx \
+  src/app/\(authenticated\)/categories/_components/EditCategoryDialog.tsx
+```
+
+발견된 legacy 토큰을 OKLCH 시맨틱으로 교체:
+- `bg-white` → `bg-bg-elev`
+- `border-gray-*` → `border-border`
+- `text-muted-foreground` → `text-fg-muted`
+- `text-gray-*` → `text-fg-muted` 또는 `text-fg-subtle`
+- `gradient-primary` (plan019/plan021 폐기) → `bg-brand-500` (단색)
+
+기능 변경 (색상 picker / Zod schema / form action) 없이 className 만 교체. 1:1 매핑.
+
+### 3. 통합 자동 verification
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+# branch: feat/plan024-categories-redesign
+
+pnpm lint
+pnpm tsc --noEmit
+pnpm build
+pnpm test:ci
+
+# EmptyState 사용
+grep -n 'EmptyState' src/app/\(authenticated\)/categories/_components/CategoryList.tsx | wc -l   # >= 1
+
+# Card empty wrapper 제거
+! grep -nE '등록된 카테고리가 없습니다.*<Card' \
+  src/app/\(authenticated\)/categories/_components/CategoryList.tsx
+
+# Dialog legacy 토큰 0
+! grep -nE 'bg-white|border-gray-|text-muted-foreground|text-gray-|gradient-primary' \
+  src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx \
+  src/app/\(authenticated\)/categories/_components/EditCategoryDialog.tsx
+
+# 신 토큰 사용
+grep -cE 'bg-bg-elev|border-border|text-fg-muted|bg-brand-500' \
+  src/app/\(authenticated\)/categories/_components/AddCategoryDialog.tsx \
+  src/app/\(authenticated\)/categories/_components/EditCategoryDialog.tsx
+```
+
+### 4. 수동 smoke
+
+- 카테고리 0개 사용자 → EmptyState 카드 (FolderPlus 아이콘 + 안내 문구) 표시
+- 카테고리 추가 → Dialog 열림 + 색상 picker + 저장 → Hero 카운터 증가
+- 카테고리 수정 → Dialog 열림 + 기존 값 pre-fill + 저장 → CategoryItem 즉시 갱신
+- 카테고리 삭제 → AlertDialog confirm → "삭제" expense red 버튼 (plan020) → 삭제 + toast
+- 다크 모드 → 모든 Dialog 자연
+
+### 5. 8단계 체크리스트
+
+| 단계 | 확인 |
+|---|---|
+| 1 구현가능성 | EmptyState 공용 + Tailwind v4 arbitrary class ✅ |
+| 2 기술스택 | 변경 없음 ✅ |
+| 3 사용자흐름 | CRUD 동작 보존 ✅ |
+| 4 UI | Hero + CategoryItem 토큰 + EmptyState + Dialog 토큰 ✅ |
+| 5 API | 변경 없음 ✅ |
+| 6 아키텍처 | CategoriesHero 신설 + EmptyState 재사용 ✅ |
+| 7 ADR | skip (기존 패턴 재사용) ✅ |
+| 8 docs | flow.md §14-5 ✅ |
+
+### 6. `index.json` status 마킹 + commit
+
+```bash
+git add tasks/plan024-categories-redesign/index.json
+git commit -m "chore(plan024): mark task completed"
+git push
+```
+
+## Critical Files
+
+| 파일 | 상태 |
+|---|---|
+| `src/app/(authenticated)/categories/_components/CategoryList.tsx` | EmptyState 재사용 |
+| `src/app/(authenticated)/categories/_components/AddCategoryDialog.tsx` | legacy 토큰 교체 |
+| `src/app/(authenticated)/categories/_components/EditCategoryDialog.tsx` | legacy 토큰 교체 |
+| `tasks/plan024-categories-redesign/index.json` | status=completed |
+
+## Out of Scope
+
+- 색상 picker 컴포넌트 신설 — 기존 유지
+- 카테고리 정렬 / 검색 — 별도 plan
+- 사용 통계 — 별도 plan
+
+## Risks
+
+| 리스크 | 완화 |
+|---|---|
+| `EmptyState` 컴포넌트 prop 시그니처가 예상과 다름 | 구현 시 실제 파일 확인 후 prop 정확히 맞춤 |
+| Dialog 안에 legacy 토큰이 광범위 (192~195 줄 파일) → 5 작업 항목 한도 위험 | className 1:1 교체는 단일 책임 작업으로 분류. 5 항목 카운트 시 (a) EmptyState 교체 (b) AddDialog 토큰 (c) EditDialog 토큰 (d) verification (e) commit |
+| `EmptyState` 안에 CTA prop 이 있으면 페이지 우상단 "카테고리 추가" 버튼과 중복 | Empty state 시점에는 페이지 우상단 버튼 1개로 충분. CTA inline 은 의도 — 둘 다 표시해도 정보 중복은 아님 (입구 2개) |


### PR DESCRIPTION
## Summary

/categories 페이지 Teal 시스템 정착 + 인라인 style 정리 plan.

### 핵심 결정

- CategoriesHero 신설 — settings/budget Hero 패턴 일관 (gradient-category, 가족명 + 총 카테고리 수)
- CategoryItem 인라인 style → CSS variable + Tailwind arbitrary class
  - \`style={{ backgroundColor: color, color }}\` → \`style={{ '--cat-color': color }} + bg-[color-mix(in_srgb,var(--cat-color)_16%,transparent)]\`
  - withAlpha helper 제거 (color-mix 가 모든 색 포맷 처리)
- 색 코드 oklch 문자열 노출 제거 (UX 노이즈)
- 아이콘 영역 정사각형 통일 (w-10 h-8 → w-10 h-10)
- Empty state → plan012 EmptyState 공용 재사용
- AddCategoryDialog / EditCategoryDialog legacy 토큰 점검 + OKLCH 교체

### docs 변경

- \`docs/flow.md\` — §14-5 신규 (/categories 구조)

### task 파일

- phase-01: CategoriesHero 신설 + page.tsx 갱신
- phase-02: CategoryItem CSS variable + 색 코드 제거 + 아이콘 정사각형
- phase-03: Empty state EmptyState 재사용 + Dialog 토큰 점검 + 검증 + completed

## Test plan

구현 PR 검증 항목:

- [ ] \`pnpm lint\` / \`pnpm tsc --noEmit\` / \`pnpm build\` / \`pnpm test:ci\` 통과
- [ ] CategoriesHero 파일 존재 + page.tsx 에서 렌더
- [ ] CategoryItem 인라인 style 1회만 (CSS variable 설정만) + withAlpha helper 제거
- [ ] \`{category.color}\` oklch 문자열 노출 제거
- [ ] 아이콘 영역 정사각형 (w-10 h-10 / w-12 h-12)
- [ ] EmptyState 공용 사용 (CategoryList)
- [ ] Dialog legacy 토큰 (bg-white / border-gray-* / text-muted-foreground) 0
- [ ] CRUD 동작 회귀 없음 (생성 / 수정 / 삭제 confirm)
- [ ] Dark mode 자연 전환