### PR TITLE
fix(transactions): 지출 추가 다이얼로그 배경 투명 문제 해결

### DIFF
--- a/src/app/(authenticated)/transactions/_components/ExpenseTabContent.tsx
+++ b/src/app/(authenticated)/transactions/_components/ExpenseTabContent.tsx
@@ -39,7 +39,7 @@ export function ExpenseTabContent({
       <DialogTrigger asChild>
         <Button className="gradient-expense hover:opacity-90 text-white">+ 지출 추가</Button>
       </DialogTrigger>
-      <DialogContent className="p-0 border-0 bg-transparent">
+      <DialogContent className="bg-bg-elev">
         <DialogTitle className="sr-only">지출 추가</DialogTitle>
         <AddExpenseForm
           categories={categories}


### PR DESCRIPTION
## Summary
- `ExpenseTabContent` 의 `DialogContent` 가 `bg-transparent border-0 p-0` 로 설정되어 있어, 자체 배경이 없는 `AddExpenseForm` 이 그대로 노출되면서 다이얼로그가 투명하게 보이던 문제 수정
- 같은 페이지의 `AddTransactionDialog` (수입/고정지출) 와 동일하게 `bg-bg-elev` 시맨틱 토큰으로 통일

## Test plan
- [ ] /transactions 의 지출 탭에서 "+ 지출 추가" 클릭 → 다이얼로그 배경이 정상 노출되는지 확인
- [ ] light/dark mode 모두 확인
- [ ] 수입·고정지출 다이얼로그와 시각적 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)