### PR TITLE
chore(deps): pnpm-lock.yaml duplicate mapping key 제거

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6129,15 +6129,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
-      '@typescript-eslint/types': 8.59.4
-      debug: 4.4.3
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.59.2':
     dependencies:
       '@typescript-eslint/types': 8.59.2


### PR DESCRIPTION
## 문제
PR #287 (`@typescript-eslint/parser` bump) 머지 결과로 `pnpm-lock.yaml` 에 동일한 키가 2번 등장:

\`\`\`
6123  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
6132  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':  ← 중복
\`\`\`

CI 의 pnpm 10.22.0 이 strict YAML 검증에서 `ERR_PNPM_BROKEN_LOCKFILE` 로 거부 → main 자체의 CI 실패 + 모든 작업 브랜치 (PR #279 등) CI 실패 유발.

## 변경 사항
완전히 동일한 내용의 2번째 entry 9줄만 제거. 의존성 버전 변경 없음 — 순수 lockfile 정리.

\`pnpm install --no-frozen-lockfile\` 로 재생성하면 lockfile 의 캐시된 resolved 가 우선시되어 `typescript-eslint` 가 `8.59.4` → `8.59.2` 로 다운그레이드되는 부작용이 있어, dependabot 의도를 보존하기 위해 수동 정리 방식 채택.

## 검증
- [x] `pnpm install --frozen-lockfile` 로컬 통과
- [x] `pnpm lint` 통과
- [x] `pnpm test:ci` 통과 (33 suites, 242 tests)

## 영향
머지 후 plan/024 등 fork-from-main 브랜치는 rebase 만으로 CI 회복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)