### PR TITLE
feat(categories): /categories 페이지 Teal 리디자인 (#plan024)

### DIFF
--- a/src/app/(authenticated)/categories/_components/CategoryItem.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryItem.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CategoryResponse } from "@/types/category";
 import { Edit2, EyeOff, Trash2 } from "lucide-react";
+import type { CSSProperties } from "react";
 
 interface CategoryItemProps {
   category: CategoryResponse;
@@ -12,33 +13,21 @@ interface CategoryItemProps {
   onDelete: (category: CategoryResponse) => void;
 }
 
-function withAlpha(color: string | undefined, a: number): string {
-  if (!color) return `oklch(0.510 0.110 188 / ${a})`;
-  if (color.startsWith("oklch(")) {
-    return color.replace(/(\s*\/\s*[\d.]+)?\)$/, ` / ${a})`);
-  }
-  // hex fallback: append 2-digit hex alpha (e.g. 0.16 → "29")
-  const hex = Math.round(a * 255).toString(16).padStart(2, "0");
-  return color + hex;
-}
-
 export function CategoryItem({
   category,
   onEdit,
   onDelete,
 }: CategoryItemProps) {
+  const colorStyle = {
+    "--cat-color": category.color ?? "var(--color-brand-500)",
+  } as CSSProperties;
+
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card className="hover:shadow-md transition-shadow" style={colorStyle}>
       <CardContent className="px-2 md:p-4">
         <div className="flex flex-col justify-between h-full gap-2 md:gap-3">
           <div className="flex items-start justify-between">
-            <div
-              className="w-10 h-8 md:w-12 md:h-12 rounded-lg flex items-center justify-center text-xl md:text-2xl shrink-0"
-              style={{
-                backgroundColor: withAlpha(category.color, 0.16),
-                color: category.color,
-              }}
-            >
+            <div className="w-10 h-10 md:w-12 md:h-12 rounded-lg flex items-center justify-center text-xl md:text-2xl shrink-0 bg-[color-mix(in_srgb,var(--cat-color)_16%,transparent)] text-[var(--cat-color)]">
               {category.icon}
             </div>
             <div className="flex gap-1">
@@ -67,10 +56,7 @@ export function CategoryItem({
                 {category.name}
               </h3>
 
-              <div
-                className="w-2.5 h-2.5 rounded-full shrink-0 md:hidden"
-                style={{ backgroundColor: category.color }}
-              />
+              <div className="w-2.5 h-2.5 rounded-full shrink-0 md:hidden bg-[var(--cat-color)]" />
 
               {category.excludeFromBudget && (
                 <Badge
@@ -84,11 +70,8 @@ export function CategoryItem({
             </div>
 
             <div className="hidden md:flex items-center gap-2 mt-1">
-              <div
-                className="w-3 h-3 md:w-4 md:h-4 rounded-full"
-                style={{ backgroundColor: category.color }}
-              />
-              <span className="text-xs text-fg-subtle">{category.color}</span>
+              <div className="w-3 h-3 md:w-4 md:h-4 rounded-full bg-[var(--cat-color)]" />
+              <span className="text-xs text-fg-subtle">색</span>
             </div>
           </div>
         </div>

--- a/src/app/(authenticated)/categories/_components/CategoryList.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryList.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { deleteCategoryAction } from "@/actions/category/delete-category-action";
-import { Card, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/empty/EmptyState";
 import type { CategoryResponse } from "@/types/category";
+import { FolderPlus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { CategoryItem } from "./CategoryItem";
@@ -54,14 +55,11 @@ export function CategoryList({
 
   if (categories.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-12">
-          <div className="text-center text-fg-muted">
-            <p className="text-lg mb-2">등록된 카테고리가 없습니다</p>
-            <p className="text-sm">카테고리를 추가해주세요</p>
-          </div>
-        </CardContent>
-      </Card>
+      <EmptyState
+        icon={FolderPlus}
+        title="등록된 카테고리가 없습니다"
+        description="카테고리를 추가해 가족의 지출을 관리해보세요"
+      />
     );
   }
 

--- a/src/app/(authenticated)/categories/_components/CategoryPageClient.tsx
+++ b/src/app/(authenticated)/categories/_components/CategoryPageClient.tsx
@@ -56,14 +56,7 @@ export function CategoryPageClient({
 
   return (
     <>
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
-        <p className="text-sm text-fg-muted">
-          총{" "}
-          <span className="font-semibold text-fg">
-            {categories.length}
-          </span>
-          개의 카테고리
-        </p>
+      <div className="flex justify-end mb-4">
         <Button onClick={() => setAddDialogOpen(true)}>
           <Plus className="w-4 h-4 mr-2" />
           카테고리 추가

--- a/src/app/(authenticated)/categories/page.tsx
+++ b/src/app/(authenticated)/categories/page.tsx
@@ -1,36 +1,38 @@
-/**
- * 카테고리 관리 페이지 - Server Component
- */
-
 import { CategoryPageClient } from "./_components/CategoryPageClient";
 import { getSelectedFamilyAction } from "@/actions/family/get-selected-family-action";
 import { getFamilyCategoriesAction } from "@/actions/category/get-categories-action";
+import { getFamiliesAction } from "@/actions/family/get-families-action";
+import { CategoriesHero } from "@/components/categories/CategoriesHero";
 import type { CategoryResponse } from "@/types/category";
 import { redirect } from "next/navigation";
 
 export default async function CategoriesPage() {
-  // 선택된 가족 UUID 가져오기
   const familyResult = await getSelectedFamilyAction();
   if (!familyResult.success || !familyResult.data) {
     redirect("/families/create");
   }
   const familyUuid = familyResult.data;
 
-  // 선택된 가족의 카테고리 목록 조회
-  const categoriesResult = await getFamilyCategoriesAction(familyUuid);
+  const [categoriesResult, familiesResult] = await Promise.all([
+    getFamilyCategoriesAction(familyUuid),
+    getFamiliesAction(),
+  ]);
+
   const categories: CategoryResponse[] = categoriesResult.success
     ? categoriesResult.data
     : [];
   const hasError = !categoriesResult.success;
 
+  const familyInfo = familiesResult.success
+    ? familiesResult.data.find((f) => f.uuid === familyUuid)
+    : null;
+
   return (
-    <div className="container mx-auto py-6 px-4 max-w-4xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-fg">카테고리 관리</h1>
-        <p className="text-fg-muted mt-1">
-          지출 카테고리를 추가, 수정, 삭제할 수 있습니다
-        </p>
-      </div>
+    <div className="container mx-auto py-6 px-4 max-w-4xl space-y-6">
+      <CategoriesHero
+        familyName={familyInfo?.name ?? null}
+        categoryCount={categories.length}
+      />
 
       <CategoryPageClient
         initialCategories={categories}

--- a/src/components/categories/CategoriesHero.tsx
+++ b/src/components/categories/CategoriesHero.tsx
@@ -1,0 +1,33 @@
+import { Card } from "@/components/ui/card";
+import { FolderTree } from "lucide-react";
+
+interface CategoriesHeroProps {
+  familyName: string | null;
+  categoryCount: number;
+}
+
+export function CategoriesHero({
+  familyName,
+  categoryCount,
+}: CategoriesHeroProps) {
+  return (
+    <Card className="overflow-hidden border-0 gradient-category text-white">
+      <div className="p-5 md:p-6">
+        <p className="text-xs md:text-sm text-white/80 mb-1">카테고리 관리</p>
+        <h1 className="text-xl md:text-2xl font-bold mb-3">
+          {familyName ?? "가족"}
+          <span className="block text-sm md:text-base font-normal text-white/80 mt-0.5">
+            지출 카테고리를 추가, 수정, 삭제할 수 있습니다
+          </span>
+        </h1>
+        <div className="flex items-center gap-2 text-sm md:text-base">
+          <FolderTree className="w-4 h-4 text-white/80" />
+          <span className="font-num font-medium tabular-nums">
+            {categoryCount}
+          </span>
+          <span className="text-xs text-white/70">개 등록됨</span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/categories/CategoriesHero.tsx
+++ b/src/components/categories/CategoriesHero.tsx
@@ -11,21 +11,21 @@ export function CategoriesHero({
   categoryCount,
 }: CategoriesHeroProps) {
   return (
-    <Card className="overflow-hidden border-0 gradient-category text-white">
+    <Card className="overflow-hidden border-0 gradient-category text-brand-fg">
       <div className="p-5 md:p-6">
-        <p className="text-xs md:text-sm text-white/80 mb-1">카테고리 관리</p>
+        <p className="text-xs md:text-sm text-brand-fg/80 mb-1">카테고리 관리</p>
         <h1 className="text-xl md:text-2xl font-bold mb-3">
           {familyName ?? "가족"}
-          <span className="block text-sm md:text-base font-normal text-white/80 mt-0.5">
+          <span className="block text-sm md:text-base font-normal text-brand-fg/80 mt-0.5">
             지출 카테고리를 추가, 수정, 삭제할 수 있습니다
           </span>
         </h1>
         <div className="flex items-center gap-2 text-sm md:text-base">
-          <FolderTree className="w-4 h-4 text-white/80" />
+          <FolderTree className="w-4 h-4 text-brand-fg/80" />
           <span className="font-num font-medium tabular-nums">
             {categoryCount}
           </span>
-          <span className="text-xs text-white/70">개 등록됨</span>
+          <span className="text-xs text-brand-fg/70">개 등록됨</span>
         </div>
       </div>
     </Card>

--- a/tasks/plan024-categories-redesign/index.json
+++ b/tasks/plan024-categories-redesign/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan024-categories-redesign",
   "description": "/categories 페이지 Teal 리디자인. CategoriesHero 신설 + CategoryItem 인라인 style → CSS variable + 색 코드 oklch 문자열 노출 제거 + 아이콘 정사각형 통일 + Empty state EmptyState 공용 재사용 (plan012).",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-05-20",
   "total_phases": 3,
   "related_docs": [
@@ -23,21 +23,21 @@
       "file": "phase-01.md",
       "title": "CategoriesHero 신설 + page.tsx 갱신 (Teal Hero)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "CategoryItem CSS variable 패턴 + 색 코드 텍스트 제거 + 아이콘 정사각형",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "Empty state EmptyState 공용 재사용 + Dialog 토큰 점검 + 검증 + completed",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "planning_checklist": {

--- a/tasks/plan024-categories-redesign/phase-01.md
+++ b/tasks/plan024-categories-redesign/phase-01.md
@@ -67,20 +67,14 @@ if (!selectedFamily.success || !selectedFamily.data) {
 }
 const familyUuid = selectedFamily.data;
 
-// ADR-F25 권한 검증 — 본인 소속 가족 목록에서 find 로 제한
-// getFamilyByIdAction(familyUuid) 직접 호출은 본 action 이 자체적으로
-// 사용자 소속 여부를 검증하지 않으므로 다른 가족 UUID 주입 시 정보 노출 위험.
-// getFamiliesAction() 결과는 본인 소속 가족만 반환하므로 find 로 안전하게 제한.
-import { getFamiliesAction } from "@/actions/family/get-families-action";
+// getFamilyByIdAction (또는 getFamiliesAction + find) 로 가족 정보 페치
+import { getFamilyByIdAction } from "@/actions/family/get-family-by-id-action";
 
-const familiesResult = await getFamiliesAction();
-const familyInfo = familiesResult.success
-  ? familiesResult.data.find((f) => f.uuid === familyUuid)
-  : null;
-const familyName = familyInfo?.name ?? null;
+const familyInfo = await getFamilyByIdAction(familyUuid);
+const familyName = familyInfo.success ? familyInfo.data.name : null;
 ```
 
-대안: `getFamilyByIdAction` 에 ADR-F25 패턴 (A) 권한 검증 (`getSelectedFamilyUuid()` 비교) 을 추가하는 경로도 가능하나, action 의 책임이 커지므로 page 측에서 `getFamiliesAction().find()` 로 제한하는 쪽이 단순. SettingsHero 가 동일 패턴.
+`getFamilyByIdAction` 시그니처 확인 후 import. 없으면 `getFamiliesAction()` 결과에서 `find(f => f.uuid === familyUuid)` 로 대체.
 
 ```tsx
 // L27-33 헤더 영역 교체
@@ -172,7 +166,6 @@ grep -nE 'gradient-category|text-brand-fg' src/components/categories/CategoriesH
 
 | 리스크 | 완화 |
 |---|---|
-| `getFamilyByIdAction` 권한 검증 미명시 시 다른 가족 UUID 주입 가능 (ADR-F25 위반) — 인증된 사용자가 자신이 속하지 않은 가족 정보 열람 위험 | `getFamiliesAction()` (본인 소속만 반환) 결과에서 `find(f => f.uuid === familyUuid)` 로 제한. 본 phase 의 page 코드 스니펫이 이미 이 패턴 반영 |
-| `getFamiliesAction` 결과 타입과 `Family` 타입 mismatch | 구현 시 `getFamiliesAction()` 반환 타입 확인 (`ActionResult<Family[]>`). SettingsHero 가 동일 패턴이므로 참조 가능 |
+| `getFamilyByIdAction` 시그니처 부재 또는 `ActionResult<Family>` 와 mismatch | 구현 시 import + 타입 확인. 없으면 `getFamiliesAction().data.find(...)` 패턴으로 대체 (이미 SettingsHero 가 동일 패턴) |
 | `gradient-category` 클래스가 globals.css 에 없음 | L230 에 존재 확인 됨 (`.gradient-category {...}`) ✅ |
 | `text-brand-fg` 토큰이 globals.css 에 없음 | plan022 phase-01 완료 후 정착. 본 plan 머지 시점에 plan022 가 미머지면 `text-white` fallback |

--- a/tasks/plan024-categories-redesign/phase-01.md
+++ b/tasks/plan024-categories-redesign/phase-01.md
@@ -67,14 +67,20 @@ if (!selectedFamily.success || !selectedFamily.data) {
 }
 const familyUuid = selectedFamily.data;
 
-// getFamilyByIdAction (또는 getFamiliesAction + find) 로 가족 정보 페치
-import { getFamilyByIdAction } from "@/actions/family/get-family-by-id-action";
+// ADR-F25 권한 검증 — 본인 소속 가족 목록에서 find 로 제한
+// getFamilyByIdAction(familyUuid) 직접 호출은 본 action 이 자체적으로
+// 사용자 소속 여부를 검증하지 않으므로 다른 가족 UUID 주입 시 정보 노출 위험.
+// getFamiliesAction() 결과는 본인 소속 가족만 반환하므로 find 로 안전하게 제한.
+import { getFamiliesAction } from "@/actions/family/get-families-action";
 
-const familyInfo = await getFamilyByIdAction(familyUuid);
-const familyName = familyInfo.success ? familyInfo.data.name : null;
+const familiesResult = await getFamiliesAction();
+const familyInfo = familiesResult.success
+  ? familiesResult.data.find((f) => f.uuid === familyUuid)
+  : null;
+const familyName = familyInfo?.name ?? null;
 ```
 
-`getFamilyByIdAction` 시그니처 확인 후 import. 없으면 `getFamiliesAction()` 결과에서 `find(f => f.uuid === familyUuid)` 로 대체.
+대안: `getFamilyByIdAction` 에 ADR-F25 패턴 (A) 권한 검증 (`getSelectedFamilyUuid()` 비교) 을 추가하는 경로도 가능하나, action 의 책임이 커지므로 page 측에서 `getFamiliesAction().find()` 로 제한하는 쪽이 단순. SettingsHero 가 동일 패턴.
 
 ```tsx
 // L27-33 헤더 영역 교체
@@ -166,6 +172,7 @@ grep -nE 'gradient-category|text-brand-fg' src/components/categories/CategoriesH
 
 | 리스크 | 완화 |
 |---|---|
-| `getFamilyByIdAction` 시그니처 부재 또는 `ActionResult<Family>` 와 mismatch | 구현 시 import + 타입 확인. 없으면 `getFamiliesAction().data.find(...)` 패턴으로 대체 (이미 SettingsHero 가 동일 패턴) |
+| `getFamilyByIdAction` 권한 검증 미명시 시 다른 가족 UUID 주입 가능 (ADR-F25 위반) — 인증된 사용자가 자신이 속하지 않은 가족 정보 열람 위험 | `getFamiliesAction()` (본인 소속만 반환) 결과에서 `find(f => f.uuid === familyUuid)` 로 제한. 본 phase 의 page 코드 스니펫이 이미 이 패턴 반영 |
+| `getFamiliesAction` 결과 타입과 `Family` 타입 mismatch | 구현 시 `getFamiliesAction()` 반환 타입 확인 (`ActionResult<Family[]>`). SettingsHero 가 동일 패턴이므로 참조 가능 |
 | `gradient-category` 클래스가 globals.css 에 없음 | L230 에 존재 확인 됨 (`.gradient-category {...}`) ✅ |
 | `text-brand-fg` 토큰이 globals.css 에 없음 | plan022 phase-01 완료 후 정착. 본 plan 머지 시점에 plan022 가 미머지면 `text-white` fallback |


### PR DESCRIPTION
## Summary

- **CategoriesHero** 신설: gradient-category Teal hero 카드 (가족명 + 카테고리 수)
- **CategoryItem** CSS variable 패턴: 인라인 style → `--cat-color` CSS variable + `color-mix()` + 아이콘 정사각형 통일 + oklch 색 코드 텍스트 제거
- **EmptyState** 공용 재사용 (plan012): CategoryList 인라인 empty → EmptyState 컴포넌트
- **ADR-F23** 준수: `text-white` → `text-brand-fg` 시맨틱 토큰

## Changes

| 파일 | 변경 |
|---|---|
| `src/components/categories/CategoriesHero.tsx` | 신규 — gradient-category Hero |
| `src/app/(authenticated)/categories/page.tsx` | getFamiliesAction 페치 + Hero 렌더 |
| `CategoryPageClient.tsx` | 카운터 row 제거, 추가 버튼만 유지 |
| `CategoryItem.tsx` | CSS variable + color-mix + 정사각형 아이콘 |
| `CategoryList.tsx` | EmptyState 컴포넌트 재사용 |

## Test plan

- [x] `pnpm lint` 통과
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test:ci` — 242 tests passed
- [x] `pnpm build` 통과
- [ ] /categories 접속 → Teal gradient Hero (가족명 + 카테고리 수) 표시
- [ ] 카테고리 0개 → EmptyState (FolderPlus 아이콘 + 안내)
- [ ] 카테고리 카드 아이콘 정사각형 + 동적 색 CSS variable
- [ ] 다크 모드 자연

🤖 Generated with [Claude Code](https://claude.com/claude-code)
