### PR TITLE
docs(plan025): 401 토큰 만료 인증 처리 + 로그아웃 버튼 수정 설계

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Claude Code가 항상 따라야 할 규칙과 참조 문서 포인터.
 | Page에서 데이터 조회 | ADR-F12 — Page에서 `serverApiGet` 직접 호출 금지, Action 경유 |
 | HTTP 클라이언트 / 재시도 설정 | ADR-F05 — ky 사용, 408/429/5xx 최대 2회 재시도 |
 | NextAuth 세션/토큰 수정 | ADR-F03 — JWT 전략, profile 캐싱, 만료 5분 전 갱신 |
-| 401 응답 / 토큰 만료 처리 | ADR-F26 — 401 을 `A001` 로 변환, 인증 에러는 기본값으로 숨기지 않고 로그인 리다이렉트 |
+| 401 응답 / 토큰 만료 처리 | ADR-F26 — 401 을 `A002`(세션 만료) 로 변환, 인증 에러는 기본값으로 숨기지 않고 로그인 리다이렉트 |
 | DropdownMenu 안 Server Action 호출 | ADR-F27 — `form` submit 금지, `onSelect` 에서 preventDefault 후 직접 호출 |
 | Server Action 입력 검증 | ADR-F06 — Zod 런타임 검증 필수 |
 | Shadcn / Tailwind v4 스타일 | ADR-F07 — 시맨틱 그라디언트 클래스, 하드코딩 금지 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Claude Code가 항상 따라야 할 규칙과 참조 문서 포인터.
 | Page에서 데이터 조회 | ADR-F12 — Page에서 `serverApiGet` 직접 호출 금지, Action 경유 |
 | HTTP 클라이언트 / 재시도 설정 | ADR-F05 — ky 사용, 408/429/5xx 최대 2회 재시도 |
 | NextAuth 세션/토큰 수정 | ADR-F03 — JWT 전략, profile 캐싱, 만료 5분 전 갱신 |
+| 401 응답 / 토큰 만료 처리 | ADR-F26 — 401 을 `A001` 로 변환, 인증 에러는 기본값으로 숨기지 않고 로그인 리다이렉트 |
+| DropdownMenu 안 Server Action 호출 | ADR-F27 — `form` submit 금지, `onSelect` 에서 preventDefault 후 직접 호출 |
 | Server Action 입력 검증 | ADR-F06 — Zod 런타임 검증 필수 |
 | Shadcn / Tailwind v4 스타일 | ADR-F07 — 시맨틱 그라디언트 클래스, 하드코딩 금지 |
 | 색 토큰 작성 (brand/semantic/surface) | ADR-F13 — OKLCH 평면 값. hex/rgb/hsl 금지 |

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -449,7 +449,7 @@
 ## ADR-F26: 백엔드 401 응답을 인증 만료로 분류해 로그인으로 일관 리다이렉트 (2026-06-02)
 
 - **결정**: 백엔드 401 응답은 "인증 만료" 단일 경로로 처리한다.
-  - `handleActionError` (try-catch 변환기) 가 `ServerApiError.status === 401` 을 `ActionError.unauthorized()` (코드 `A001`) 로 변환한다.
+  - `handleActionError` (try-catch 변환기) 가 `ServerApiError.status === 401` 을 `ActionError.sessionExpired()` (코드 `A002`) 로 변환한다.
   - `getActionDataOrDefault` 는 결과 코드가 `A001`/`A002` (인증 에러) 일 때는 기본값을 반환하지 않고 `handleActionError` 로 redirect 한다.
   - refresh 실패는 jwt callback 에서 `token.error` 표시만 하고, 실제 무효화는 다음 API 호출이 401 을 받는 시점에 일어난다.
   - redirect 목적지는 `/auth/signin?error=auth` 이며, signin 진입 시 sonner 토스트로 만료를 고지한다.

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -446,3 +446,31 @@
 - **트레이드오프**: `assertFamilyAccess` 는 매 호출마다 `getFamilies()` 페치 (단 backend 가 캐시 + 짧은 TTL). single-family 패턴의 session 비교는 캐시된 JWT 만 사용해 0 네트워크.
 - **적용 범위**: `src/lib/server/auth/auth-helpers.ts` (helper) + `src/actions/family/update-family-action.ts` (B) + `src/actions/category/create-category-action.ts` (A, session 비교 추가) + `src/actions/invitation/delete-invitation-action.ts` (C). 다른 Action 은 이미 표준 패턴 준수.
 
+## ADR-F26: 백엔드 401 응답을 인증 만료로 분류해 로그인으로 일관 리다이렉트 (2026-06-02)
+
+- **결정**: 백엔드 401 응답은 "인증 만료" 단일 경로로 처리한다.
+  - `handleActionError` (try-catch 변환기) 가 `ServerApiError.status === 401` 을 `ActionError.unauthorized()` (코드 `A001`) 로 변환한다.
+  - `getActionDataOrDefault` 는 결과 코드가 `A001`/`A002` (인증 에러) 일 때는 기본값을 반환하지 않고 `handleActionError` 로 redirect 한다.
+  - refresh 실패는 jwt callback 에서 `token.error` 표시만 하고, 실제 무효화는 다음 API 호출이 401 을 받는 시점에 일어난다.
+  - redirect 목적지는 `/auth/signin?error=auth` 이며, signin 진입 시 sonner 토스트로 만료를 고지한다.
+- **맥락**: 기존엔 401 이 `ServerApiError(status:401)` 까지는 도달했다.
+  그러나 `handleActionError` 가 status 를 검사하지 않고 모두 `internalError` (C 계열) 로 변환해 `onAuthError` (A001/A002) 분기에 닿지 못했다.
+  그 결과 `getActionDataOrDefault` 를 쓰는 dashboard/budget 은 만료 응답을 빈 데이터(0)로 숨겨 무효 토큰인 채 페이지가 잔존했다.
+  refresh 실패 시에도 jwt callback 이 만료 토큰을 유지해 무효 요청이 계속 나갔다.
+- **대안 기각**:
+  - HTTP 클라이언트 (`client.ts` afterResponse hook) 에서 직접 redirect: Service 레이어에서 호출되는데 `redirect()` 는 RSC/Action context 구분이 필요해 레이어 경계를 깬다. 변환은 에러 레이어에 두는 것이 책임에 맞다.
+  - jwt callback 에서 refresh 실패 즉시 세션 무효화: NextAuth v5 동작 검증 부담이 크고, 페이지 진입 자체가 차단돼 토스트 고지 흐름과 맞물리기 어렵다. 401 시점 무효화가 기존 `action-result-handler` 흐름과 일관된다.
+- **적용 범위**: `src/lib/errors/action-error.ts` (변환) + `src/lib/server/action-result-handler.ts` (인증 에러 가드) + `src/lib/server/auth/config.ts` (token.error 표시) + signin 토스트.
+
+## ADR-F27: Radix `DropdownMenuItem` 안에서 form submit 금지 — `onSelect` 직접 호출 (2026-06-02)
+
+- **결정**: `DropdownMenuItem` 안에 Server Action 을 붙일 때는 `<form action={...}>` 대신, `onSelect` 에서 `event.preventDefault()` 로 자동 닫힘을 막고 Server Action 을 직접 호출한다.
+- **맥락**: 로그아웃 버튼이 `DropdownMenuItem asChild` 안에 `<form action={signOutAction}>` + submit 버튼을 두는 구조였다.
+  클릭하면 `DropdownMenuItem` 의 `onSelect` 가 메뉴를 닫으며 Portal 을 unmount 한다.
+  그 과정에서 form 이 DOM 에서 제거되어 native submit 이 발생하기 전에 유실됐다.
+  로그인 시점과 무관하게 로그아웃이 항상 동작하지 않았다.
+- **대안 기각**:
+  - form 을 `DropdownMenu` 바깥으로 분리: 메뉴 항목 레이아웃을 깨고, 메뉴 닫힘 타이밍과 submit 순서를 다시 맞춰야 해 복잡도만 늘어난다.
+  - `onSelect` 유지 + setTimeout 으로 submit 지연: 타이밍 의존이라 취약하다.
+- **적용 범위**: `src/components/layout/Header.tsx`. 향후 메뉴 항목에서 Server Action 호출 시 동일 패턴 적용.
+

--- a/tasks/plan025-auth-token-expiry-handling/index.json
+++ b/tasks/plan025-auth-token-expiry-handling/index.json
@@ -1,0 +1,48 @@
+{
+  "name": "plan025-auth-token-expiry-handling",
+  "description": "백엔드 401(토큰 만료)을 인증 에러로 분류해 로그인으로 일관 리다이렉트 + refresh 실패 가드 + 로그아웃 버튼 Radix submit 함정 수정",
+  "status": "pending",
+  "created_at": "2026-06-02",
+  "total_phases": 5,
+  "related_docs": [
+    "docs/adr.md",
+    "CLAUDE.md"
+  ],
+  "phases": [
+    {
+      "number": 1,
+      "file": "phase-01.md",
+      "title": "401 응답을 인증 만료(A002)로 분류 + 인증 에러는 기본값으로 숨기지 않기",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 2,
+      "file": "phase-02.md",
+      "title": "jwt callback refresh 실패 시 token.error 가드 (무한 재시도 방지)",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 3,
+      "file": "phase-03.md",
+      "title": "로그아웃 버튼 Radix DropdownMenuItem form submit 유실 수정",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 4,
+      "file": "phase-04.md",
+      "title": "signin 진입 시 세션 만료 sonner 토스트 고지",
+      "model": "sonnet",
+      "status": "pending"
+    },
+    {
+      "number": 5,
+      "file": "phase-05.md",
+      "title": "통합 검증 + index.json completed 마킹",
+      "model": "haiku",
+      "status": "pending"
+    }
+  ]
+}

--- a/tasks/plan025-auth-token-expiry-handling/phase-01.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-01.md
@@ -1,0 +1,139 @@
+# Phase 01 — 401 응답을 인증 만료(A002)로 분류 + 인증 에러는 기본값으로 숨기지 않기
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+백엔드 401 응답이 "인증 만료" 경로로 흐르도록 끊긴 변환 고리를 잇는다.
+현재는 401 → `ServerApiError(status:401)` 까지만 가고, 그 뒤 변환기가 status 를 무시해
+모두 `internalError`(C 계열)로 뭉개져 `onAuthError`(A001/A002) 분기가 도달 불가다.
+그 결과 `getActionDataOrDefault` 를 쓰는 dashboard/budget 은 만료 응답을 빈 데이터(0)로 숨겨
+무효 토큰인 채 페이지가 잔존한다.
+
+근거: `docs/adr.md` ADR-F26.
+
+**범위 외**:
+- jwt callback 의 refresh 실패 처리 → phase 2.
+- 로그아웃 버튼 → phase 3.
+- signin 토스트 → phase 4.
+
+---
+
+## 배경 (현재 코드 위치)
+
+- `src/lib/server/api/types.ts` — `ServerApiError extends Error` 는 `status?: number` 필드 보유.
+- `src/lib/server/api/client.ts:224` — HTTP 에러 시 `new ServerApiError(msg, error.response.status, errorData)` 로 status 채움 (401 포함).
+- `src/lib/errors/action-error.ts:224` — `handleActionError(error, defaultMessage)`: try-catch 에서 던져진 에러를 `ActionResult` 로 변환하는 **변환기**. 현재 `ServerApiError` 의 status 를 검사하지 않음.
+- `src/lib/server/action-result-handler.ts` — `handleActionError(result, options)`(redirect 처리기, 동명이인 주의) + `getActionDataOrDefault(result, defaultValue)`.
+- `src/lib/errors/error-code.ts` — `A001`=UNAUTHORIZED("로그인이 필요합니다"), `A002`=SESSION_EXPIRED("세션이 만료되었습니다").
+- `src/lib/errors/action-error.ts` static 헬퍼: `unauthorized()`(A001) 존재. `sessionExpired()` **없음** → 추가 필요.
+
+## 작업 항목 (4)
+
+### 1. `src/lib/errors/action-error.ts` — `ActionError.sessionExpired()` 헬퍼 추가
+
+`unauthorized()`(111행 근처) 바로 아래에 추가. `ErrorCode.SESSION_EXPIRED`("A002") 사용.
+
+```ts
+static sessionExpired(message?: string): ActionError {
+  return new ActionError(ErrorCode.SESSION_EXPIRED, message || "세션이 만료되었습니다");
+}
+```
+
+`ErrorCode` import 가 이미 있는지 확인 — 없으면 `import { ErrorCode } from "./error-code"` 추가 (파일 내 기존 import 스타일 따름).
+
+### 2. `src/lib/errors/action-error.ts` — `handleActionError` 변환기에 401 분기 추가
+
+`handleActionError(error, defaultMessage)`(224행) 의 `error instanceof Error` 분기보다 **먼저**, `ServerApiError` 의 401 을 인증 만료로 변환한다.
+
+```ts
+import { ServerApiError } from "@/lib/server/api/types";
+// ...
+export function handleActionError(error: unknown, defaultMessage: string): ActionResult<never> {
+  if (error instanceof ActionError) {
+    return error.toFailureResult();
+  }
+
+  // 백엔드 401 = 인증 만료 (ADR-F26)
+  if (error instanceof ServerApiError && error.status === 401) {
+    return ActionError.sessionExpired().toFailureResult();
+  }
+
+  if (error instanceof Error) {
+    // ... 기존 네트워크/internalError 로직 그대로 ...
+  }
+  // ...
+}
+```
+
+주의: `ServerApiError` import 가 순환 의존을 만들지 않는지 확인. `lib/errors` → `lib/server/api/types` 방향. `types.ts` 가 `lib/errors` 를 import 하지 않으므로 단방향 — 안전. 만약 순환이 발생하면 `error.name === "ServerApiError" && (error as { status?: number }).status === 401` 로 덕타이핑 대체.
+
+### 3. `src/lib/server/action-result-handler.ts` — `getActionDataOrDefault` 가 인증 에러는 숨기지 않기
+
+`getActionDataOrDefault(result, defaultValue)` 에서 실패 코드가 인증 계열(A001/A002)이면 기본값 대신 `handleActionError`(같은 파일의 redirect 처리기)로 redirect.
+
+```ts
+export function getActionDataOrDefault<T>(result: ActionResult<T>, defaultValue: T): T {
+  if (result.success) {
+    return result.data;
+  }
+
+  // 인증 에러는 빈 데이터로 숨기지 않고 로그인으로 (ADR-F26)
+  if (result.error.code === "A001" || result.error.code === "A002") {
+    handleActionError(result); // redirect, never 반환
+  }
+
+  console.error("Action failed, using default value:", {
+    code: result.error.code,
+    message: result.error.message,
+  });
+  return defaultValue;
+}
+```
+
+`handleActionError`(redirect 버전)의 기본 동작은 A001/A002 → `/auth/signin?error=auth&message=...` redirect (이미 구현됨). 추가 옵션 불필요.
+
+### 4. 테스트 — `src/__tests__/` 에 변환/가드 단위 테스트 (ADR-F09 jest.mock 방식)
+
+- `handleActionError`(action-error.ts 변환기): `new ServerApiError("...", 401)` 입력 → 반환 `ActionResult` 의 `error.code === "A002"` 검증.
+- 401 이 아닌 ServerApiError(예: 500) → 여전히 `internalError`(C 계열) 로 변환되는지(회귀 방지).
+- `getActionDataOrDefault`: A002 결과 입력 시 `redirect` 가 호출되는지 (`next/navigation` 의 `redirect` 를 jest.mock 으로 스파이). 성공 결과 / 비인증 실패 결과는 기존대로 data/기본값 반환.
+
+기존 테스트 위치/패턴 참조: `src/__tests__/` 하위. `next/navigation` mock 은 다른 액션 테스트에서 쓰는 방식 그대로.
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/lib/errors/action-error.ts` | 수정 — `sessionExpired()` 헬퍼 + 401 변환 분기 |
+| `src/lib/server/action-result-handler.ts` | 수정 — `getActionDataOrDefault` 인증 가드 |
+| `src/__tests__/...` | 신규 — 변환/가드 단위 테스트 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+pnpm lint
+pnpm test --silent 2>&1 | tail -20
+
+# sessionExpired 헬퍼 존재
+grep -n "static sessionExpired" src/lib/errors/action-error.ts
+
+# 401 변환 분기 존재
+grep -nE "status === 401" src/lib/errors/action-error.ts
+
+# getActionDataOrDefault 인증 가드 존재
+grep -nE 'A001"? *\|\| *result.error.code === "A002"|code === "A002"' src/lib/server/action-result-handler.ts
+```
+
+기대: 모든 grep 1건 이상 매치, `pnpm lint` exit 0, 신규 테스트 통과.
+
+## 의도 메모 (왜)
+
+- 변환을 HTTP 클라이언트(client.ts)가 아니라 에러 레이어(action-error.ts)에 둔 이유: client.ts 는 Service 에서 호출되는데 `redirect()` 는 RSC/Action context 구분이 필요해 레이어 경계를 깬다. 변환은 에러 레이어, redirect 는 action-result-handler 가 책임 (ADR-F26 대안 기각 참조).
+- 401 을 A002(SESSION_EXPIRED)로 보낸 이유: A001(UNAUTHORIZED)은 "처음부터 미인증", A002 는 "세션 만료"로 의미가 더 정확. `onAuthError` 분기는 둘 다 잡으므로 동작 동일하나 메시지/의미가 맞다.

--- a/tasks/plan025-auth-token-expiry-handling/phase-02.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-02.md
@@ -1,0 +1,133 @@
+# Phase 02 — jwt callback refresh 실패 시 token.error 가드 (무한 재시도 방지)
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+refresh 토큰까지 만료되어 갱신이 실패했을 때, jwt callback 이 매 호출마다 무의미한 refresh 를
+반복하지 않도록 `token.error` 로 1회 표시하고 이후 재시도를 건너뛴다.
+실제 로그인 리다이렉트는 phase 1 의 401 경로가 담당한다 (jwt callback 에서 즉시 세션을 죽이지 않음).
+
+근거: `docs/adr.md` ADR-F26 ("refresh 실패는 jwt callback 에서 token.error 표시만, 무효화는 401 시점").
+
+**범위 외**:
+- 401 → 로그인 리다이렉트 → phase 1 (이미 처리).
+- 클라이언트 측 useSession 감지/강제 로그아웃 → 이번 plan 범위 외 (서버 401 경로로 충분).
+
+---
+
+## 배경 (현재 코드)
+
+`src/lib/server/auth/config.ts` jwt callback (66~89행):
+
+```ts
+if (token.backendTokenExpiredAt && token.backendRefreshToken && token.backendAccessToken) {
+  const expiredAt = new Date(token.backendTokenExpiredAt);
+  const now = new Date();
+  const bufferTime = 5 * 60 * 1000;
+  if (now.getTime() >= expiredAt.getTime() - bufferTime) {
+    const refreshedResponse = await refreshBackendToken({ refreshToken: token.backendRefreshToken });
+    if (refreshedResponse.success) {
+      token.backendAccessToken = refreshedResponse.data.accessToken;
+      // ...
+    }
+    // 실패 시: 아무것도 안 함 → 다음 호출에서 또 refresh 시도 (무한 반복)
+  }
+}
+```
+
+`refreshBackendToken`(`src/lib/server/auth/backend-auth.ts`)은 try-catch 로 항상 `{success:true|false}` 반환 (throw 하지 않음).
+
+## 작업 항목 (3)
+
+### 1. `src/types/next-auth.d.ts` — JWT 에 `error` 필드 추가
+
+`declare module "next-auth/jwt"` 의 `interface JWT` 에 추가:
+
+```ts
+/** refresh 실패 표시 — 설정되면 jwt callback 이 추가 refresh 재시도를 건너뜀 */
+error?: "RefreshAccessTokenError";
+```
+
+### 2. `src/lib/server/auth/config.ts` — refresh 실패 가드
+
+jwt callback 의 refresh 블록을 다음과 같이 보강:
+
+- 블록 진입 전에 `token.error === "RefreshAccessTokenError"` 면 refresh 를 시도하지 않고 그대로 `return token` (이미 실패한 토큰 — 401 경로가 처리).
+- refresh 성공 시 기존 필드 갱신 + `token.error = undefined` (혹시 이전 실패 플래그가 남아 있으면 해제).
+- refresh 실패 시 `token.error = "RefreshAccessTokenError"` 설정 (만료 토큰은 그대로 둠).
+
+```ts
+// 이미 refresh 실패한 토큰이면 재시도하지 않음 (401 경로가 처리)
+if (token.error === "RefreshAccessTokenError") {
+  return token;
+}
+
+if (token.backendTokenExpiredAt && token.backendRefreshToken && token.backendAccessToken) {
+  const expiredAt = new Date(token.backendTokenExpiredAt);
+  const now = new Date();
+  const bufferTime = 5 * 60 * 1000;
+  if (now.getTime() >= expiredAt.getTime() - bufferTime) {
+    const refreshedResponse = await refreshBackendToken({ refreshToken: token.backendRefreshToken });
+    if (refreshedResponse.success) {
+      token.backendAccessToken = refreshedResponse.data.accessToken;
+      token.backendRefreshToken = refreshedResponse.data.refreshToken;
+      token.backendTokenExpiredAt = refreshedResponse.data.expiredAt;
+      token.backendTokenIssuedAt = refreshedResponse.data.issuedAt;
+      token.error = undefined;
+    } else {
+      console.warn("[auth.js callback (JWT)] backend token refresh 실패 — 다음 API 호출 401 시 로그인으로 처리");
+      token.error = "RefreshAccessTokenError";
+    }
+  }
+}
+return token;
+```
+
+기존 `초기 로그인`/`trigger === "update"` 분기는 건드리지 않는다. 위 가드는 그 두 분기 **뒤**(기존 refresh 블록 자리)에 둔다. 초기 로그인 분기에서 새 토큰을 발급하므로 그 경로에서는 `token.error` 가 자연히 없음.
+
+### 3. 테스트 — `src/__tests__/` jwt callback refresh 실패 가드 (ADR-F09)
+
+`refreshBackendToken` 을 jest.mock 으로 모킹:
+- 만료 임박 토큰 + refresh 실패(`{success:false}`) → 반환 token 의 `error === "RefreshAccessTokenError"`.
+- `token.error` 가 이미 설정된 입력 → `refreshBackendToken` 이 호출되지 않음 (재시도 스킵 검증, mock 호출 횟수 0).
+- refresh 성공 → 토큰 갱신 + `error` 가 undefined.
+
+기존 auth 관련 테스트 패턴 참조: `src/__tests__/` 하위에서 `@/lib/server/auth` 또는 `backend-auth` 를 mock 하는 방식.
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/types/next-auth.d.ts` | 수정 — JWT.error 필드 |
+| `src/lib/server/auth/config.ts` | 수정 — refresh 실패 가드 |
+| `src/__tests__/...` | 신규 — jwt callback 가드 테스트 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+pnpm lint
+pnpm test --silent 2>&1 | tail -20
+
+# JWT.error 타입 추가
+grep -n "RefreshAccessTokenError" src/types/next-auth.d.ts
+
+# 재시도 스킵 가드 존재
+grep -nE 'token.error === "RefreshAccessTokenError"' src/lib/server/auth/config.ts
+
+# 실패 시 플래그 설정 존재
+grep -nE 'token.error = "RefreshAccessTokenError"' src/lib/server/auth/config.ts
+```
+
+기대: 모든 grep 1건 이상, `pnpm lint` exit 0, 신규 테스트 통과.
+
+## 의도 메모 (왜)
+
+- `token.error` 의 소비처는 jwt callback 자기 자신(재시도 가드)이라 dead field 가 아니다.
+- jwt callback 에서 즉시 세션을 죽이지 않은 이유: NextAuth v5 의 세션 즉시 무효화는 동작 검증 부담이 크고, 페이지 진입 자체를 막아 phase 4 의 토스트 고지 흐름과 어긋난다. 401 시점 처리가 기존 `action-result-handler` 흐름과 일관 (ADR-F26 대안 기각).

--- a/tasks/plan025-auth-token-expiry-handling/phase-03.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-03.md
@@ -1,0 +1,100 @@
+# Phase 03 — 로그아웃 버튼 Radix DropdownMenuItem form submit 유실 수정
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+로그아웃 버튼이 항상 동작하지 않는 문제를 고친다.
+`<DropdownMenuItem asChild><form action={signOutAction}><button type="submit">` 구조에서
+클릭 시 `DropdownMenuItem` 의 `onSelect` 가 메뉴를 닫으며 Portal 을 unmount → form 이 DOM 에서
+제거되어 native submit 이 발생하기 전에 유실된다. 로그인 시점과 무관하게 항상 실패.
+
+근거: `docs/adr.md` ADR-F27.
+
+**범위 외**:
+- 401/세션 만료 처리 → phase 1, 2.
+- `signOutAction` 내부 로직(쿠키 삭제 + signOut)은 정상이므로 변경하지 않는다.
+
+---
+
+## 배경 (현재 코드)
+
+`src/components/layout/Header.tsx:127` 근처:
+
+```tsx
+<DropdownMenuItem className="text-expense focus:text-expense" asChild>
+  <form action={signOutAction}>
+    <button type="submit" className="flex items-center w-full">
+      <LogOut className="mr-2 h-4 w-4" />
+      <span>로그아웃</span>
+    </button>
+  </form>
+</DropdownMenuItem>
+```
+
+`Header.tsx` 는 이미 `"use client"` (1행). `signOutAction` 은 `src/actions/auth/signout-action.ts` 의 Server Action — 클라이언트에서 직접 호출 가능 (`await signOutAction()`).
+다른 메뉴 항목(설정 등)은 `onClick={() => router.push(...)}` 패턴 사용 — 동일 스타일 참고.
+
+## 작업 항목 (2)
+
+### 1. `src/components/layout/Header.tsx` — form 제거, onSelect 직접 호출
+
+`form` + submit 버튼 구조를 제거하고, `DropdownMenuItem` 의 `onSelect` 에서 자동 닫힘을 막은 뒤 `signOutAction()` 을 직접 호출한다.
+
+```tsx
+<DropdownMenuItem
+  className="text-expense focus:text-expense"
+  onSelect={(e) => {
+    e.preventDefault();
+    void signOutAction();
+  }}
+>
+  <LogOut className="mr-2 h-4 w-4" />
+  <span>로그아웃</span>
+</DropdownMenuItem>
+```
+
+- `asChild` 제거 (이제 자식이 form 이 아니라 일반 메뉴 항목 내용).
+- `e.preventDefault()` 로 Radix 의 자동 메뉴 닫힘(+ Portal unmount)을 막아 Server Action 호출이 유실되지 않게 한다.
+- `void` 로 floating promise lint 경고 회피 (`signOutAction` 은 내부에서 `signOut({ redirectTo })` 로 redirect 하므로 호출자는 결과를 기다리지 않아도 됨).
+
+### 2. `src/__tests__/components/layout/Header.test.tsx` — 로그아웃 테스트 갱신
+
+기존 테스트(198행 근처 "로그아웃 버튼을 클릭하면 signOutAction 을 호출한다")가 form submit 기준이면, onSelect/click 기준으로 갱신한다.
+- 메뉴를 열고 로그아웃 항목을 클릭(또는 select) → `signOutAction` mock 이 호출되는지 검증.
+- 기존 mock 선언(`signOutAction: (...args) => mockSignOutAction(...args)`)은 그대로 활용.
+
+Radix DropdownMenu 의 항목 클릭은 Testing Library 에서 trigger 를 먼저 열어야 한다. 기존 테스트가 메뉴를 여는 방식(userEvent.click(trigger))을 따른다. onSelect 가 keyboard/pointer 양쪽에서 발화하므로 `userEvent.click(로그아웃 항목)` 으로 충분.
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/components/layout/Header.tsx` | 수정 — form 제거, onSelect 직접 호출 |
+| `src/__tests__/components/layout/Header.test.tsx` | 수정 — 로그아웃 테스트 갱신 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+pnpm lint
+pnpm test --silent src/__tests__/components/layout/Header.test.tsx 2>&1 | tail -20
+
+# form action 제거 확인 (로그아웃에 form 미사용)
+! grep -nE '<form action=\{signOutAction\}' src/components/layout/Header.tsx
+
+# onSelect 직접 호출 패턴 존재
+grep -nE 'onSelect=.*signOutAction|void signOutAction' src/components/layout/Header.tsx
+```
+
+기대: 첫 grep exit 1(매치 없음), 둘째 grep 1건 이상, Header 테스트 통과, `pnpm lint` exit 0.
+
+## 의도 메모 (왜)
+
+- `onSelect` + `preventDefault` 가 정답인 이유: Radix `DropdownMenuItem` 의 기본 동작은 select 시 메뉴를 닫는 것이고, 닫힘은 Portal unmount 를 동반한다. form submit 은 그 unmount 와 경쟁해 유실된다. preventDefault 로 닫힘을 막고 명시적으로 Server Action 을 호출하면 경쟁이 사라진다 (ADR-F27).
+- `setTimeout` 으로 submit 을 지연시키는 우회는 타이밍 의존이라 채택하지 않음 (ADR-F27 대안 기각).

--- a/tasks/plan025-auth-token-expiry-handling/phase-04.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-04.md
@@ -1,0 +1,113 @@
+# Phase 04 — signin 진입 시 세션 만료 sonner 토스트 고지
+
+**Model**: sonnet
+**Status**: pending
+
+---
+
+## 목표
+
+세션 만료로 `/auth/signin?error=auth` 로 리다이렉트됐을 때, 사용자가 왜 로그아웃됐는지
+즉시 알 수 있도록 sonner 토스트를 띄운다 ("토스트 후 이동" 결정).
+
+근거: `docs/adr.md` ADR-F26, ADR-F08(sonner 토스트), ADR-F24(sonner 토큰 매핑).
+
+**범위 외**:
+- 401 변환/리다이렉트 → phase 1 (이미 처리).
+- signin 의 기존 인라인 에러 배너(`bg-expense/10 ...`)는 모든 error 유형 공통이므로 **유지**. 토스트는 만료(auth) 케이스 보강용.
+
+---
+
+## 배경 (현재 코드)
+
+`src/app/auth/signin/page.tsx` 는 Server Component.
+- `searchParams` 에서 `error`, `message` 를 읽어 인라인 배너로 표시 중.
+- `error === "auth"` → 만료 케이스. 기존 배너 문구: "인증이 만료되었습니다. 다시 로그인해주세요."
+
+토스트는 클라이언트에서만 띄울 수 있으므로 작은 `"use client"` 컴포넌트가 필요하다.
+sonner `Toaster` 는 이미 `src/app/providers.tsx` 에 마운트됨 (ADR-F24). `toast` 는 `import { toast } from "sonner"`.
+
+## 작업 항목 (2)
+
+### 1. 신규 클라이언트 컴포넌트 — 세션 만료 토스트 트리거
+
+`src/app/auth/signin/_components/SessionExpiredToast.tsx` (또는 signin 디렉터리 규약에 맞는 위치) 신규 생성:
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+interface SessionExpiredToastProps {
+  error?: string;
+}
+
+/**
+ * 세션 만료(error=auth)로 로그인 페이지에 도달했을 때 1회 토스트 고지.
+ * 인라인 배너(상시)와 별개로 즉시 인지를 돕는다 (ADR-F26).
+ */
+export function SessionExpiredToast({ error }: SessionExpiredToastProps) {
+  const shown = useRef(false);
+  useEffect(() => {
+    if (error === "auth" && !shown.current) {
+      shown.current = true;
+      toast.error("세션이 만료되어 다시 로그인이 필요해요");
+    }
+  }, [error]);
+  return null;
+}
+```
+
+`useRef` 가드는 StrictMode 의 double-invoke / 리렌더로 토스트가 중복되는 것을 막는다.
+
+### 2. `src/app/auth/signin/page.tsx` — 컴포넌트 마운트
+
+`error` 값을 `SessionExpiredToast` 에 전달한다. 기존 인라인 배너는 그대로 둔다.
+
+```tsx
+import { SessionExpiredToast } from "./_components/SessionExpiredToast";
+// ...
+return (
+  <AuthCenterCard ...>
+    <SessionExpiredToast error={error} />
+    {(error || customMessage) && ( /* 기존 인라인 배너 그대로 */ )}
+    <SignInForm callbackUrl={callbackUrl} />
+    {/* ... */}
+  </AuthCenterCard>
+);
+```
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/app/auth/signin/_components/SessionExpiredToast.tsx` | 신규 — 만료 토스트 트리거 |
+| `src/app/auth/signin/page.tsx` | 수정 — 컴포넌트 마운트 |
+
+## 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+pnpm lint
+pnpm build 2>&1 | tail -15
+
+# 신규 컴포넌트 존재 + "use client"
+head -1 src/app/auth/signin/_components/SessionExpiredToast.tsx | grep -q "use client" && echo "use client OK"
+
+# page 에서 마운트 확인
+grep -n "SessionExpiredToast" src/app/auth/signin/page.tsx
+```
+
+기대: 토스트 컴포넌트 존재 + `"use client"` 첫 줄, page 에 import+마운트 2건, `pnpm lint`/`pnpm build` 성공.
+
+수동 smoke (`pnpm dev`):
+- `/auth/signin?error=auth` 진입 → sonner 토스트 "세션이 만료되어 다시 로그인이 필요해요" + 인라인 배너 동시 표시.
+- `/auth/signin` (error 없음) 진입 → 토스트 미표시.
+
+## 의도 메모 (왜)
+
+- 인라인 배너를 토스트로 대체하지 않고 둘 다 둔 이유: 배너는 network/profile/OAuth 등 모든 error 유형 공통이라 제거 불가. 토스트는 만료 케이스의 즉시 인지를 보강 (한쪽은 상시 배너, 한쪽은 일시 토스트).
+- 토스트 메시지를 평이한 한국어로 둔 이유: 한국어 표현 정책 (외래어/직역 회피).

--- a/tasks/plan025-auth-token-expiry-handling/phase-05.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-05.md
@@ -50,7 +50,8 @@ grep -n "SessionExpiredToast" src/app/auth/signin/page.tsx
 
 ```bash
 # cwd: /Users/nhn/personal/fos-accountbook
-sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan025-auth-token-expiry-handling/index.json
+# perl 사용 — macOS(BSD)/Linux(GNU) 양쪽 호환 (sed -i 는 두 환경의 백업 인수 문법이 달라 깨짐)
+perl -i -pe 's/"status": "pending"/"status": "completed"/g' tasks/plan025-auth-token-expiry-handling/index.json
 
 # 검증: index 1개 + phase 5개 = 6건
 grep -c '"status": "completed"' tasks/plan025-auth-token-expiry-handling/index.json

--- a/tasks/plan025-auth-token-expiry-handling/phase-05.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-05.md
@@ -1,0 +1,75 @@
+# Phase 05 — 통합 검증 + index.json completed 마킹
+
+**Model**: haiku
+**Status**: pending
+
+---
+
+## 목표
+
+phase 1~4 의 변경을 통합 검증하고, 잔재를 grep 으로 확인한 뒤 task 를 완료 처리한다.
+
+---
+
+## 작업 항목 (3)
+
+### 1. 통합 검증
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+pnpm lint
+pnpm test --silent 2>&1 | tail -25
+pnpm build 2>&1 | tail -15
+```
+
+기대: lint exit 0, 전체 테스트 통과, build 성공.
+
+### 2. 변경 잔재 / 회귀 grep
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+
+# phase 1 — 401 변환 + 인증 가드 적용됨
+grep -n "static sessionExpired" src/lib/errors/action-error.ts
+grep -nE "status === 401" src/lib/errors/action-error.ts
+grep -nE 'code === "A002"' src/lib/server/action-result-handler.ts
+
+# phase 2 — refresh 실패 가드 적용됨
+grep -nE 'token.error === "RefreshAccessTokenError"' src/lib/server/auth/config.ts
+
+# phase 3 — 로그아웃 form 제거됨
+! grep -nE '<form action=\{signOutAction\}' src/components/layout/Header.tsx
+
+# phase 4 — 토스트 컴포넌트 마운트됨
+grep -n "SessionExpiredToast" src/app/auth/signin/page.tsx
+```
+
+기대: `!` 가 붙은 grep 은 exit 1(매치 없음), 나머지는 1건 이상 매치.
+
+### 3. index.json + 모든 phase status 를 completed 로 마킹 (단일 commit 포함)
+
+```bash
+# cwd: /Users/nhn/personal/fos-accountbook
+sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/plan025-auth-token-expiry-handling/index.json
+
+# 검증: index 1개 + phase 5개 = 6건
+grep -c '"status": "completed"' tasks/plan025-auth-token-expiry-handling/index.json
+```
+
+기대: `grep -c` 결과 = 6 (top-level status 1 + phases 5).
+
+각 phase-NN.md 본문 상단 `**Status**: pending` 도 `completed` 로 갱신 (선택 — index.json 이 단일 소스).
+
+이 phase 의 변경(검증 + completed 마킹)을 마지막 commit 에 포함한다.
+
+---
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `tasks/plan025-auth-token-expiry-handling/index.json` | 수정 — status completed |
+
+## 의도 메모 (왜)
+
+- 마지막 phase 가 completed 마킹을 자체 포함하는 이유: executor 가 scope 가드로 자체 추가하지 않으므로(올바른 행동), team-lead 의 PR 직전 main 직접 수정 유혹을 없앤다 (common-pitfalls § 1-8).


### PR DESCRIPTION
## Summary

로그인 만료 후 재접속 시 발생하는 두 가지 인증 문제의 수정 설계(docs + task)다.

- 백엔드 401(토큰 만료)을 인증 만료로 분류해 로그인 페이지로 일관 리다이렉트하도록 설계한다.
- 로그아웃 버튼이 항상 동작하지 않는 Radix form submit 유실을 수정하도록 설계한다.

본 PR 은 계획(ADR + task)만 머지한다. 구현은 `/build-with-teams plan025` 로 별도 PR.

## Changes

### docs — ADR 2건
- **ADR-F26**: 백엔드 401 을 `ActionError.sessionExpired()`(A002)로 변환, `getActionDataOrDefault` 가 인증 에러를 빈 데이터로 숨기지 않고 redirect, refresh 실패는 jwt callback 에서 `token.error` 표시만 하고 무효화는 401 시점.
- **ADR-F27**: Radix `DropdownMenuItem` 안에서 `<form>` submit 금지, `onSelect` 에서 preventDefault 후 Server Action 직접 호출.
- `CLAUDE.md` 상황별 ADR 표에 F26/F27 행 추가.

### task — plan025 (5 phase)
- phase 1 — 401 → A002 분류 + 인증 에러 가드 (`action-error.ts`, `action-result-handler.ts`)
- phase 2 — jwt callback refresh 실패 `token.error` 가드 (`config.ts`, `next-auth.d.ts`)
- phase 3 — 로그아웃 버튼 Radix submit 수정 (`Header.tsx`)
- phase 4 — signin 세션 만료 sonner 토스트 (`SessionExpiredToast`)
- phase 5 — 통합 검증 + completed 마킹

## Verification

문서/task 변경이라 코드 빌드 영향 없음. 구현 PR 에서 검증할 항목:

- `pnpm lint && pnpm test && pnpm build` 통과
- 401 응답 → `/auth/signin?error=auth` 리다이렉트 + 만료 토스트 표시
- dashboard/budget 이 만료 응답을 빈 데이터(0)로 숨기지 않음
- 로그아웃 버튼 클릭 시 항상 `signOutAction` 호출 (정상 세션 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
