### PR TITLE
feat(auth): 401 토큰 만료 인증 처리 + 로그아웃 버튼 수정 (plan025)

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -460,7 +460,7 @@
 - **대안 기각**:
   - HTTP 클라이언트 (`client.ts` afterResponse hook) 에서 직접 redirect: Service 레이어에서 호출되는데 `redirect()` 는 RSC/Action context 구분이 필요해 레이어 경계를 깬다. 변환은 에러 레이어에 두는 것이 책임에 맞다.
   - jwt callback 에서 refresh 실패 즉시 세션 무효화: NextAuth v5 동작 검증 부담이 크고, 페이지 진입 자체가 차단돼 토스트 고지 흐름과 맞물리기 어렵다. 401 시점 무효화가 기존 `action-result-handler` 흐름과 일관된다.
-- **적용 범위**: `src/lib/errors/action-error.ts` (변환) + `src/lib/server/action-result-handler.ts` (인증 에러 가드) + `src/lib/server/auth/config.ts` (token.error 표시) + signin 토스트.
+- **적용 범위**: `src/lib/errors/action-error.ts` (변환) + `src/lib/server/action-result-handler.ts` (인증 에러 가드) + `src/lib/server/auth/refresh-token.ts` (refresh 가드·token.error 표시) + `src/lib/server/auth/config.ts` (jwt callback 진입점) + signin 토스트.
 
 ## ADR-F27: Radix `DropdownMenuItem` 안에서 form submit 금지 — `onSelect` 직접 호출 (2026-06-02)
 

--- a/src/__tests__/auth/jwt-refresh-guard.test.ts
+++ b/src/__tests__/auth/jwt-refresh-guard.test.ts
@@ -1,0 +1,95 @@
+/**
+ * jwt callback refresh 실패 가드 단위 테스트 (ADR-F09 jest.mock 방식)
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/env/server.env", () => ({
+  serverEnv: {
+    BACKEND_API_URL: "http://localhost:8080",
+  },
+}));
+
+jest.mock("@/lib/server/auth/backend-auth");
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({ set: jest.fn() }),
+}));
+
+import { refreshBackendToken } from "@/lib/server/auth/backend-auth";
+import { refreshTokenIfNeeded } from "@/lib/server/auth/refresh-token";
+import type { JWT } from "next-auth/jwt";
+
+const mockRefreshBackendToken = refreshBackendToken as jest.MockedFunction<
+  typeof refreshBackendToken
+>;
+
+function makeToken(overrides: Partial<JWT> = {}): JWT {
+  const futureExpiry = new Date(Date.now() + 3600000).toISOString();
+  return {
+    userUuid: "test-uuid",
+    backendAccessToken: "access-token",
+    backendRefreshToken: "refresh-token",
+    backendTokenExpiredAt: futureExpiry,
+    backendTokenIssuedAt: new Date().toISOString(),
+    profile: null,
+    ...overrides,
+  };
+}
+
+function makeExpiredToken(overrides: Partial<JWT> = {}): JWT {
+  const pastExpiry = new Date(Date.now() - 1000).toISOString();
+  return makeToken({ backendTokenExpiredAt: pastExpiry, ...overrides });
+}
+
+describe("refreshTokenIfNeeded — refresh 실패 가드", () => {
+  beforeEach(() => {
+    mockRefreshBackendToken.mockClear();
+  });
+
+  it("refresh 실패 시 token.error를 RefreshAccessTokenError로 설정한다", async () => {
+    mockRefreshBackendToken.mockResolvedValue({
+      success: false,
+      error: "Unauthorized",
+    });
+
+    const token = makeExpiredToken();
+    const result = await refreshTokenIfNeeded(token);
+
+    expect(result.error).toBe("RefreshAccessTokenError");
+    expect(mockRefreshBackendToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("token.error가 이미 설정된 경우 refreshBackendToken을 호출하지 않는다 (재시도 스킵)", async () => {
+    const token = makeExpiredToken({ error: "RefreshAccessTokenError" });
+    const result = await refreshTokenIfNeeded(token);
+
+    expect(mockRefreshBackendToken).not.toHaveBeenCalled();
+    expect(result.error).toBe("RefreshAccessTokenError");
+  });
+
+  it("refresh 성공 시 토큰을 갱신하고 token.error가 undefined로 초기화된다", async () => {
+    mockRefreshBackendToken.mockResolvedValue({
+      success: true,
+      data: {
+        user: { uuid: "test-uuid", email: "test@test.com", name: "테스트" },
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+        expiredAt: new Date(Date.now() + 3600000).toISOString(),
+        issuedAt: new Date().toISOString(),
+      },
+    });
+
+    const token = makeExpiredToken({ error: undefined });
+    const result = await refreshTokenIfNeeded(token);
+
+    expect(result.backendAccessToken).toBe("new-access-token");
+    expect(result.error).toBeUndefined();
+    expect(mockRefreshBackendToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("만료 임박하지 않은 토큰은 refresh를 시도하지 않는다", async () => {
+    const token = makeToken();
+    await refreshTokenIfNeeded(token);
+
+    expect(mockRefreshBackendToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/layout/Header.test.tsx
+++ b/src/__tests__/components/layout/Header.test.tsx
@@ -212,7 +212,7 @@ describe("Header", () => {
       await user.click(logoutButton);
     });
 
-    // Then — signOutAction 이 form submit 으로 호출됨
+    // Then — signOutAction 이 onSelect 에서 직접 호출됨 (ADR-F27)
     await waitFor(() => {
       expect(mockSignOutAction).toHaveBeenCalled();
     });

--- a/src/__tests__/lib/action-error.test.ts
+++ b/src/__tests__/lib/action-error.test.ts
@@ -1,0 +1,74 @@
+/**
+ * handleActionError 변환기 단위 테스트 (ADR-F09 jest.mock 방식)
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/env/server.env", () => ({
+  serverEnv: {
+    BACKEND_API_URL: "http://localhost:8080",
+  },
+}));
+
+import { handleActionError, ActionError } from "@/lib/errors/action-error";
+import { ServerApiError } from "@/lib/server/api/types";
+
+describe("handleActionError 변환기", () => {
+  describe("ServerApiError 401 → A002 변환", () => {
+    it("status 401 ServerApiError를 A002(SESSION_EXPIRED)로 변환한다", () => {
+      const error = new ServerApiError("Unauthorized", 401);
+      const result = handleActionError(error, "기본 에러 메시지");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("A002");
+        expect(result.error.message).toBe("세션이 만료되었습니다");
+      }
+    });
+
+    it("status 401이 아닌 ServerApiError(500)는 internalError(C 계열)로 변환한다 (회귀 방지)", () => {
+      const error = new ServerApiError("Internal Server Error", 500);
+      const result = handleActionError(error, "서버 오류");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("C003");
+      }
+    });
+
+    it("status 없는 ServerApiError는 internalError(C 계열)로 변환한다", () => {
+      const error = new ServerApiError("Unknown error");
+      const result = handleActionError(error, "서버 오류");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("C003");
+      }
+    });
+  });
+
+  describe("이미 ActionError인 경우 그대로 통과", () => {
+    it("ActionError는 변환 없이 그대로 반환한다", () => {
+      const error = ActionError.unauthorized();
+      const result = handleActionError(error, "기본 메시지");
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe("A001");
+      }
+    });
+  });
+
+  describe("ActionError.sessionExpired() 헬퍼", () => {
+    it("기본 메시지로 A002 에러를 생성한다", () => {
+      const error = ActionError.sessionExpired();
+      expect(error.code).toBe("A002");
+      expect(error.message).toBe("세션이 만료되었습니다");
+    });
+
+    it("커스텀 메시지로 A002 에러를 생성한다", () => {
+      const error = ActionError.sessionExpired("토큰이 만료되었습니다");
+      expect(error.code).toBe("A002");
+      expect(error.message).toBe("토큰이 만료되었습니다");
+    });
+  });
+});

--- a/src/__tests__/lib/action-result-handler.test.ts
+++ b/src/__tests__/lib/action-result-handler.test.ts
@@ -1,0 +1,101 @@
+/**
+ * action-result-handler 단위 테스트 (ADR-F09 jest.mock 방식)
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/env/server.env", () => ({
+  serverEnv: {
+    BACKEND_API_URL: "http://localhost:8080",
+  },
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+
+import { redirect } from "next/navigation";
+import {
+  getActionDataOrDefault,
+  handleActionError,
+} from "@/lib/server/action-result-handler";
+import type { ActionResult } from "@/lib/errors";
+
+const mockRedirect = redirect as jest.MockedFunction<typeof redirect>;
+
+describe("getActionDataOrDefault", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("성공 결과는 데이터를 반환한다", () => {
+    const result: ActionResult<number> = { success: true, data: 42 };
+    const value = getActionDataOrDefault(result, 0);
+    expect(value).toBe(42);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("A002(SESSION_EXPIRED) 실패 결과는 redirect를 호출한다 (ADR-F26)", () => {
+    const result: ActionResult<number> = {
+      success: false,
+      error: { code: "A002", message: "세션이 만료되었습니다" },
+    };
+
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    expect(() => getActionDataOrDefault(result, 0)).toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/signin")
+    );
+  });
+
+  it("A001(UNAUTHORIZED) 실패 결과는 redirect를 호출한다 (ADR-F26)", () => {
+    const result: ActionResult<number> = {
+      success: false,
+      error: { code: "A001", message: "로그인이 필요합니다" },
+    };
+
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    expect(() => getActionDataOrDefault(result, 0)).toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/signin")
+    );
+  });
+
+  it("비인증 실패 결과(C 계열)는 기본값을 반환한다", () => {
+    const result: ActionResult<number> = {
+      success: false,
+      error: { code: "C003", message: "서버 오류" },
+    };
+
+    const value = getActionDataOrDefault(result, 99);
+    expect(value).toBe(99);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleActionError (redirect 처리기)", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("A002 에러는 /auth/signin?error=auth 로 redirect한다", () => {
+    const result = {
+      success: false as const,
+      error: { code: "A002" as const, message: "세션이 만료되었습니다" },
+    };
+
+    mockRedirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    expect(() => handleActionError(result)).toThrow("NEXT_REDIRECT");
+    expect(mockRedirect).toHaveBeenCalledWith(
+      expect.stringContaining("error=auth")
+    );
+  });
+});

--- a/src/app/auth/signin/_components/SessionExpiredToast.tsx
+++ b/src/app/auth/signin/_components/SessionExpiredToast.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 interface SessionExpiredToastProps {
-  error?: string;
+  error?: "auth";
 }
 
 /**

--- a/src/app/auth/signin/_components/SessionExpiredToast.tsx
+++ b/src/app/auth/signin/_components/SessionExpiredToast.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+interface SessionExpiredToastProps {
+  error?: string;
+}
+
+/**
+ * 세션 만료(error=auth)로 로그인 페이지에 도달했을 때 1회 토스트 고지.
+ * 인라인 배너(상시)와 별개로 즉시 인지를 돕는다 (ADR-F26).
+ */
+export function SessionExpiredToast({ error }: SessionExpiredToastProps) {
+  const shown = useRef(false);
+  useEffect(() => {
+    if (error === "auth" && !shown.current) {
+      shown.current = true;
+      toast.error("세션이 만료되어 다시 로그인이 필요해요");
+    }
+  }, [error]);
+  return null;
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -25,7 +25,7 @@ export default async function SignInPage({
       title="우리집 가계부"
       subtitle="가족과 함께 관리하는 스마트 가계부"
     >
-      <SessionExpiredToast error={error} />
+      <SessionExpiredToast error={error === "auth" ? "auth" : undefined} />
       {(error || customMessage) && (
         <div className="bg-expense/10 border border-expense/20 text-expense px-4 py-3 rounded-md">
           <p className="text-sm font-medium">

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,6 +1,7 @@
 import { Users } from "lucide-react";
 import { AuthCenterCard } from "@/components/auth/AuthCenterCard";
 import { SignInForm } from "@/components/auth/SignInForm";
+import { SessionExpiredToast } from "./_components/SessionExpiredToast";
 
 export default async function SignInPage({
   searchParams,
@@ -24,6 +25,7 @@ export default async function SignInPage({
       title="우리집 가계부"
       subtitle="가족과 함께 관리하는 스마트 가계부"
     >
+      <SessionExpiredToast error={error} />
       {(error || customMessage) && (
         <div className="bg-expense/10 border border-expense/20 text-expense px-4 py-3 rounded-md">
           <p className="text-sm font-medium">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -124,16 +124,15 @@ export function Header({ session, selectedFamilyUuid }: HeaderProps) {
                     <span>설정</span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem className="text-expense focus:text-expense" asChild>
-                    <form action={signOutAction}>
-                      <button
-                        type="submit"
-                        className="flex items-center w-full"
-                      >
-                        <LogOut className="mr-2 h-4 w-4" />
-                        <span>로그아웃</span>
-                      </button>
-                    </form>
+                  <DropdownMenuItem
+                    className="text-expense focus:text-expense"
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      void signOutAction();
+                    }}
+                  >
+                    <LogOut className="mr-2 h-4 w-4" />
+                    <span>로그아웃</span>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/src/lib/errors/action-error.ts
+++ b/src/lib/errors/action-error.ts
@@ -4,6 +4,7 @@
  */
 
 import { ERROR_MESSAGES, type ErrorCode } from "./error-code";
+import { ServerApiError } from "@/lib/server/api/types";
 
 /**
  * Server Action 에러 정보
@@ -110,6 +111,13 @@ export class ActionError extends Error {
    */
   static unauthorized(message?: string): ActionError {
     return new ActionError("A001", message || "로그인이 필요합니다");
+  }
+
+  /**
+   * 세션 만료
+   */
+  static sessionExpired(message?: string): ActionError {
+    return new ActionError("A002", message || "세션이 만료되었습니다");
   }
 
   /**
@@ -228,6 +236,11 @@ export function handleActionError(
   // 이미 ActionError인 경우
   if (error instanceof ActionError) {
     return error.toFailureResult();
+  }
+
+  // 백엔드 401 = 인증 만료 (ADR-F26)
+  if (error instanceof ServerApiError && error.status === 401) {
+    return ActionError.sessionExpired().toFailureResult();
   }
 
   // Error 객체인 경우

--- a/src/lib/server/action-result-handler.ts
+++ b/src/lib/server/action-result-handler.ts
@@ -172,6 +172,11 @@ export function getActionDataOrDefault<T>(
     return result.data;
   }
 
+  // 인증 에러는 빈 데이터로 숨기지 않고 로그인으로 (ADR-F26)
+  if (result.error.code === "A001" || result.error.code === "A002") {
+    return handleActionError(result);
+  }
+
   // 에러 로깅 (선택적)
   console.error("Action failed, using default value:", {
     code: result.error.code,

--- a/src/lib/server/auth/config.ts
+++ b/src/lib/server/auth/config.ts
@@ -1,8 +1,9 @@
 import type { NextAuthConfig } from "next-auth";
 import Google from "next-auth/providers/google";
 import Naver from "next-auth/providers/naver";
-import { refreshBackendToken, requestSocialLogin } from "./backend-auth";
+import { requestSocialLogin } from "./backend-auth";
 import { fetchUserProfile } from "./profile-fetcher";
+import { refreshTokenIfNeeded } from "./refresh-token";
 
 export const authConfig = {
   providers: [Google, Naver],
@@ -62,33 +63,7 @@ export const authConfig = {
         return token;
       }
 
-      // 토큰 갱신이 필요한 경우 (만료 시간 체크)
-      if (
-        token.backendTokenExpiredAt &&
-        token.backendRefreshToken &&
-        token.backendAccessToken
-      ) {
-        const expiredAt = new Date(token.backendTokenExpiredAt);
-        const now = new Date();
-        const bufferTime = 5 * 60 * 1000; // 5분 전에 갱신
-
-        // 토큰이 만료되기 5분 전이면 갱신
-        if (now.getTime() >= expiredAt.getTime() - bufferTime) {
-          console.log("[auth.js callback (JWT)] refreshing backend token");
-          const refreshedResponse = await refreshBackendToken({
-            refreshToken: token.backendRefreshToken,
-          });
-
-          if (refreshedResponse.success) {
-            token.backendAccessToken = refreshedResponse.data.accessToken;
-            token.backendRefreshToken = refreshedResponse.data.refreshToken;
-            token.backendTokenExpiredAt = refreshedResponse.data.expiredAt;
-            token.backendTokenIssuedAt = refreshedResponse.data.issuedAt;
-          }
-        }
-      }
-
-      return token;
+      return refreshTokenIfNeeded(token);
     },
 
     /**

--- a/src/lib/server/auth/refresh-token.ts
+++ b/src/lib/server/auth/refresh-token.ts
@@ -1,0 +1,46 @@
+import type { JWT } from "next-auth/jwt";
+import { refreshBackendToken } from "./backend-auth";
+
+/**
+ * refresh 실패 가드를 포함한 토큰 갱신 로직
+ *
+ * - token.error === "RefreshAccessTokenError" 이면 재시도하지 않고 바로 반환 (ADR-F26)
+ * - 만료 5분 전부터 갱신 시도; 실패 시 token.error 설정
+ */
+export async function refreshTokenIfNeeded(token: JWT): Promise<JWT> {
+  // 이미 refresh 실패한 토큰이면 재시도하지 않음 (401 경로가 처리)
+  if (token.error === "RefreshAccessTokenError") {
+    return token;
+  }
+
+  if (
+    token.backendTokenExpiredAt &&
+    token.backendRefreshToken &&
+    token.backendAccessToken
+  ) {
+    const expiredAt = new Date(token.backendTokenExpiredAt);
+    const now = new Date();
+    const bufferTime = 5 * 60 * 1000; // 5분 전에 갱신
+
+    if (now.getTime() >= expiredAt.getTime() - bufferTime) {
+      const refreshedResponse = await refreshBackendToken({
+        refreshToken: token.backendRefreshToken,
+      });
+
+      if (refreshedResponse.success) {
+        token.backendAccessToken = refreshedResponse.data.accessToken;
+        token.backendRefreshToken = refreshedResponse.data.refreshToken;
+        token.backendTokenExpiredAt = refreshedResponse.data.expiredAt;
+        token.backendTokenIssuedAt = refreshedResponse.data.issuedAt;
+        token.error = undefined;
+      } else {
+        console.warn(
+          "[auth.js callback (JWT)] backend token refresh 실패 — 다음 API 호출 401 시 로그인으로 처리"
+        );
+        token.error = "RefreshAccessTokenError";
+      }
+    }
+  }
+
+  return token;
+}

--- a/src/lib/server/auth/refresh-token.ts
+++ b/src/lib/server/auth/refresh-token.ts
@@ -32,11 +32,9 @@ export async function refreshTokenIfNeeded(token: JWT): Promise<JWT> {
         token.backendRefreshToken = refreshedResponse.data.refreshToken;
         token.backendTokenExpiredAt = refreshedResponse.data.expiredAt;
         token.backendTokenIssuedAt = refreshedResponse.data.issuedAt;
-        token.error = undefined;
+        delete token.error;
       } else {
-        console.warn(
-          "[auth.js callback (JWT)] backend token refresh 실패 — 다음 API 호출 401 시 로그인으로 처리"
-        );
+        // 갱신 실패 — token.error 플래그만 설정. 다음 API 호출 401 시 ADR-F26 흐름(A002 → redirect)이 사용자 인지 처리.
         token.error = "RefreshAccessTokenError";
       }
     }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -33,5 +33,7 @@ declare module "next-auth/jwt" {
     backendTokenIssuedAt: string;
     /** 사용자 프로필 정보 (jwt callback에서 캐싱) */
     profile: UserProfile | null;
+    /** refresh 실패 표시 — 설정되면 jwt callback이 추가 refresh 재시도를 건너뜀 */
+    error?: "RefreshAccessTokenError";
   }
 }

--- a/tasks/plan025-auth-token-expiry-handling/index.json
+++ b/tasks/plan025-auth-token-expiry-handling/index.json
@@ -1,7 +1,7 @@
 {
   "name": "plan025-auth-token-expiry-handling",
   "description": "백엔드 401(토큰 만료)을 인증 에러로 분류해 로그인으로 일관 리다이렉트 + refresh 실패 가드 + 로그아웃 버튼 Radix submit 함정 수정",
-  "status": "pending",
+  "status": "completed",
   "created_at": "2026-06-02",
   "total_phases": 5,
   "related_docs": [
@@ -14,35 +14,35 @@
       "file": "phase-01.md",
       "title": "401 응답을 인증 만료(A002)로 분류 + 인증 에러는 기본값으로 숨기지 않기",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 2,
       "file": "phase-02.md",
       "title": "jwt callback refresh 실패 시 token.error 가드 (무한 재시도 방지)",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 3,
       "file": "phase-03.md",
       "title": "로그아웃 버튼 Radix DropdownMenuItem form submit 유실 수정",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 4,
       "file": "phase-04.md",
       "title": "signin 진입 시 세션 만료 sonner 토스트 고지",
       "model": "sonnet",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "number": 5,
       "file": "phase-05.md",
       "title": "통합 검증 + index.json completed 마킹",
       "model": "haiku",
-      "status": "pending"
+      "status": "completed"
     }
   ]
 }

--- a/tasks/plan025-auth-token-expiry-handling/phase-01.md
+++ b/tasks/plan025-auth-token-expiry-handling/phase-01.md
@@ -35,15 +35,17 @@
 
 ### 1. `src/lib/errors/action-error.ts` — `ActionError.sessionExpired()` 헬퍼 추가
 
-`unauthorized()`(111행 근처) 바로 아래에 추가. `ErrorCode.SESSION_EXPIRED`("A002") 사용.
+`unauthorized()`(111행 근처) 바로 아래에 추가. 코드값은 `"A002"` 문자열 리터럴 사용.
 
 ```ts
 static sessionExpired(message?: string): ActionError {
-  return new ActionError(ErrorCode.SESSION_EXPIRED, message || "세션이 만료되었습니다");
+  return new ActionError("A002", message || "세션이 만료되었습니다");
 }
 ```
 
-`ErrorCode` import 가 이미 있는지 확인 — 없으면 `import { ErrorCode } from "./error-code"` 추가 (파일 내 기존 import 스타일 따름).
+import 변경 불필요.
+이 파일의 `ErrorCode` 는 `import { ERROR_MESSAGES, type ErrorCode }` 로 **타입 전용 import** 다.
+값으로 쓰면 tsc TS2693 컴파일 에러가 난다 — 기존 헬퍼(`unauthorized()`→`"A001"`, `familyNotSelected()`→`"F002"`)와 동일하게 문자열 리터럴을 쓴다.
 
 ### 2. `src/lib/errors/action-error.ts` — `handleActionError` 변환기에 401 분기 추가
 


### PR DESCRIPTION
## Summary

로그인 만료 후 재접속 시 발생하던 두 가지 인증 문제를 수정한다 (plan025 구현).
계획 PR #304(ADR + task) 머지 후의 구현 PR.

- 백엔드 401(토큰 만료)을 인증 만료(`A002`)로 분류해 로그인 페이지로 일관 리다이렉트한다.
- 로그아웃 버튼이 항상 동작하지 않던 Radix `form` submit 유실을 수정한다.

## Changes

### Phase 1·2 — 401 → A002 변환 + refresh 가드 (ADR-F26)
- `handleActionError`(변환기)가 `ServerApiError.status === 401`을 `ActionError.sessionExpired()`(A002)로 변환.
- `getActionDataOrDefault`가 인증 에러(A001/A002)를 기본값으로 숨기지 않고 redirect.
- jwt callback refresh 실패 시 `token.error`로 1회 표시 후 재시도 스킵 — 갱신 무한 반복 방지.
- refresh 가드 로직을 `refresh-token.ts`로 분리. nextJest가 `authConfig.callbacks`를 undefined로 처리해 config.ts 직접 단위 테스트가 불가능 → 헬퍼 분리로 테스트 충족. 동작은 동일하고 config.ts는 진입점만 담당.

### Phase 3 — 로그아웃 버튼 수정 (ADR-F27)
- `<DropdownMenuItem asChild><form action>` 구조는 `onSelect` 자동 닫힘이 Portal unmount를 동반해 submit이 유실됐다.
- `onSelect`에서 `preventDefault()` 후 `signOutAction()` 직접 호출로 교체.

### Phase 4 — 세션 만료 토스트 (ADR-F26, ADR-F08)
- `?error=auth` 리다이렉트 시 `SessionExpiredToast`가 sonner 토스트 1회 고지.
- 기존 인라인 배너는 모든 error 공통이라 유지.

### docs
- ADR-F26 적용 범위에 `refresh-token.ts` 반영, config.ts는 진입점으로 정정.

## Review (build-with-teams 5-agent)
- **critic**: APPROVE (phase-01의 `ErrorCode` type-only import → `"A002"` 문자열 리터럴 1건 수정 후 승인).
- **code-reviewer**: PASS. MEDIUM(이동된 `console.log` 제거), LOW(`return handleActionError` 명시) 2건 반영. refresh 네트워크 예외는 `refreshBackendToken`이 try-catch로 항상 `{success}` 반환(throw 안 함) 확인.
- **docs-verifier**: 차단 위반 없음. ADR-F26 적용 범위 docs 정정 1건 반영.

## Test plan
- `pnpm lint` exit 0
- `pnpm test` — 36 suites / 257 passed (신규 테스트 4파일: action-error, action-result-handler, jwt-refresh-guard, Header)
- `pnpm build` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
