### PR TITLE
feat(tokens): brand 색 Teal → Toss 블루(h=257) 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Page (app/) → Action (actions/) → Service (services/) → lib/server/api
 ### 스타일링
 
 - **OKLCH 토큰 강제** (ADR-F13) — `globals.css` 의 `@theme` 블록 외부에서 hex/rgb/hsl 직접 작성 금지
-  - brand: `--color-brand-{50..900}` (Teal h=188)
+  - brand: `--color-brand-{50..900}` (Toss Blue h=257)
   - semantic: `--color-{income|expense|warning}`
   - surface: `--color-{bg|bg-elev|bg-muted|fg|fg-muted|fg-subtle|border|border-strong}` (light/dark 분리)
 - **시맨틱 그라디언트 클래스 필수** — 하드코딩 색상 금지

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -259,7 +259,7 @@
 
 ## ADR-F13: OKLCH 색 시스템 채택
 - **결정**: 모든 디자인 토큰을 OKLCH 색 공간으로 정의한다 (HSL 채널 패턴 폐기). brand 50~900, semantic(income/expense/warning), neutral 0~950, surface(bg/fg/border 등) 모두 `oklch(L C H)` 평면 값.
-- **맥락**: Teal fintech 리디자인(`tokens.js` / `styleguide.css` handoff)에서 brand=Teal h=188 + semantic 분리 + dark mode 토큰을 한 번에 정의해야 함. HSL 은 어두운 색 명도가 hue 따라 다르게 인지됨 → 토큰 스케일이 시각적으로 균일하지 않음.
+- **맥락**: Teal fintech 리디자인(`tokens.js` / `styleguide.css` handoff)에서 brand=Teal h=188(→ 현재 Toss Blue h=257, [ADR-F28](#adr-f28)) + semantic 분리 + dark mode 토큰을 한 번에 정의해야 함. HSL 은 어두운 색 명도가 hue 따라 다르게 인지됨 → 토큰 스케일이 시각적으로 균일하지 않음.
 - **대안 기각**:
   - HSL 채널 + shadcn 패턴 유지: 어두운 색에서 명도 들쭉날쭉. brand 50~900 같은 단계 스케일에 부적합.
   - 하이브리드 (shadcn HSL + OKLCH 일부): 동일 토큰을 두 형식으로 관리 → 동기화 사고 위험.
@@ -473,4 +473,22 @@
   - form 을 `DropdownMenu` 바깥으로 분리: 메뉴 항목 레이아웃을 깨고, 메뉴 닫힘 타이밍과 submit 순서를 다시 맞춰야 해 복잡도만 늘어난다.
   - `onSelect` 유지 + setTimeout 으로 submit 지연: 타이밍 의존이라 취약하다.
 - **적용 범위**: `src/components/layout/Header.tsx`. 향후 메뉴 항목에서 Server Action 호출 시 동일 패턴 적용.
+
+---
+
+<a id="adr-f28"></a>
+
+## ADR-F28: brand 색 Teal(h=188) → Toss Blue(h=257) 변경 (2026-06-02)
+
+- **결정**: brand 토큰 `--color-brand-{50..900}` + tint/fg, 그리고 brand 에서 파생되는 shadow·`--primary`·`--ring`·`gradient-{primary,family,category}` 의 hue 를 188(Teal) 에서 257(Toss Blue) 로 변경한다.
+  - semantic(income 152 / expense 25 / warning 78) 과 neutral(230) 은 불변.
+  - 카테고리 home 톤(`--color-cat-home`)은 brand 와 독립한 카테고리 팔레트라 188(teal) 유지.
+  - dark mode `--primary`/`--ring` 도 257 로 일관 적용.
+- **맥락**: Teal 보다 시원하고 선명한 파랑(Toss `#3182F6` ≈ `oklch(0.624 0.196 257)`) 을 brand 로 선호.
+  brand 토큰만 바꾸면 헤더·버튼·FAB 는 자동 반영되지만, 예산 카드 gradient 는 바뀌지 않았다.
+  gradient 클래스·shadow·`--primary`·`--ring` 이 brand 토큰을 참조하지 않고 hue 를 직접 하드코딩하고 있어, 이들도 257 로 함께 바꿔야 전역 적용이 완성됐다.
+- **트레이드오프**: gradient/shadow 가 `var(--color-brand-*)` 를 참조했다면 토큰 한 곳만 바꾸면 됐다.
+  hue 하드코딩이라 `globals.css` 전반의 188→257 일괄 치환이 필요했다.
+  향후 brand 재변경 비용을 줄이려면 gradient 정의를 brand 토큰 참조로 리팩토링하는 별도 작업이 바람직하다.
+- **적용 범위**: `src/app/globals.css`. ADR-F13 의 OKLCH 체계는 불변 — 본 ADR 은 brand hue 값만 갱신.
 

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -119,7 +119,7 @@ src/
 
 - **단일 소스**: `src/app/globals.css` 의 `@theme` 블록. OKLCH 평면 값 (ADR-F13).
 - **토큰 카테고리**:
-  - `--color-brand-{50..900}` — Teal h=188 스케일 (primary/hover/pressed 파생)
+  - `--color-brand-{50..900}` — Toss Blue h=257 스케일 (primary/hover/pressed 파생)
   - `--color-{income|expense|warning}` — semantic 의미색
   - `--color-neutral-{0..950}` — cool gray h=230
   - `--color-{bg|bg-elev|bg-muted|fg|fg-muted|fg-subtle|border|border-strong}` — surface 토큰 (light/dark 분리)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,18 +3,18 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-  /* ── brand teal (h=188) ─────────────────────── */
-  --color-brand-tint: oklch(0.975 0.025 188); /* Hero fade 배경 (brand-50 보다 채도 약간 높음) */
-  --color-brand-50:  oklch(0.975 0.018 188);
-  --color-brand-100: oklch(0.945 0.040 188);
-  --color-brand-200: oklch(0.890 0.075 188);
-  --color-brand-300: oklch(0.810 0.105 188);
-  --color-brand-400: oklch(0.720 0.130 188);
-  --color-brand-500: oklch(0.640 0.140 188);
-  --color-brand-600: oklch(0.555 0.130 188);
-  --color-brand-700: oklch(0.470 0.110 188);
-  --color-brand-800: oklch(0.385 0.090 188);
-  --color-brand-900: oklch(0.300 0.070 188);
+  /* ── brand toss blue (h=257) ────────────────── */
+  --color-brand-tint: oklch(0.975 0.030 257); /* Hero fade 배경 (brand-50 보다 채도 약간 높음) */
+  --color-brand-50:  oklch(0.975 0.020 257);
+  --color-brand-100: oklch(0.945 0.048 257);
+  --color-brand-200: oklch(0.890 0.090 257);
+  --color-brand-300: oklch(0.810 0.135 257);
+  --color-brand-400: oklch(0.720 0.175 257);
+  --color-brand-500: oklch(0.640 0.190 257);
+  --color-brand-600: oklch(0.555 0.195 257);
+  --color-brand-700: oklch(0.470 0.165 257);
+  --color-brand-800: oklch(0.385 0.130 257);
+  --color-brand-900: oklch(0.300 0.095 257);
 
   /* ── semantic ───────────────────────────────── */
   --color-income:  oklch(0.610 0.150 152);
@@ -23,7 +23,7 @@
   --color-expense-fg: oklch(0.985 0.003 25);
   --color-income-fg:  oklch(0.985 0.003 152);
   --color-warning-fg: oklch(0.985 0.003 78);
-  --color-brand-fg:   oklch(0.985 0.003 188);
+  --color-brand-fg:   oklch(0.985 0.004 257);
 
   /* ── neutral (cool gray, h=230) ─────────────── */
   --color-neutral-0:   oklch(1 0 0);
@@ -59,10 +59,10 @@
   --shadow-default: 0 2px 8px -2px rgb(15 23 42 / 0.06), 0 1px 3px -1px rgb(15 23 42 / 0.04);
   --shadow-popover: 0 8px 24px -8px rgb(15 23 42 / 0.12), 0 2px 6px -2px rgb(15 23 42 / 0.06);
   --shadow-modal:   0 24px 48px -16px rgb(15 23 42 / 0.18), 0 8px 16px -8px rgb(15 23 42 / 0.10);
-  --shadow-brand-btn: 0 6px 18px -6px oklch(0.640 0.140 188 / 0.5);
-  --shadow-hero-cta:  0 10px 28px -10px oklch(0.640 0.140 188 / 0.55);
+  --shadow-brand-btn: 0 6px 18px -6px oklch(0.640 0.140 257 / 0.5);
+  --shadow-hero-cta:  0 10px 28px -10px oklch(0.640 0.140 257 / 0.55);
   --shadow-cta-white: 0 8px 24px oklch(0 0 0 / 0.18);
-  --shadow-fab:     0 6px 20px -4px oklch(0.640 0.140 188 / 0.45),
+  --shadow-fab:     0 6px 20px -4px oklch(0.640 0.140 257 / 0.45),
                     0 2px 6px -2px rgb(15 23 42 / 0.10);
 
   /* ── font (mono only — sans/num from next/font) ─ */
@@ -154,7 +154,7 @@
 
   --background:            oklch(0.155 0.010 230);
   --foreground:            oklch(0.965 0.005 230);
-  --primary:               oklch(0.720 0.130 188);
+  --primary:               oklch(0.720 0.130 257);
   --primary-foreground:    oklch(0.190 0.010 230);
   --secondary:             oklch(0.275 0.012 230);
   --secondary-foreground:  oklch(0.965 0.005 230);
@@ -170,7 +170,7 @@
   --popover-foreground:    oklch(0.965 0.005 230);
   --border:                oklch(0.275 0.012 230);
   --input:                 oklch(0.275 0.012 230);
-  --ring:                  oklch(0.720 0.130 188);
+  --ring:                  oklch(0.720 0.130 257);
 }
 
 @layer base {
@@ -200,13 +200,13 @@
     background: linear-gradient(
       160deg,
       oklch(0.985 0.003 230) 0%,
-      oklch(0.945 0.040 188 / 0.4) 55%,
-      oklch(0.945 0.040 188 / 0.2) 100%
+      oklch(0.945 0.040 257 / 0.4) 55%,
+      oklch(0.945 0.040 257 / 0.2) 100%
     );
   }
 
   .gradient-primary {
-    background-image: linear-gradient(135deg, oklch(0.720 0.130 188) 0%, oklch(0.555 0.130 188) 100%);
+    background-image: linear-gradient(135deg, oklch(0.720 0.130 257) 0%, oklch(0.555 0.130 257) 100%);
   }
 
   .gradient-expense {
@@ -222,7 +222,7 @@
   }
 
   .gradient-family {
-    background-image: linear-gradient(135deg, oklch(0.810 0.105 188) 0%, oklch(0.640 0.140 188) 100%);
+    background-image: linear-gradient(135deg, oklch(0.810 0.105 257) 0%, oklch(0.640 0.140 257) 100%);
   }
 
   .hero-fade {
@@ -230,7 +230,7 @@
   }
 
   .gradient-category {
-    background-image: linear-gradient(135deg, oklch(0.890 0.075 188) 0%, oklch(0.720 0.130 188) 100%);
+    background-image: linear-gradient(135deg, oklch(0.890 0.075 257) 0%, oklch(0.720 0.130 257) 100%);
   }
 
   .gradient-card-label {


### PR DESCRIPTION
## 무엇을

brand 색을 Teal(h=188) 에서 Toss 블루(h=257, `#3182F6`) 로 변경한다.
더 시원하고 선명한 파랑을 brand 로 쓴다.

## 변경

- `globals.css`: brand 토큰 + 파생(shadow·`--primary`·`--ring`·gradient) hue 188→257
- semantic(지출 빨강·수입 초록·잔여 주황)·neutral 불변
- 카테고리 home 톤(`--color-cat-home`)은 brand 와 독립한 팔레트라 188(teal) 유지
- dark mode `--primary`·`--ring` 도 257 일관
- docs: ADR-F28 신설 + ADR-F13 cross-ref + CLAUDE.md·code-architecture hue 표기 갱신

## 미리보기 검증

dev 에서 전역 적용 확인:

- 헤더·버튼·FAB·예산 gradient·카테고리 헤더 모두 Toss 블루
- semantic·카테고리 색 dot 영향 없음
- `pnpm build` 정상 — Compiled successfully (static 15/15)

## 후속 (별도)

- `docs/flow.md`(4곳)·`ADR-F24` 의 시각 설명 "Teal gradient" 잔여 표기 일괄 정리
- gradient·shadow 가 hue 를 하드코딩 → brand 토큰 참조로 리팩토링하면 향후 재변경이 토큰 한 곳으로 끝난다 (ADR-F28 트레이드오프)

## 의존

이 브랜치는 main 기반이라 빌드 fix(#306) 가 없어 task md 의 Tailwind 깨짐 패턴이 남아 있다.
그 때문에 dev 는 500 이 날 수 있으나 색상 변경과 무관하고, production build 는 통과한다.
#306 머지 후 rebase 하면 해소된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
