### PR TITLE
docs(workflow): 계획+구현 단일 PR 전환 + build-with-teams 노하우

### DIFF
--- a/.claude/skills/build-with-teams/SKILL.md
+++ b/.claude/skills/build-with-teams/SKILL.md
@@ -376,7 +376,8 @@ critic 평가 관점:
 
 단순 "재평가 부탁" 만 보내면 critic 이 캐시된 v1 결과를 재전송 가능. critic 회신이 v1 과 동일 내용이면 즉시 강제 재읽기 메시지 송신 (이번 세션 plan007-2 에서 1회 발생, 위 패턴으로 즉시 회복).
 
-**docs-verifier / code-reviewer 도 동일 v1 재전송 (fos-accountbook plan026 직접 관측)**: critic 뿐 아니라 docs-verifier(architect) 도 재검증 시 "재전송합니다" 라며 이미 수정된 지적을 잔존으로 회신하는 사고. 위 critic 패턴을 그대로 적용하되, 한 단계 더 강하게 — team-lead 가 **수정된 실제 파일 라인을 직접 grep/awk 로 떠서 재검증 메시지에 증거로 붙인다**.
+**docs-verifier / code-reviewer 도 동일 v1 재전송 (fos-accountbook plan026 직접 관측)**: critic 뿐 아니라 docs-verifier(architect) 도 재검증 시 "재전송합니다" 라며 이미 수정된 지적을 잔존으로 회신하는 사고.
+위 critic 패턴을 그대로 적용하되, 한 단계 더 강하게 — team-lead 가 **수정된 실제 파일 라인을 직접 grep/awk 로 떠서 재검증 메시지에 증거로 붙인다**.
 
 ```
 $ grep -cE "<수정 확인 패턴>" <파일>
@@ -385,7 +386,8 @@ $ awk 'NR==<줄>' <파일>
 <실제 수정된 라인 내용>
 ```
 
-증거를 붙이면 sub-agent 가 캐시 대신 실제 상태를 보고 재판정한다. plan026 에서 docs-verifier 1회 v1 재전송 → 라인 증거 첨부 후 즉시 PASS 회복.
+증거를 붙이면 sub-agent 가 캐시 대신 실제 상태를 보고 재판정한다.
+plan026 에서 docs-verifier 1회 v1 재전송 → 라인 증거 첨부 후 즉시 PASS 회복.
 
 ### 6. executor 실행
 
@@ -404,7 +406,8 @@ executor 규칙:
 - 완료/실패 시 team-lead 에게 결과 보고
 - 코드 주석 규칙은 프로젝트 `CLAUDE.md` 를 따른다 (자명한 내용을 한국어로 번역한 주석 금지)
 
-**phase별 executor 스폰 — 4+ phase 대 규모 권장 (fos-accountbook plan026 관측)**: 단일 executor 가 여러 phase 를 순차 처리하면 idle 알림 / 완료 보고 / 다음 phase 지시가 메시지 큐에서 교차해 "이미 완료했습니다" 혼선이 반복된다 (plan026 에서 phase 2~4 에 3회 발생). phase 경계마다 executor 를 새로 스폰하면 각 phase 가 깨끗한 컨텍스트로 시작하고 보고-종료가 명확해진다.
+**phase별 executor 스폰 — 4+ phase 대 규모 권장 (fos-accountbook plan026 관측)**: 단일 executor 가 여러 phase 를 순차 처리하면 idle 알림 / 완료 보고 / 다음 phase 지시가 메시지 큐에서 교차해 "이미 완료했습니다" 혼선이 반복된다 (plan026 에서 phase 2~4 에 3회 발생).
+phase 경계마다 executor 를 새로 스폰하면 각 phase 가 깨끗한 컨텍스트로 시작하고 보고-종료가 명확해진다.
 
 - 한 phase 완료 보고를 받으면 그 executor 에 `shutdown_request` → 승인 후 다음 phase 전용 executor 를 새 이름(`executor-p{N}`)으로 스폰.
 - 새 이름을 쓰면 inactive 멤버 이름 충돌(`-2` suffix) + auto-deliver 누락도 회피.
@@ -413,7 +416,9 @@ executor 규칙:
 
 ### 검증 grep 은 변수 없이 직접 경로 (fos-accountbook plan026 관측)
 
-team-lead·executor 가 `SK=".../a .../b"; grep ... $SK` 처럼 셸 변수로 grep 경로를 넘기면, 변수가 빈 값으로 확장돼 **0건으로 오인**하는 사고가 plan026 에서 2회 발생 (실제론 잔존하는데 통과로 판정). 검증 grep 은 경로를 직접 나열한다. 0건이 나오면 변수 확장부터 의심하고 단일 경로로 재확인.
+team-lead·executor 가 `SK=".../a .../b"; grep ... $SK` 처럼 셸 변수로 grep 경로를 넘기면, 변수가 빈 값으로 확장돼 **0건으로 오인**하는 사고가 plan026 에서 2회 발생했다 (실제론 잔존하는데 통과로 판정).
+검증 grep 은 경로를 직접 나열한다.
+0건이 나오면 변수 확장부터 의심하고 단일 경로로 재확인한다.
 
 ### 7. 코드 품질 검사 (code-reviewer)
 

--- a/.claude/skills/build-with-teams/SKILL.md
+++ b/.claude/skills/build-with-teams/SKILL.md
@@ -376,6 +376,17 @@ critic 평가 관점:
 
 단순 "재평가 부탁" 만 보내면 critic 이 캐시된 v1 결과를 재전송 가능. critic 회신이 v1 과 동일 내용이면 즉시 강제 재읽기 메시지 송신 (이번 세션 plan007-2 에서 1회 발생, 위 패턴으로 즉시 회복).
 
+**docs-verifier / code-reviewer 도 동일 v1 재전송 (fos-accountbook plan026 직접 관측)**: critic 뿐 아니라 docs-verifier(architect) 도 재검증 시 "재전송합니다" 라며 이미 수정된 지적을 잔존으로 회신하는 사고. 위 critic 패턴을 그대로 적용하되, 한 단계 더 강하게 — team-lead 가 **수정된 실제 파일 라인을 직접 grep/awk 로 떠서 재검증 메시지에 증거로 붙인다**.
+
+```
+$ grep -cE "<수정 확인 패턴>" <파일>
+0          ← 이미 해소됨
+$ awk 'NR==<줄>' <파일>
+<실제 수정된 라인 내용>
+```
+
+증거를 붙이면 sub-agent 가 캐시 대신 실제 상태를 보고 재판정한다. plan026 에서 docs-verifier 1회 v1 재전송 → 라인 증거 첨부 후 즉시 PASS 회복.
+
 ### 6. executor 실행
 
 critic APPROVE 후 executor 를 `run_in_background: true`, `mode: "bypassPermissions"` 로 스폰. critic 승인 + docs-verifier 검증의 이중 안전망이 있으므로 executor 는 권한 확인 없이 실행.
@@ -392,6 +403,17 @@ executor 규칙:
 - **커밋은 하지 않음** — team-lead 가 검증 후 커밋
 - 완료/실패 시 team-lead 에게 결과 보고
 - 코드 주석 규칙은 프로젝트 `CLAUDE.md` 를 따른다 (자명한 내용을 한국어로 번역한 주석 금지)
+
+**phase별 executor 스폰 — 4+ phase 대 규모 권장 (fos-accountbook plan026 관측)**: 단일 executor 가 여러 phase 를 순차 처리하면 idle 알림 / 완료 보고 / 다음 phase 지시가 메시지 큐에서 교차해 "이미 완료했습니다" 혼선이 반복된다 (plan026 에서 phase 2~4 에 3회 발생). phase 경계마다 executor 를 새로 스폰하면 각 phase 가 깨끗한 컨텍스트로 시작하고 보고-종료가 명확해진다.
+
+- 한 phase 완료 보고를 받으면 그 executor 에 `shutdown_request` → 승인 후 다음 phase 전용 executor 를 새 이름(`executor-p{N}`)으로 스폰.
+- 새 이름을 쓰면 inactive 멤버 이름 충돌(`-2` suffix) + auto-deliver 누락도 회피.
+- 소~중 규모(1~3 phase)는 단일 executor 로 충분 — 스폰 오버헤드가 혼선 비용을 넘는다.
+- phase 가 자기완결적(이전 대화 없이 독립 실행 가능)이라 컨텍스트 비공유가 무해하다.
+
+### 검증 grep 은 변수 없이 직접 경로 (fos-accountbook plan026 관측)
+
+team-lead·executor 가 `SK=".../a .../b"; grep ... $SK` 처럼 셸 변수로 grep 경로를 넘기면, 변수가 빈 값으로 확장돼 **0건으로 오인**하는 사고가 plan026 에서 2회 발생 (실제론 잔존하는데 통과로 판정). 검증 grep 은 경로를 직접 나열한다. 0건이 나오면 변수 확장부터 의심하고 단일 경로로 재확인.
 
 ### 7. 코드 품질 검사 (code-reviewer)
 

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -166,8 +166,8 @@ task 파일을 **사용자에게 제출하기 전**에 반드시 [`common-pitfal
 3. **`common-pitfalls.md` PLAN-1~9 소진 체크리스트 + 각 phase domain 매칭 CODE-N 함정 사전 해소** — task 제출 전 self-check
 4. **plan 브랜치 생성** — `git switch -c plan/{N}-{kebab-slug} origin/main`. 매 plan 마다 origin/main 기준 신규 브랜치 (이전 plan 브랜치 위에 쌓지 않는다)
 5. **git commit** — docs 변경 + task 파일을 **한 커밋** 으로 묶어 생성. commit 메시지: `docs(plan{N}): {plan 한 줄 요약}`
-6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정).
-7. **git push -u origin plan/{N}-{kebab-slug} 만 — PR 생성 안 함**. 원격에 push 만 하면 다른 세션이 `tasks/plan{N}-*/` 를 fetch 로 이어받을 수 있다.
+6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정). **PR 은 생성하지 않는다.**
+7. **PR 생성 단계 생략** — push 만으로 다른 세션이 `tasks/plan{N}-*/` 를 fetch 로 이어받을 수 있다. PR 은 `/build-with-teams` 가 계획+구현 완료 후 1개만 생성한다.
 8. **main 으로 복귀** — `git switch main`. 이후 `/build-with-teams plan{N}` 가 **같은 `plan/{N}` 브랜치에서** 구현을 이어 붙인다.
 9. 사용자 보고 + 실행 안내:
 

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -167,22 +167,29 @@ task 파일을 **사용자에게 제출하기 전**에 반드시 [`common-pitfal
 4. **plan 브랜치 생성** — `git switch -c plan/{N}-{kebab-slug} origin/main`. 매 plan 마다 origin/main 기준 신규 브랜치 (이전 plan 브랜치 위에 쌓지 않는다)
 5. **git commit** — docs 변경 + task 파일을 **한 커밋** 으로 묶어 생성. commit 메시지: `docs(plan{N}): {plan 한 줄 요약}`
 6. **git push -u origin plan/{N}-{kebab-slug}** — 원격에 push (`-u` 로 upstream 설정).
-7. **PR 생성** — `gh pr create --base main --head plan/{N}-{kebab-slug} --title "docs(plan{N}): {요약}" --body ...`. 본문은 변경 요약 (docs 변경 + task phase 목록) + Test plan (구현 PR 검증 항목) 포함. plan 브랜치가 main 에 머지되어야 향후 다른 세션에서 `tasks/plan{N}-*/` 를 참조할 수 있고, 머지 이력에 plan 의 존재가 남는다.
-8. **main 으로 복귀** — `git switch main`. 이후 사용자가 `/build-with-teams` 호출 시 origin/main 에서 새 `feat/plan{N}-*` 브랜치로 구현 시작.
+7. **git push -u origin plan/{N}-{kebab-slug} 만 — PR 생성 안 함**. 원격에 push 만 하면 다른 세션이 `tasks/plan{N}-*/` 를 fetch 로 이어받을 수 있다.
+8. **main 으로 복귀** — `git switch main`. 이후 `/build-with-teams plan{N}` 가 **같은 `plan/{N}` 브랜치에서** 구현을 이어 붙인다.
 9. 사용자 보고 + 실행 안내:
 
-> plan{N} task 파일 생성 + PR #{번호} 생성 완료 (브랜치: `plan/{N}-{kebab-slug}`).
-> PR 머지 후 `/build-with-teams plan{N}` 로 구현을 시작하면 `feat/plan{N}-{kebab-slug}` 브랜치에서 phase 실행 후 별도 구현 PR 이 생성됩니다.
+> plan{N} task + docs 를 `plan/{N}-{kebab-slug}` 브랜치에 push 완료 (**PR 미생성**).
+> `/build-with-teams plan{N}` 로 구현하면 같은 브랜치에서 phase 실행 후 docs+task+구현을 묶어 `plan/{N}`→main **단일 PR** 이 생성됩니다.
 
-**PR 정책 (2026-05-11 결정)**: plan 의 docs + task 변경은 별도 PR 로 머지. 구현 PR 과 분리. 이유: (a) 계획 단계 검토 + 구현 단계 검토 부담을 분산, (b) 머지 이력에서 "계획 / 구현" 식별 즉시 가능, (c) plan 머지 후 `tasks/plan{N}-*/` 가 main 에 존재해야 `/build-with-teams` 가 어디서든 시작 가능. CLAUDE.md "브랜치 명명" 표의 정책과 일치.
+**PR 정책 (2026-06-02 갱신 — 단일 PR)**: planning 은 PR 을 만들지 않는다.
+`plan/{N}` 브랜치에 task+docs commit + push 만 한다.
+build-with-teams 가 같은 브랜치에서 구현을 이어 붙이고, 완료 후 `plan/{N}`→main **단일 PR**(계획+구현) 을 생성한다.
+
+- 이유: 계획 PR 을 따로 머지하면 그 사이 main 변경과 구현 브랜치가 충돌한다.
+- 실사례: plan026 에서 #308(계획 PR) 을 먼저 머지 → #311(구현 PR) 이 common-pitfalls / adr.md conflict.
+- 단일 PR 로 계획+구현을 한 번에 머지해 이 충돌을 원천 차단한다.
+- 다른 세션이 plan 을 이어받는 건 `plan/{N}` 브랜치 push 로 충분하다 (main 머지 불필요).
 
 ### 중복 실행 방지
 
-`status="pending"` 인 task 가 main 에 머지된 상태에서 다른 세션이 `/build-with-teams plan{N}` 호출 시 사전 검증이 통과해 중복 실행 위험 — 다음 가드로 방지:
+단일 PR 워크플로에서는 계획이 main 에 머지되지 않으므로(plan/{N} 브랜치에만 존재), 중복 실행은 다음 가드로 방지:
 
-- `/build-with-teams` 실행 시 origin/main 의 latest `index.json` 의 `status` 가 `"completed"` 면 즉시 종료
+- `/build-with-teams` 가 plan/{N} 브랜치의 `index.json` `status` 가 `"completed"` 면 (= 이미 단일 PR 머지됨) 즉시 종료
 - 구현 phase 의 마지막 단계가 항상 `status="completed"` 마킹 + commit 포함 (CLAUDE.md "Task 작업 규칙")
-- 동일 plan 을 두 세션이 동시에 잡으면 PR 생성 시 브랜치 충돌로 자연 감지
+- 동일 plan 을 두 세션이 동시에 잡으면 `plan/{N}` push 시 브랜치 충돌로 자연 감지
 
 ### 예외
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,12 +288,12 @@ markdown 렌더링 결과는 동일하지만 소스 가독성 ↑ + git diff 정
 
 | 단계 | 브랜치 | 내용 |
 |---|---|---|
-| 계획 | `plan/{N}-{slug}` | `tasks/plan{N}-{slug}/` task 파일 + docs 갱신 (→ main 머지) |
-| 구현 | `feat/plan{N}-{slug}` | task 의 phase 별 코드 commit (→ main 머지) |
+| 계획+구현 | `plan/{N}-{slug}` | `/planning` 이 task+docs commit + push (**PR 생성 안 함**) → `/build-with-teams` 가 **같은 브랜치**에서 구현 → `plan/{N}`→main **단일 PR** |
 | 기타 | `chore/...` · `fix/...` · `refactor/...` · `docs/...` | 일반 작업 |
 
-plan 의 계획/구현 분리는 머지 이력에서 즉시 식별 + 검토 부담 분산이 목적.
-`/build-with-teams` 사전검증 4번이 task-only 머지를 잡아도 정상 — `feat/plan{N}-{slug}` 신 브랜치로 진행.
+계획과 구현을 **단일 PR** 로 묶는다 (2026-06-02 갱신).
+계획 PR 을 따로 머지하면 그 사이 main 변경과 구현 브랜치가 충돌하기 때문 (plan026 사례: #308 계획 PR 머지 → #311 구현 PR conflict).
+`/planning` 은 `plan/{N}` 브랜치 push 까지만, PR 은 `/build-with-teams` 가 계획+구현 완료 후 1개만 생성한다.
 
 ### 예시
 


### PR DESCRIPTION
## 무엇을

plan026 실행 중 발견한 워크플로 결함과 운영 노하우를 반영한다.

## 1) 계획+구현 단일 PR 로 전환 (근본 수정)

`planning` 과 `build-with-teams` 의 PR 정책이 불일치했다:
- `planning/SKILL.md` — 계획 단계에서 **PR 생성**
- `build-with-teams/SKILL.md` — "planning 은 push 만 하고 **PR 은 build-with-teams 가 생성**" 가정

이 불일치로 plan026 에서 #308(계획 PR)을 먼저 머지 → #311(구현 PR)이 common-pitfalls·adr.md conflict 가 났다.

**변경**: `planning` 은 `plan/{N}` 브랜치에 task+docs push 만 (PR 생성 제거). `build-with-teams` 가 같은 브랜치에서 구현을 이어 붙이고 `plan/{N}`→main **단일 PR**(계획+구현)을 생성한다. 계획 PR 을 따로 머지하지 않으니 그 사이 main 변경과의 충돌이 원천 차단된다.

- `CLAUDE.md` 브랜치 명명 표 갱신 (feat/plan 분리 폐기 → plan/{N} 단일)
- `planning/SKILL.md` 완료 절차에서 PR 생성 제거 + PR 정책 갱신 + 중복 실행 가드 조정

## 2) build-with-teams 운영 노하우 (plan026 실측)

- **phase별 executor 스폰** (4+ phase 권장) — 단일 executor 가 여러 phase 를 순차 처리하면 idle/완료/지시 메시지가 교차해 "이미 완료" 혼선이 반복(plan026 3회). phase 경계마다 새 executor 스폰으로 컨텍스트 격리.
- **docs-verifier 도 v1 재전송 사고** — critic 뿐 아니라 docs-verifier 도 재검증 시 캐시된 v1 판정을 재전송. 실제 파일 라인을 grep/awk 로 떠서 증거로 붙이면 즉시 회복.
- **검증 grep 은 변수 없이 직접 경로** — `$SK` 같은 셸 변수가 빈 값으로 확장돼 0건 오인(plan026 2회). 경로 직접 나열.

## Test plan

- 문서/스킬 변경만 (코드 변경 없음). `pnpm lint:md` exit 0 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
